### PR TITLE
Add a tracked gitleaks pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Block commits containing credential-shaped data.
+#
+# This hook is tracked in the repo, but git does not enable tracked hooks
+# automatically. Every clone needs the one-time:
+#
+#   git config core.hooksPath .githooks
+#
+# Bypass (use sparingly, e.g. a deliberate test fixture):
+#   SKIP_GITLEAKS=1 git commit ...
+#   git commit --no-verify ...
+
+[ -n "$SKIP_GITLEAKS" ] && exit 0
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+	printf '\n\033[33mWARNING: gitleaks not found — commit NOT scanned for secrets.\033[0m\n'
+	printf '  Install with: brew install gitleaks\n\n'
+	exit 0
+fi
+
+if ! gitleaks git --staged --redact --no-banner; then
+	printf '\n\033[31mCommit blocked: gitleaks flagged credential-shaped data above.\033[0m\n'
+	printf '  If the secret is real, rotate it — do not just unstage it.\n'
+	printf '  If it is a false positive, add a rule to .gitleaksignore or append\n'
+	printf '  the "gitleaks:allow" comment to the offending line.\n\n'
+	exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -226,6 +226,26 @@ splits every move into ≤60px chunks and derives absolute positions by
 pinning against the kernel's edge clamp first. Boot is clean, so anything you
 want to click has to be launched from a menu first.)
 
+## Secret scanning
+
+There are no credentials anywhere in this repo or its history, and a tracked
+pre-commit hook is there to keep it that way: `.githooks/pre-commit` runs
+[gitleaks](https://github.com/gitleaks/gitleaks) over the staged diff and
+refuses the commit if anything credential-shaped shows up.
+
+Git does not enable tracked hooks on its own, so each clone needs a one-time:
+
+```
+brew install gitleaks
+git config core.hooksPath .githooks
+```
+
+Without gitleaks on PATH the hook warns loudly and lets the commit through,
+rather than making commits impossible on a machine that lacks the tool. To
+bypass it deliberately -- a test fixture that is *meant* to look like a key --
+use `SKIP_GITLEAKS=1 git commit` or `git commit --no-verify`. If a real secret
+ever does land, rotate it; deleting the line does not un-leak it.
+
 ## License
 
 MIT -- see [LICENSE](LICENSE). Everything here is hand-written; no third-party


### PR DESCRIPTION
Audited the repo for secrets, found none, and added a hook to keep it that way.

## The audit

Every blob that has ever existed here was scanned — 281 blobs / 37.85MB, covering all commits, all 14 branches, the reflog, and the unreachable/dangling objects left by old stashes and rebases. Two independent passes agreed: a hand-rolled scan (~25 vendor token formats plus an entropy pass over text blobs) and gitleaks' full ruleset run over every blob dumped to disk, binaries included.

**Result: no secrets, ever.** The only pattern hits were false positives — `keyboard_type = keyboard_pc_xt` in `vm/xt/86box.cfg` tripping a `*KEY*=` rule, and the `WEB_REPO=/path/to/os8088-web` placeholder in the release skill. No `.env`/`.pem`/`.key` files in the tree or history; commit metadata is clean; the release skill authenticates via `gh auth status` rather than an in-repo token.

Coverage extends to the server side too: every `refs/pull/*/head` SHA and every remote branch — including `feat/built-in-task-manager`, which has no local branch — resolves to a commit that was scanned. No history exists only on GitHub. So no `git filter-repo` rewrite is needed.

## The hook

`.githooks/pre-commit` runs `gitleaks git --staged` and refuses the commit on any finding.

It lives in `.githooks/` rather than `.git/hooks/` so it is versioned and reviewable and survives a clone. Git will not enable tracked hooks on its own — that would let any cloned repo run code on checkout — so each clone still needs a one-time `git config core.hooksPath .githooks`, documented in the README and in the hook's own header.

Design choices:

- **Fails open** with a loud warning when gitleaks is not on PATH, rather than making commits impossible on a machine without the tool.
- **`SKIP_GITLEAKS=1`** bypasses it for fixtures deliberately shaped like keys.
- Blocked-commit output points at rotation, not deletion — unstaging a leaked key does not un-leak it.

## Testing

| Case | Result |
|---|---|
| Fake AWS key + GitHub PAT staged | Blocked, HEAD unchanged |
| `SKIP_GITLEAKS=1 git commit` | Bypass works |
| Ordinary clean commit | Passes |

Re-verified after moving the hook to `.githooks/` and setting `core.hooksPath`, since that could have broken it. This PR's own commit was scanned by the hook.

Worth noting: my first canary used `AKIAIOSFODNN7EXAMPLE` and passed silently — that is AWS's documentation key, which gitleaks allowlists by design. Retested with randomly generated values. gitleaks matches credential *shapes* and deliberately ignores known-fake ones.

## Not covered

This is a local hook, so it is advisory — it protects this checkout once configured, but nothing stops a push from an unconfigured clone. Actual enforcement would need GitHub push protection or a CI job running `gitleaks git` on PRs. Happy to add that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)