### PR TITLE
make 486 and make pentium: the fast end of the range, and the CPU name 86Box swallows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ vm/*/screenshots/
 vm/xt-sound/nvr/
 vm/286-sound/nvr/
 vm/386-sound/nvr/
+vm/486/nvr/
+vm/pentium/nvr/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ make 386         # 86Box Micronics: 386DX @ 25MHz, 2MB, VGA (vm/386dx)
 make xt-sound    # ...the XT again with a Sound Blaster 2.0 in it (vm/xt-sound)
 make 286-sound   # 286 + SB16 (vm/286-sound)
 make 386-sound   # 386DX + SB16 (vm/386-sound)
+make 486         # 86Box AMI 486 (SiS 471): 486DX2 @ 66MHz, 8MB, VGA, SB16 (vm/486)
+make pentium     # 86Box ASUS P/I-P55TP4XE: Pentium 133, 16MB, VGA, SB16 (vm/pentium)
 make bench    # build the testing apps in tests/ into build/bench.img and
               # bench360.img. ON DEMAND ONLY — `all` never builds tests/ and
               # nothing under it ships. Run one with

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ VM386DX := $(CURDIR)/vm/386dx
 VMXTSND := $(CURDIR)/vm/xt-sound
 VM286SND := $(CURDIR)/vm/286-sound
 VM386SND := $(CURDIR)/vm/386-sound
+# The top of the range: a 486DX2/66 and a Pentium 133, both with an SB16.
+VM486 := $(CURDIR)/vm/486
+VMPENT := $(CURDIR)/vm/pentium
 
 # VIDEO=cga|herc|vga forces the adapter instead of probing for it (SPEC.md
 # 39.1). The shipped images are always built without it, so they auto-detect;
@@ -85,7 +88,7 @@ KERNEL_SRC := kernel/kernel.asm
 KERNEL_INC := $(wildcard kernel/*.inc)
 
 .PHONY: all run run-640 debug test test-snd xt xt-640 xt-cga xt-hercules \
-        286 386sx 386 xt-sound 286-sound 386-sound bench clean
+        286 386sx 386 xt-sound 286-sound 386-sound 486 pentium bench clean
 
 # `all` deliberately does NOT build anything under tests/ (see the bench block
 # below). The testing apps are on-demand only: `make bench`.
@@ -689,6 +692,33 @@ xt-sound: $(IMG360) $(APPSIMG360)
 386-sound: $(IMG) $(APPSIMG)
 	@$(UNPROTECT_B) $(VM386SND)/86box.cfg
 	$(BOX) -P $(VM386SND) -N
+
+# The far end of the range, both carrying an SB16 on the ISA bus:
+#
+#   486      AMI 486 (SiS 471) board, 486DX2 @ 66MHz (2 x 33), 8MB
+#   pentium  ASUS P/I-P55TP4XE (430FX), Pentium P54C @ 133MHz (2 x 66), 16MB
+#
+# 8086 real-mode code runs verbatim on both, so what these are FOR is the
+# other end of the timing range: everything sized while looking at a 4.77MHz
+# 8088 (typematic deadlines, the tracker's ring refill, Arkanoid's frame
+# pacing) also has to behave on a machine two orders of magnitude faster,
+# and that is not something QEMU's untimed execution can answer either.
+#
+# The CPU names are 86Box's own and were checked by launching it on a
+# throwaway config and reading the file back after exit (which is how the
+# tree checks any candidate machine): `pentium` is NOT a family - 86Box
+# silently falls back to `pentium_p54c` at its default 75MHz, so a config
+# saying `pentium` boots a P75 while claiming a P133. `i486dx2` is real.
+#
+# Both are AT-class, so the first launch of each stops at the BIOS setup
+# screen wanting a CMOS - same one-time cost per VM directory as the 286.
+486: $(IMG) $(APPSIMG)
+	@$(UNPROTECT_B) $(VM486)/86box.cfg
+	$(BOX) -P $(VM486) -N
+
+pentium: $(IMG) $(APPSIMG)
+	@$(UNPROTECT_B) $(VMPENT)/86box.cfg
+	$(BOX) -P $(VMPENT) -N
 
 # NOTHING IN build/ IS TRACKED, and that is a decision rather than an accident.
 #

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -328,13 +328,27 @@ floppy. The judgement is made on hardware.
 Real period hardware: the video **detection probe**, the 6845 programming, a
 4.77 MHz 8088's actual timing, a real CGA or Hercules card, an SB 2.0 on an
 XT bus, and the 286/386 machines. `make xt`, `xt-640`, `xt-cga`,
-`xt-hercules`, `xt-sound`, `286`, `286-sound`, `386sx`, `386`, `386-sound`.
+`xt-hercules`, `xt-sound`, `286`, `286-sound`, `386sx`, `386`, `386-sound`,
+`486`, `pentium`.
+
+The last two are the *fast* end rather than the period end: a 486DX2/66 and a
+Pentium 133, both with an SB16. 8086 real-mode code runs on them verbatim, so
+what they answer is whether the constants sized against a 4.77 MHz 8088 still
+behave two orders of magnitude up — typematic deadlines, the tracker's ring
+refill, Arkanoid's frame pacing. QEMU cannot answer that either: it does not
+model a clock speed at all.
 
 It is not installed in the web container and needs BIOS ROMs, so those
 targets do not run there. Nothing above them does.
 
-Two 86Box-specific traps worth knowing before blaming the OS: it silently
-clamps `mem_size` to the machine's maximum, and a `wp://` prefix on an
+Three 86Box-specific traps worth knowing before blaming the OS: it silently
+clamps `mem_size` to the machine's maximum; a `wp://` prefix on an
 `fdd_0N_fn` path mounts that floppy write-protected — which the OS then
 faithfully reports as "Write protected", and which means `SYSTEM.CFG`
-settings do not survive a reboot.
+settings do not survive a reboot; and an unrecognised `cpu_family` is
+**silently replaced** rather than rejected, at that family's *default* speed.
+`cpu_family = pentium` is not a name 86Box knows: it boots a P54C at 75MHz
+while the config still says 133. The cheap check for any candidate machine or
+CPU is the one in CLAUDE.md — launch 86Box on a throwaway copy of the config,
+`kill -TERM` it, and read the file back, because 86Box rewrites it on exit
+with whatever it actually accepted.

--- a/vm/486/86box.cfg
+++ b/vm/486/86box.cfg
@@ -1,0 +1,44 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M4
+scale = 2
+uuid = af016032-0efb-5154-b9ab-9e2fe2362efd
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = i486dx2
+cpu_multi = 2
+cpu_speed = 66666666
+cpu_use_dynarec = 0
+fpu_type = internal
+machine = ami471
+mem_size = 8192
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Sound]
+sndcard = sb16
+
+[Sound Blaster 16 #1]
+base = 0220
+irq = 5
+dma = 1
+dma16 = 5
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = wp://../../build/os8088.img
+fdd_01_type = 35_2hd
+fdd_02_fn = ../../build/apps.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1

--- a/vm/pentium/86box.cfg
+++ b/vm/pentium/86box.cfg
@@ -1,0 +1,44 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M4
+scale = 2
+uuid = 9e124bd6-b436-53ba-8f7b-ad8ce8369348
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = pentium_p54c
+cpu_multi = 2
+cpu_speed = 133333333
+cpu_use_dynarec = 0
+fpu_type = internal
+machine = p54tp4xe
+mem_size = 16384
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Sound]
+sndcard = sb16
+
+[Sound Blaster 16 #1]
+base = 0220
+irq = 5
+dma = 1
+dma16 = 5
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = wp://../../build/os8088.img
+fdd_01_type = 35_2hd
+fdd_02_fn = ../../build/apps.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1


### PR DESCRIPTION
Two new 86Box targets, both carrying a Sound Blaster 16 on the ISA bus:

| target | machine | CPU | RAM | video | sound |
|---|---|---|---|---|---|
| `make 486` | AMI 486 (SiS 471), `ami471` | 486DX2 @ 66MHz (2 x 33) | 8MB | OTI-067 VGA | SB16 @ 220/IRQ5/DMA 1,5 |
| `make pentium` | ASUS P/I-P55TP4XE (430FX), `p54tp4xe` | Pentium P54C @ 133MHz (2 x 66) | 16MB | OTI-067 VGA | SB16 @ 220/IRQ5/DMA 1,5 |

Both boot the 1.44MB images, both carry a serial Microsoft mouse on COM1, and
both follow the existing sound machines' shape exactly — including the `wp://`
that stays on the boot floppy and comes off the data floppy at launch.

## Why

8086 real-mode code runs verbatim on a 486 and a Pentium, so these are not
about compatibility. They are the *other end of the timing range*. Every
constant in this tree was sized while looking at a 4.77MHz 8088 — typematic
deadlines, the tracker's ring refill, Arkanoid's frame pacing — and none of it
has been looked at two orders of magnitude up. QEMU cannot answer that either:
it does not model a clock speed at all.

## The trap this found

An unrecognised `cpu_family` is **silently replaced** by 86Box rather than
rejected, at that family's *default* speed. `cpu_family = pentium` is not a
name 86Box knows — a config saying `pentium` boots a P54C at **75MHz** while
still reading 133 to anyone who opens the file. `pentium_p54c` is the name
that takes the multiplier; `i486dx2` is real as written.

This is now the third entry in `docs/TESTING.md`'s 86Box traps paragraph,
next to the silent `mem_size` clamp and `wp://`.

## Verification

Mechanical, via CLAUDE.md's own recipe for vetting a candidate machine (launch
86Box on the config, `kill -TERM` it, read the file back — it rewrites the file
with whatever it actually accepted):

- Both configs came back **unchanged** apart from the `uuid` and `host_cpu`
  86Box fills in — every CPU, memory, video and sound key accepted verbatim.
- `mem_size` was **not clamped** at either 8192 or 16384 (the trap that ruled
  out `ibmat` for the 286).
- Both BIOSes ran far enough to write their CMOS: `vm/486/nvr/ami471.nvr` and
  `vm/pentium/nvr/p54tp4xe.nvr`, 128 bytes each.
- `make -n 486` / `make -n pentium` resolve, and both `nvr/` directories are
  gitignored alongside the other nine.

**Not verified: the desktop actually painting on either machine.** 86Box has no
automation socket, both are AT-class so the first launch of each stops at the
BIOS setup screen wanting one manual "EXIT FOR BOOT", and `screencapture` on
this host returns the desktop without any window — so the visual check is
interactive and is left to a human at the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)