### PR TITLE
The same binary on a 286 and two 386s: three AT-class 86Box machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ vm/xt/nvr/
 vm/xt640/nvr/
 vm/xt-cga/nvr/
 vm/xt-hercules/nvr/
+vm/286/nvr/
+vm/386sx/nvr/
+vm/386dx/nvr/
 vm/*/screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ make xt       # boot 360KB images on an emulated IBM PC/XT in 86Box
 make xt-640   # same XT with a full 640KB RAM (vm/xt640/86box.cfg)
 make xt-cga      # XT + real CGA card, 256KB (vm/xt-cga)
 make xt-hercules # XT + real Hercules card, 256KB (vm/xt-hercules)
+make 286         # 86Box AT clone: 286 @ 12.5MHz, 1MB, VGA (vm/286)
+make 386sx       # 86Box Shuttle HOT-304: 386SX @ 16MHz, 2MB, VGA (vm/386sx)
+make 386         # 86Box Micronics: 386DX @ 25MHz, 2MB, VGA (vm/386dx)
 make clean
 ```
 
@@ -64,7 +67,8 @@ Testing quirks (learned the hard way):
 - Run `tools/sndcheck.py` only after QMP `quit` — a still-running QEMU's wav capture is partial and under-reports duration (and quitting with an SB stream underrun-paused flushes a residual ~20 ms blip at the file's very end; see docs/SOUND-PLAN.md Phase 4).
 - **QEMU emulates no CGA and no Hercules card** — only VGA-class devices. `make test VIDEO=cga` works because SeaVGABIOS's `int 10h AX=0006h` is a byte-exact CGA framebuffer, but it never exercises the detection probe. Hercules has no automatable path at all: `HERCSEG` + `tools/hercshot.py` verifies its pixels out of RAM, and `make xt-hercules` is the only real test.
 - `tools/mouse.py` paces its moves explicitly (one connection, `sleep` between packets) because the msmouse backend runs at 1200 baud and drops a move whose predecessor is still in flight. On a fast host the old one-process-per-move spacing was not enough, and the symptom is a cursor that never moves while every screendump still looks plausible.
-- Only QEMU is routinely verified. `vm/xt/86box.cfg` keys are best-effort guesses and 86Box rewrites its own preference keys on exit (harmless drift — except that it silently clamps `mem_size` to the machine's maximum: `ibmxt` caps at 256K, which is why `vm/xt640` uses `ibmxt86`, the 1986 board revision).
+- Only QEMU is routinely verified. `vm/xt/86box.cfg` keys are best-effort guesses and 86Box rewrites its own preference keys on exit (harmless drift — except that it silently clamps `mem_size` to the machine's maximum: `ibmxt` caps at 256K, which is why `vm/xt640` uses `ibmxt86`, the 1986 board revision; the same trap rules out `ibmat` for the 1MB 286, which 86Box clamps to 512K). The cheap way to test a candidate machine without booting it: launch 86Box on a throwaway copy of the config, `kill -TERM` it, and read the config back — 86Box rewrites it on exit with whatever it actually accepted.
+- The AT-class targets (`286`, `386sx`, `386`) boot the **1.44MB** images, not the 360KB ones, and they have a CMOS the XT does not: on a fresh `vm/<machine>/nvr/` the BIOS stops at its setup screen and wants "EXIT FOR BOOT" picked once. That is a one-time cost per VM directory, not a failure.
 - 86Box's `wp://` prefix on an `fdd_0N_fn` path mounts that floppy **write-protected**, and int 13h then answers status 03h — which the OS faithfully reports as "Write protected" (`FERR_WPROT`). The data floppy carried `wp://` from the read-only-filesystem era and had to lose it before SPEC.md §18.4 writes could work on the XT; the **boot** floppy keeps it deliberately. If saving to B: starts failing on 86Box again, check this before suspecting `diskw.inc` — 86Box may have rewritten the key on exit.
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ VM    := $(CURDIR)/vm/xt
 VM640 := $(CURDIR)/vm/xt640
 VMCGA := $(CURDIR)/vm/xt-cga
 VMHERC := $(CURDIR)/vm/xt-hercules
+VM286 := $(CURDIR)/vm/286
+VM386SX := $(CURDIR)/vm/386sx
+VM386DX := $(CURDIR)/vm/386dx
 
 # VIDEO=cga|herc|vga forces the adapter instead of probing for it (SPEC.md
 # 39.1). The shipped images are always built without it, so they auto-detect;
@@ -60,7 +63,8 @@ FILESIZE = $$(stat -c%s $(1) 2>/dev/null || stat -f%z $(1))
 KERNEL_SRC := kernel/kernel.asm
 KERNEL_INC := $(wildcard kernel/*.inc)
 
-.PHONY: all run run-640 debug test test-snd xt xt-640 xt-cga xt-hercules clean
+.PHONY: all run run-640 debug test test-snd xt xt-640 xt-cga xt-hercules \
+        286 386sx 386 clean
 
 all: $(IMG) $(IMG360) $(APPSIMG) $(APPSIMG360)
 
@@ -343,6 +347,40 @@ xt-cga: $(IMG360) $(APPSIMG360)
 xt-hercules: $(IMG360) $(APPSIMG360)
 	@$(UNPROTECT_B) $(VMHERC)/86box.cfg
 	$(BOX) -P $(VMHERC) -N
+
+# The other end of the range: an AT-class machine, VGA, more RAM than the OS
+# can reach. os8088 is 8086 code in real mode, so a 286/386 runs it verbatim -
+# these targets exist to prove exactly that, and to see the same 640KB ceiling
+# on a machine that has megabytes behind it (int 12h still answers 640).
+#
+#   286    AMI 286 clone board, 286 @ 12.5MHz, 1MB
+#   386sx  Shuttle HOT-304, 386SX @ 16MHz, 2MB
+#   386    Micronics 386 board, 386DX @ 25MHz, 2MB
+#
+# All three carry an OTI-067 VGA, a serial Microsoft mouse on COM1 and 1.44MB
+# drives (so they boot the same images QEMU does), and all three are
+# interactive: 86Box has no automation socket.
+#
+# The 286 is deliberately NOT `ibmat`: 86Box caps the real 5170 planar at
+# 512KB and clamps mem_size down to it SILENTLY, the same trap `vm/xt640`
+# hit with `ibmxt`. A clone AT board takes the full megabyte.
+#
+# Unlike the XT, an AT-class machine has a CMOS, and on the very first launch
+# it is empty: the BIOS stops at its setup screen (the AMI board offers
+# "EXIT FOR BOOT / RUN CMOS SETUP"). Pick EXIT FOR BOOT once - 86Box saves
+# the CMOS to vm/<machine>/nvr/ (gitignored) and every later boot goes
+# straight to the desktop.
+286: $(IMG) $(APPSIMG)
+	@$(UNPROTECT_B) $(VM286)/86box.cfg
+	$(BOX) -P $(VM286) -N
+
+386sx: $(IMG) $(APPSIMG)
+	@$(UNPROTECT_B) $(VM386SX)/86box.cfg
+	$(BOX) -P $(VM386SX) -N
+
+386: $(IMG) $(APPSIMG)
+	@$(UNPROTECT_B) $(VM386DX)/86box.cfg
+	$(BOX) -P $(VM386DX) -N
 
 clean:
 	rm -rf $(BUILD)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ make run      # boot it in QEMU (with an emulated serial mouse)
 make run-640  # the same, on a 640KB machine
 make xt       # boot the 360KB image on an emulated IBM PC/XT in 86Box
 make xt-640   # the same XT with a full 640KB of RAM
+make 286      # 86Box: 286 @ 12.5MHz, 1MB, VGA
+make 386sx    # 86Box: 386SX @ 16MHz, 2MB, VGA
+make 386      # 86Box: 386DX @ 25MHz, 2MB, VGA
 make test     # boot headless with a QMP socket for scripted testing
 make debug    # boot with QEMU halted, waiting for gdb on :1234
 make clean
@@ -291,6 +294,18 @@ you can watch. `make xt-640` boots the same setup with a full 640KB of
 RAM (`vm/xt640/86box.cfg`) — on the 1986 XT board revision (`ibmxt86`),
 because the original 1982 planar maxes out at 256KB and 86Box silently
 clamps `mem_size` back to the board's limit.
+
+The other end of the range: `make 286`, `make 386sx` and `make 386` boot the
+1.44MB image on AT-class 86Box machines — an AMI 286 clone board at 12.5MHz
+with 1MB (`vm/286`), a Shuttle HOT-304 386SX at 16MHz with 2MB
+(`vm/386sx`) and a Micronics 386DX at 25MHz with 2MB (`vm/386dx`) — all
+three with the same OTI-067 VGA and serial mouse. os8088 is 8086 code in
+real mode, so a 286 or a 386 runs it verbatim, just faster; the extra
+megabytes stay invisible, because int 12h still answers 640K and the OS
+never leaves real mode. (Not `ibmat` for the 286: 86Box caps the real 5170
+planar at 512KB, the same silent clamp as the XT. And unlike an XT, these
+machines have a CMOS — on the first launch the BIOS stops at its setup
+screen, and picking "EXIT FOR BOOT" once writes `vm/<machine>/nvr/`.)
 
 ## Scripted testing
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1915,6 +1915,16 @@ FAT snapshot begins. Keep this block last.
   adapter it was built for and would otherwise not rebuild. `xt-cga` /
   `xt-hercules` (`vm/xt-cga`, `vm/xt-hercules`) boot 86Box with the real
   cards; every shipped image is built with neither knob set.
+- AT-class 86Box targets: `286` (`vm/286`, AMI 286 clone board, 286 @
+  12.5MHz, 1MB), `386sx` (`vm/386sx`, Shuttle HOT-304, 386SX @ 16MHz, 2MB)
+  and `386` (`vm/386dx`, Micronics 386, 386DX @ 25MHz, 2MB), all with an
+  OTI-067 VGA, a serial mouse and 1.44MB drives — they boot `$(IMG)` /
+  `$(APPSIMG)`, not the 360KB pair. Nothing in the OS changes: it is 8086
+  code in real mode, int 12h still caps at 640K, and the RAM above it is
+  unreachable by design. Two 86Box traps apply: `mem_size` is clamped to the
+  board maximum without a word (which is why the 286 is not `ibmat` — the
+  5170 planar stops at 512KB), and an empty CMOS makes the BIOS stop at its
+  setup screen once, until `vm/<machine>/nvr/` exists.
 - Gate packages ride their own scratch images and are mounted in place of
   the apps disk with `make test-snd TESTAPPS=<img>` (the `test` target's B:
   drive is fixed): `build/fmtest.img` (§34 Phase 3), `build/sbtest.img`

--- a/vm/286/86box.cfg
+++ b/vm/286/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 8e13dc3a-a9ac-57d3-95d0-d6291927be80
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = wp://../../build/os8088.img
+fdd_01_type = 35_2hd
+fdd_02_fn = ../../build/apps.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1

--- a/vm/386dx/86box.cfg
+++ b/vm/386dx/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 414586dd-be19-5759-bdad-2fea28b3a3f3
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = i386dx
+cpu_multi = 1
+cpu_speed = 25000000
+cpu_use_dynarec = 0
+machine = micronics386
+mem_size = 2048
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_type = 35_2hd
+fdd_01_fn = wp://../../build/os8088.img
+fdd_02_type = 35_2hd
+fdd_02_fn = ../../build/apps.img
+fdd_host_buffering = 1

--- a/vm/386sx/86box.cfg
+++ b/vm/386sx/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = c65e12e1-94d6-5b32-a8c2-29af5ffac4a8
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = i386sx
+cpu_multi = 1
+cpu_speed = 16000000
+cpu_use_dynarec = 0
+machine = shuttle386sx
+mem_size = 2048
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = wp://../../build/os8088.img
+fdd_01_type = 35_2hd
+fdd_02_fn = ../../build/apps.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1


### PR DESCRIPTION
os8088 is 8086 code in real mode, so a 286 or a 386 runs it verbatim — and nothing in the tree said so, because every emulated-hardware target was an XT. Three new 86Box configurations, all with an OTI-067 ISA VGA and a Microsoft serial mouse on COM1, and all booting the **1.44MB** images rather than the 360KB pair:

| target | config | machine | CPU | RAM |
|---|---|---|---|---|
| `make 286` | `vm/286` | `ami286` | 286 @ 12.5MHz | 1MB |
| `make 386sx` | `vm/386sx` | `shuttle386sx` | 386SX @ 16MHz | 2MB |
| `make 386` | `vm/386dx` | `micronics386` | 386DX @ 25MHz | 2MB |

The OS itself changes not at all, and that is the point of the targets: int 12h still answers 640K, the kernel never leaves real mode, and the megabytes above conventional memory stay unreachable by design. What they buy is the other end of the speed range from `make xt` — the same desktop without the 4.77MHz repaints you can watch.

### Two 86Box behaviours worth writing down

Both read as a broken config rather than an emulator setting:

- **`mem_size` is clamped to the board maximum silently**, which is why the 286 is a clone board and not `ibmat`: the real 5170 planar stops at 512KB and 86Box quietly rewrites 1024 to 512. Exactly the trap that put `vm/xt640` on `ibmxt86`. The cheap way to test a candidate machine is to launch 86Box on a throwaway copy of the config and kill it — it rewrites the file on exit with whatever it actually accepted, so `machine`, `cpu_family`, `mem_size` and the fdd types can all be checked without watching a boot. `ami286`, `award286` and `super286c` all keep the full megabyte; `ami286` is the one here.
- **These machines have a CMOS and an XT does not.** On a fresh `vm/<machine>/nvr/` the BIOS stops at its setup screen (`EXIT FOR BOOT / RUN CMOS SETUP`) and waits. One selection per VM directory; 86Box then saves the CMOS and later boots go straight through. `nvr/` is gitignored alongside the XT machines'.

Documented in SPEC.md §16, README.md and CLAUDE.md.

### Verification

All three configurations survive an 86Box load/save round trip with machine, CPU family, speed, memory size, VGA card and both 1.44MB drive types intact — so nothing is being silently clamped or dropped. Reaching the desktop is interactive by nature (86Box has no automation socket, as SPEC.md §39.9 already says of `xt-cga` and `xt-hercules`) and is not automated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
