### PR TITLE
README: disclose AI authorship, drop the hand-written claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ claude                                  # ...or: codex
 
 ---
 
+> **This is an experimental project, written with AI.** Essentially all of the
+> code, and these docs, were produced by coding agents (Claude Code and Codex)
+> under human direction and review. It exists for hobbyists, retrocomputing
+> enthusiasts and nostalgia — not for production use, and not as a claim of
+> hand-written craftsmanship.
+
 A Macintosh System 1-style graphical operating system for the Intel 8086,
 written in real-mode assembly and booted from a floppy. 640x480, 16 colors,
 overlapping draggable windows, pull-down menus, closable multi-instance
@@ -403,8 +409,10 @@ ever does land, rotate it; deleting the line does not un-leak it.
 
 ## License
 
-MIT -- see [LICENSE](LICENSE). Everything here is hand-written; no third-party
-code is vendored into the OS, so the whole tree is covered by that one license.
+MIT -- see [LICENSE](LICENSE). No third-party code is vendored into the OS, so
+the whole tree is covered by that one license. As noted at the top, the code
+was written with AI coding agents; it is an experimental hobby project and, per
+the MIT text, comes with no warranty of any kind.
 
 The website in the sibling `os8088-web` repository is a separate matter: it
 vendors the v86 emulator (BSD-2-Clause), SeaBIOS and SeaVGABIOS binaries


### PR DESCRIPTION
The License section claimed **"Everything here is hand-written"**, which is not true of this tree — essentially all of the code and docs were produced by coding agents (Claude Code / Codex) under human direction and review.

- Drop that clause, keeping the part that actually bears on licensing: no third-party code is vendored into the OS, so one license covers the whole tree.
- Add a callout under the title stating the project is experimental and written with AI, for hobbyists / retrocomputing / nostalgia rather than production use.
- Repeat the disclosure briefly in the License section, next to MIT's no-warranty point.

`LICENSE` is left untouched on purpose: it is the stock MIT text with no authorship claim in it, and appending prose there tends to break automated license detection.

Not in this PR: `CONTRIBUTING.md` still says "hand-written" in two places (lines 3 and 311). Happy to fix in a follow-up.

`python3 tools/checkdocs.py` passes (491 headings, 103 slots, 0 problems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)