### PR TITLE
Add the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jggonz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -225,3 +225,12 @@ python3 tools/qmp.py build/qmp.sock 'quit'
 splits every move into ≤60px chunks and derives absolute positions by
 pinning against the kernel's edge clamp first. Boot is clean, so anything you
 want to click has to be launched from a menu first.)
+
+## License
+
+MIT -- see [LICENSE](LICENSE). Everything here is hand-written; no third-party
+code is vendored into the OS, so the whole tree is covered by that one license.
+
+The website in the sibling `os8088-web` repository is a separate matter: it
+vendors the v86 emulator (BSD-2-Clause), SeaBIOS and SeaVGABIOS binaries
+(LGPLv3) and a bitmap font (CC BY-SA 4.0), each shipped with its own license.


### PR DESCRIPTION
Declares os8088 MIT-licensed. Until now the repo had no LICENSE file, which
means default copyright -- readable and forkable, but not legally reusable.

MIT fits what this codebase is for: people read it and lift pieces out of it
(the mode 12h fills, the PIT context switch, the dual-assembly relocation
trick), and MIT gets out of the way of that. Nothing third-party is vendored
into the OS, so one license covers the whole tree.

The copyright line reads `Copyright (c) 2026 jggonz` -- taken from the git
author name. Change it to a legal name if you would rather.

The os8088.com website says in three places that no license is declared; that
copy is updated in a companion change to the website repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)