### PR TITLE
Add 640KB boot targets for QEMU and 86Box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,11 @@ os8088: a Macintosh System 1-style GUI OS for the Intel 8086, written entirely i
 ```
 make          # build all four floppy images into build/
 make run      # boot in QEMU with emulated serial mouse (1.44MB images)
+make run-640  # same, as a maxed-out 640KB machine (-m 1M; QEMU/SeaBIOS can't boot below 1MB, int 12h caps at 640K anyway; SeaBIOS's EBDA makes it 639K)
 make test     # boot headless with QMP socket at build/qmp.sock for scripted testing
 make debug    # boot QEMU halted, waiting for gdb on :1234
 make xt       # boot 360KB images on an emulated IBM PC/XT in 86Box
+make xt-640   # same XT with a full 640KB RAM (vm/xt640/86box.cfg)
 make clean
 ```
 
@@ -36,7 +38,7 @@ Testing quirks (learned the hard way):
 - Menus need press/move/up sequences (`mouse.py down` / `to` / `up`), not `click`.
 - Double-clicks compare birth ticks with a 9-tick (~0.5s) window: two separate `mouse.py click` invocations are too slow. Position with `mouse.py to X Y`, then send both clicks over one QMP connection: `qmp.py build/qmp.sock 'mouse_button 1' 'sleep 0.08' 'mouse_button 0' 'sleep 0.12' 'mouse_button 1' 'sleep 0.08' 'mouse_button 0'`.
 - Small changes (e.g. one revealed 16px Minesweeper cell) are easy to misread as "nothing happened" in a full 640x480 screendump — crop and zoom before concluding a click was lost.
