### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for os8088.
+# Every file in the repo is owned by @jggonz, so every pull request
+# requests review from that account automatically.
+#
+# To make that review mandatory, enable branch protection on `main`:
+#   Settings -> Rules/Branches -> Require a pull request before merging
+#                             -> Require review from Code Owners
+
+* @jggonz


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with a single `* @jggonz` rule, so every pull request automatically requests review from that account.

Note that CODEOWNERS only *requests* review. To make it blocking, `main` needs a branch protection rule / ruleset with "Require a pull request before merging" + "Require review from Code Owners". CODEOWNERS also only takes effect once it lands on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)