-- Only QEMU is routinely verified. `vm/xt/86box.cfg` keys are best-effort guesses and 86Box rewrites its own preference keys on exit (harmless drift).
+- Only QEMU is routinely verified. `vm/xt/86box.cfg` keys are best-effort guesses and 86Box rewrites its own preference keys on exit (harmless drift — except that it silently clamps `mem_size` to the machine's maximum: `ibmxt` caps at 256K, which is why `vm/xt640` uses `ibmxt86`, the 1986 board revision).
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ APPSIMG := $(BUILD)/apps.img
 APPSIMG360 := $(BUILD)/apps360.img
 BOX   := /Applications/86Box.app/Contents/MacOS/86Box
 VM    := $(CURDIR)/vm/xt
+VM640 := $(CURDIR)/vm/xt640
 
 # "size of this file in bytes" is spelled differently by GNU coreutils and by
 # BSD/macOS stat, and this gets built on both. Try GNU first, fall back to BSD.
@@ -24,7 +25,7 @@ FILESIZE = $$(stat -c%s $(1) 2>/dev/null || stat -f%z $(1))
 KERNEL_SRC := kernel/kernel.asm
 KERNEL_INC := $(wildcard kernel/*.inc)
 
-.PHONY: all run debug test xt clean
+.PHONY: all run run-640 debug test xt xt-640 clean
 
 all: $(IMG) $(IMG360) $(APPSIMG) $(APPSIMG360)
 
@@ -109,6 +110,14 @@ run: $(IMG) $(APPSIMG)
 	$(QEMU) -drive file=$(IMG),format=raw,if=floppy -boot a $(MOUSE) \
 		-drive file=$(APPSIMG),format=raw,if=floppy,index=1
 
+# A maxed-out 640KB machine. QEMU/SeaBIOS cannot boot with less than 1MB
+# of guest RAM (SeaBIOS wedges during POST at -m 512k and -m 640k alike),
+# but conventional memory tops out at 640K regardless of installed RAM, so
+# -m 1M makes int 12h report 640K - same as a fully populated XT.
+run-640: $(IMG) $(APPSIMG)
+	$(QEMU) -m 1M -drive file=$(IMG),format=raw,if=floppy -boot a $(MOUSE) \
+		-drive file=$(APPSIMG),format=raw,if=floppy,index=1
+
 debug: $(IMG) $(APPSIMG)
 	$(QEMU) -drive file=$(IMG),format=raw,if=floppy -boot a $(MOUSE) -s -S \
 		-drive file=$(APPSIMG),format=raw,if=floppy,index=1
@@ -125,6 +134,10 @@ test: $(IMG) $(APPSIMG)
 # Boot the 360KB image on emulated period hardware in 86Box.
 xt: $(IMG360) $(APPSIMG360)
 	$(BOX) -P $(VM) -N
+
+# The same XT with a full 640KB of RAM instead of 256KB.
+xt-640: $(IMG360) $(APPSIMG360)
+	$(BOX) -P $(VM640) -N
 
 clean:
 	rm -rf $(BUILD)

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ never had (switchable to cooperative from the Control Panel, if you want to
 feel what they were up against).
 
 ```
-make        # build all four floppy images
-make run    # boot it in QEMU (with an emulated serial mouse)
-make xt     # boot the 360KB image on an emulated IBM PC/XT in 86Box
-make test   # boot headless with a QMP socket for scripted testing
-make debug  # boot with QEMU halted, waiting for gdb on :1234
+make          # build all four floppy images
+make run      # boot it in QEMU (with an emulated serial mouse)
+make run-640  # the same, on a 640KB machine
+make xt       # boot the 360KB image on an emulated IBM PC/XT in 86Box
+make xt-640   # the same XT with a full 640KB of RAM
+make test     # boot headless with a QMP socket for scripted testing
+make debug    # boot with QEMU halted, waiting for gdb on :1234
 make clean
 ```
 
@@ -218,12 +220,23 @@ A 1.44MB drive postdates the 8086 by years, so period hardware gets the
 `make run` boots QEMU with `-chardev msmouse,id=m0 -serial chardev:m0` —
 grab the guest pointer and the arrow follows.
 
+`make run-640` boots the same QEMU as a maxed-out 640KB machine.
+QEMU/SeaBIOS cannot actually run with less than 1MB of guest RAM, but
+conventional memory tops out at 640K regardless of installed RAM, so
+`-m 1M` makes int 12h — the only way the OS learns the memory size —
+report a full conventional memory map, same as a fully populated XT.
+(SeaBIOS reserves 1KB at the top for its EBDA, so the OS sees 639K;
+86Box's XT BIOS has no EBDA and reports a true 640K.)
+
 `make xt` boots the 360KB image on an emulated IBM PC/XT in 86Box
 (`vm/xt/86box.cfg`): 8088 @ 4.77MHz, 256KB RAM, an Oak OTI-067 8-bit ISA
 VGA card, and a Microsoft serial mouse on COM1. VGA arrived in 1987, nine
 years after the 8086, but ISA VGA cards did work in XTs — a legitimate if
 fancy period configuration. Expect the real 4.77MHz experience: repaints
-you can watch.
+you can watch. `make xt-640` boots the same setup with a full 640KB of
+RAM (`vm/xt640/86box.cfg`) — on the 1986 XT board revision (`ibmxt86`),
+because the original 1982 planar maxes out at 256KB and 86Box silently
+clamps `mem_size` back to the board's limit.
 
 ## Scripted testing
 

--- a/vm/xt640/86box.cfg
+++ b/vm/xt640/86box.cfg
@@ -1,0 +1,32 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 5194618c-5231-58a7-8927-48f18784f1a3
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 8088
+cpu_multi = 1
+cpu_speed = 4772728
+cpu_use_dynarec = 0
+machine = ibmxt86
+mem_size = 640
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_pc_xt
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = wp://../../build/os8088-360.img
+fdd_02_fn = wp://../../build/apps360.img
+fdd_host_buffering = 1


### PR DESCRIPTION
## Summary
- `make run-640` boots QEMU as a maxed-out 640KB conventional-memory machine. QEMU/SeaBIOS cannot POST below 1MB of guest RAM (verified crashing at both `-m 512k` and `-m 640k`), but int 12h caps at 640K regardless of installed RAM, so `-m 1M` reads as a fully populated XT. SeaBIOS reserves 1KB for its EBDA, so the OS sees 639K; 86Box's XT BIOS has no EBDA and reports a true 640K.
- `make xt-640` boots a new 86Box profile (`vm/xt640/86box.cfg`) with 640KB of RAM. It uses `ibmxt86` — the 1986 XT board revision — because the 1982 `ibmxt` planar maxes out at 256KB and 86Box silently clamps `mem_size` back to the board limit (and rewrites the config on exit).
- README and CLAUDE.md updated to document the new targets, the SeaBIOS 1MB floor, the 639K/640K EBDA difference, and the 86Box `mem_size` clamping quirk.

## Testing
- Booted the QEMU configuration headless and confirmed via QMP that the BDA base-memory word reads 0x27F (639K) and the desktop comes up with both disk icons.
- An earlier 512K variant of this setup was verified end-to-end with the Task Manager showing `RAM 39K/512K`, before settling on the patch-free 640K approach.
- `make xt-640` launches the `ibmxt86` profile; machine ID confirmed present in the installed 86Box build. (86Box is not scripted in this repo, so no automated verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)