### PR TITLE
vm: an XT with BOTH mono cards — `make xt-multimon`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vm/xt/nvr/
 vm/xt640/nvr/
 vm/xt-cga/nvr/
 vm/xt-hercules/nvr/
+vm/xt-multimon/nvr/
 vm/286/nvr/
 vm/386sx/nvr/
 vm/386dx/nvr/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,15 @@ sees an up-to-date `kernel.bin`, boots the previous configuration, and it reads
 exactly like the feature being broken.
 
 86Box targets for period hardware, one per `vm/` directory: `xt`, `xt-640`,
-`xt-cga`, `xt-hercules`, `xt-sound`, `286`, `286-sound`, `386sx`, `386`,
-`386-sound`, `486`, `pentium`, `xt-z`, `386-z`; plus `marty` (MartyPC). The
-last two are the Frotz machines (§59.9) and the only ones that put a story
-floppy in B: instead of the apps disk — `make zdisk` builds it, and
-`tools/getstories.py` fetches the stories, which are never committed.
+`xt-cga`, `xt-hercules`, `xt-multimon`, `xt-sound`, `286`, `286-sound`,
+`386sx`, `386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`; plus `marty`
+(MartyPC). `xt-multimon` is the **two-card** XT — a CGA and a Hercules, a
+monitor window each — and the only 86Box machine that can show §39.12–§39.19's
+extended desktop; it boots Single, and Control Panel → Display → Desktop is
+what extends it (§39.19.1). `xt-z` and `386-z` are the Frotz machines (§59.9)
+and the only ones that put a story floppy in B: instead of the apps disk —
+`make zdisk` builds it, and `tools/getstories.py` fetches the stories, which
+are never committed.
 
 **Nothing in `build/` is tracked — never commit a binary.** The toolchain is
 deterministic on purpose (`tools/os88disk.py` pins the volume serial and every

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ VM    := $(CURDIR)/vm/xt
 VM640 := $(CURDIR)/vm/xt640
 VMCGA := $(CURDIR)/vm/xt-cga
 VMHERC := $(CURDIR)/vm/xt-hercules
+# The DUAL-DISPLAY machine (SPEC.md 39.12-39.19): the same XT with BOTH mono
+# cards in it, each on its own monitor window.
+VMMULTI := $(CURDIR)/vm/xt-multimon
 VM286 := $(CURDIR)/vm/286
 VM386SX := $(CURDIR)/vm/386sx
 VM386DX := $(CURDIR)/vm/386dx
@@ -281,7 +284,7 @@ KERNEL_SRC := kernel/kernel.asm
 KERNEL_INC := $(wildcard kernel/*.inc)
 
 .PHONY: small kernsplit all run run-640 run-720 debug test test-snd xt xt-640 xt-cga \
-        xt-hercules 286 386sx 386 xt-sound 286-sound 386-sound 486 pentium \
+        xt-hercules xt-multimon 286 386sx 386 xt-sound 286-sound 386-sound 486 pentium \
         bench field stackprobe trklog npbench clicktest marty comscan \
         fonts fontsheets fontlist \
         stories zdisk ztest zh zhboot zcheck zgfx zpic zscreens xt-z 386-z \
@@ -2151,6 +2154,54 @@ xt-cga: $(IMG360) $(APPSIMG360)
 xt-hercules: $(IMG360) $(APPSIMG360)
 	@$(UNPROTECT) $(VMHERC)/86box.cfg
 	$(BOX) -P $(VMHERC) -N
+
+# ...and the same XT with BOTH of them in it: SPEC.md 39.12-39.19's extended
+# desktop on the machine it was written for. A CGA at B8000 and a Hercules at
+# B0000, two CRTCs, two monitors, and 86Box opens a window per card ("86Box
+# Monitor #2" is the Hercules). That pairing is the one thing QEMU cannot
+# stage at all and the one `vid_dual_ok` accepts: [vid_avail] must be exactly
+# VID_A_HERC | VID_A_CGA, so a second VGA-shaped card would not do.
+#
+# THE SECOND CARD IS `hercules_plus` AND NOT `hercules`, WHICH IS NOT A
+# PREFERENCE - it is the difference between a machine that offers the extended
+# desktop and one that silently does not. 86Box's plain `hercules` does not
+# answer 32KB at B0000 while the card is still in the text mode POST left it
+# in: vid_memchk writes 0x55 at B000:0000 and 0xAA at B000:1000 and reads the
+# first back, and on that device the second write lands on the first. That is
+# the MDA signature the probe exists to reject (SPEC.md 39.11.1 - a text-only
+# 4KB card has no 720x348 mode to offer), so the kernel is right and the model
+# is what differs; `hercules_plus` - a real 1986 HGC+, and period hardware for
+# an ibmxt86 - keeps the two offsets apart and is found. MEASURED, both ways,
+# by forcing [vid_dmode] to Extend and watching which card the desktop grows
+# onto: `hercules` stays black in POST's text mode, `hercules_plus` comes up
+# carrying the desktop. If the Control Panel has no Display page on some other
+# 86Box video pairing, this is the first thing to suspect - the page is hidden
+# when [vid_avail] has one bit (SPEC.md 31.10.1) and nothing announces why.
+#
+# THE CGA IS PRIMARY, which is what `gfxcard` means here - `gfxcard_2` is the
+# card the BIOS does not own, and the OS duly comes up on the colour one. That
+# matters because the primary is what the chrome is drawn on (SPEC.md 39.16)
+# and what sits at the virtual origin. Swapping which monitor carries the menu
+# bar is the Control Panel's job (Display -> a row -> Activate,
+# SPEC.md 39.19.2), not this file's.
+# It also matches vm/xt-multimon's opposite number under MartyPC,
+# os8088_5150_both, which the tools/martypc configs put in the same order for
+# a POST reason - so the two emulators disagree about nothing.
+#
+# THE EXTENDED DESKTOP IS OFF WHEN IT BOOTS, and that is SPEC.md 39.19.1: the
+# kernel can detect a second CARD and nothing can detect a second MONITOR, so
+# Single is the default and the second window stays dark until the machine is
+# told. Control Panel -> Display -> Desktop: Right or Below. The setting is
+# written to SYSTEM.CFG when the panel is CLOSED (SPEC.md 31.8), so close it
+# with the box on the title bar and the next boot comes up extended.
+#
+# 640KB on an `ibmxt86` planar, where the two mono machines above are 256KB on
+# an `ibmxt`: a second display costs no conventional RAM (both framebuffers
+# are card memory) but the windows opened across it do, and a machine bought
+# to have more desktop should be able to fill it.
+xt-multimon: $(IMG360) $(APPSIMG360)
+	@$(UNPROTECT) $(VMMULTI)/86box.cfg
+	$(BOX) -P $(VMMULTI) -N
 
 # The other end of the range: an AT-class machine, VGA, more RAM than the OS
 # can reach. os8088 is 8086 code in real mode, so a 286/386 runs it verbatim -

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -121,6 +121,7 @@ emulator have the hardware": a ✅ means reach for it first.
 | CGA 640x200 mono | ✅ | ✅ | `make test VIDEO=cga` | renders; dumps 640x400 (line-doubled) |
 | Hercules 720x348 mono | ✅ | ✅ | `make test VIDEO=herc HERCSEG=0x7000` | renders; 55.8% lit at the desktop |
 | Adapter switching (SPEC.md §39.11) | ⚠️ | ➖ | the `os8088_xt_vga` / `_5150_both` / `_5150_herc` / `_5150_cga` machines | MartyPC is the instrument, and one direction is out of its reach. Verified: the page lists **Vga + Cga** on `_xt_vga`, **Hercules + Cga** on `_5150_both`, and exactly **one** row on the two single-card machines; the live switch works **both ways on `_xt_vga`** and **CGA → Hercules on `_5150_both`**; the choice survives a reboot through `SYSTEM.CFG`'s `VM` key; and a disk asking for a card the machine lacks is **refused**, staying on the probe's answer. NOT verifiable here: **Hercules → CGA on a dual-card machine**, because MartyPC's MDA decodes the whole 64KB at B0000–BFFFF whatever 3BFh's page bit says — measured, B0000 and B8000 read back byte-identical — so the two cards contend for B8000 and the CGA's rendered output stays black although the card is correctly in `Mode6HiResGraphics`. A real HGC with that bit clear (which `vid_setmode` leaves clear) decodes B0000–B7FFF only. **That direction wants a run on the 5150.** The same aliasing is what `vid_cga_alias` (§39.11.1) exists to reject, and it is why the Hercules-only machine stopped reporting a CGA that is not there. **Hiding the page** (§31.10.1) verified on both single-card 5150s — the list is Scheduler/Buffer/Date-Time/Drivers/Sound and no Display row — with the static/driver boundary checked on `os8088_xt_hdd`, where the hard-disk driver's own page lands at row 5 (the slot the hidden page vacated) and dispatches to the driver, not to Display. **Blanking the outgoing card** (§39.11.4) verified on `_5150_both` in both directions: CGA → Hercules takes the CGA card from `Mode6HiResGraphics` to `Mode1TextCo40` (3D8h video bit clear), and Hercules → CGA trips an I/O breakpoint on 3B8h — a port `vid_setmode`'s CGA path never touches, so that write is `vid_blank` and nothing else |
+| Two displays at once (SPEC.md §39.12–§39.19) | ✅ | ❌ | `tests/dualcheck.py` on the `os8088_5150_both` machine, or `make xt-multimon` | MartyPC is the instrument, because only it can read the guest's own answer back; 86Box is where the pair is two 6845s on a period bus. Verified on `xt-multimon` (an `ibmxt86`, 640KB, `gfxcard = cga` + `gfxcard_2 = hercules_plus`): the machine boots to the desktop on the **CGA**, the probe finds the mono card, and forcing `[vid_dmode]` to Extend grows the desktop onto "86Box Monitor #2" - §39.13's bring-up of a card the ROM never touched, on a second card that works. **`gfxcard_2 = hercules` is NOT found, and reads exactly like the feature being missing**: 86Box's plain Hercules answers only 4KB at B0000 while it is still in POST's text mode, so `vid_memchk`'s 0xAA at B000:1000 lands on its 0x55 at B000:0000 and the card is rejected as the text-only MDA that signature means (§39.11.1). The kernel is right and the model differs; the symptom is a Control Panel with **no Display page at all** (§31.10.1 hides it when `[vid_avail]` has one bit), which announces nothing about why. NOT verifiable here: **the extend as the user reaches it**. 86Box has no automation socket, the Desktop row is a mouse click (`tests/dispcp.py`'s coordinates, driven by hand), and macOS will not let a script synthesise one - so `[vid_dmode]` forced in a scratch build is how the machine was checked, and `dualcheck.py` is what says the geometry is right |
 | PC speaker | ✅ | ✅ | `make test-snd`, or `MARTYPC_WAV=` | dominant 880.0 Hz (891.0 on MartyPC, inside tolerance) |
 | AdLib / OPL2 | ✅ | ✅ | `make test-snd ADLIB=1`, or the `os8088_5150_sb` machine | dominant 880.0 Hz from a keyed 440; the Sound page's Test tone came out of MartyPC's OPL2 at 660 Hz |
 | Sound Blaster (DMA streams) | ✅ | ✅ | `make test-snd SB16=1 TESTAPPS=build/sbtest.img`, or the `os8088_5150_sb` machine | 2.00 s at 1000.0 Hz on BOTH. MartyPC's is a DSP **2.01** by default — the classic `0x48`+`0x1C` auto-init path — where QEMU's is an SB16; `dsp_version` picks |
@@ -1646,8 +1647,22 @@ Narrower than it was, now that MartyPC covers the 8088 probe, the 6845 and
 the sound cards: **a machine that is not an 8088** (the 286, 386, 486 and
 Pentium targets), a **period bus** under a card rather than a modelled one,
 and a second opinion on the video probe. `make xt`,
-`xt-640`, `xt-cga`, `xt-hercules`, `xt-sound`, `286`, `286-sound`, `386sx`,
-`386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`.
+`xt-640`, `xt-cga`, `xt-hercules`, `xt-multimon`, `xt-sound`, `286`,
+`286-sound`, `386sx`, `386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`.
+
+`xt-multimon` is the **two-card** XT — a CGA and a Hercules in one box, one
+monitor window each, which is what SPEC.md §39.12–§39.19's extended desktop
+is for. 86Box takes the second card as `gfxcard_2 = hercules_plus` alongside
+`gfxcard = cga` and opens it as "86Box Monitor #2"; that key was established
+the same way every other machine setting in this file was, by reading the
+config back after an exit. **`hercules_plus` and not `hercules`** — the matrix
+row above has the measurement, and the failure mode is a Control Panel with no
+Display page rather than an error. It is a **second instrument** for a machine
+MartyPC already has (`os8088_5150_both`, and `tests/dualcheck.py` is the
+gate), and the card order matches it, so the two emulators disagree about
+nothing. What 86Box adds is a real 6845 pair on a period bus; what it lacks
+is `dualcheck.py`'s reach into guest memory, so what it answers is *"does it
+look right"* rather than *"is it right"*.
 
 The last pair are the Frotz machines (SPEC.md 59.9) and are the only targets
 that put something other than the apps disk in B:. They also cover a drive

--- a/vm/xt-multimon/86box.cfg
+++ b/vm/xt-multimon/86box.cfg
@@ -1,0 +1,36 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 88f75498-582e-5ce1-b424-82cfbc497a29
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 8088
+cpu_multi = 1
+cpu_speed = 4772728
+cpu_use_dynarec = 0
+machine = ibmxt86
+mem_size = 640
+pit_mode = 0
+
+[Video]
+gfxcard = cga
+gfxcard_2 = hercules_plus
+video_fullscreen_scale_maximized = 1
+
+[Hercules]
+display_type = 0
+
+[Input devices]
+keyboard_type = keyboard_pc_xt
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-360.img
+fdd_02_fn = ../../build/apps360.img
+fdd_host_buffering = 1


### PR DESCRIPTION
An 86Box machine for SPEC.md §39.12–§39.19's extended desktop, which had none: an `ibmxt86` at 4.77MHz with 640KB, a **CGA at B8000 and a Hercules at B0000**, and a monitor window per card ("86Box Monitor #2" is the mono one).

It is a second instrument for a machine MartyPC already has as `os8088_5150_both` — the card order matches it, so the two emulators stage the same box. What 86Box adds is two real 6845s on a period bus; what it lacks is `dualcheck.py`'s reach into guest memory, so it answers *"does it look right"* rather than *"is it right"*.

## The second card is `hercules_plus`, and that is the whole of why it works

86Box's plain `hercules` answers only **4KB** at B0000 while it is still in the text mode POST left it in. `vid_memchk` writes `0x55` at `B000:0000` and `0xAA` at `B000:1000` and reads the first back — on that device the second write lands on the first, so the probe rejects the card. Correctly: that is the MDA signature §39.11.1 exists to reject, a text-only card having no 720×348 mode to offer. **The kernel is right and the model differs.** `hercules_plus` (a real 1986 HGC+, period hardware for an `ibmxt86`) keeps the two offsets apart and is found.

The symptom of getting this wrong is a Control Panel with **no Display page at all** — §31.10.1 hides it when `[vid_avail]` has one bit — and nothing announces why. Both the Makefile comment and the TESTING.md matrix row record the trap for the next pairing that hits it.

## How it was measured

A first version of this claimed detection it had not tested, and the review that caught it was booting the thing and looking for the Display page. The check that actually answers, with no mouse involved: force `[vid_dmode]` to Extend in a scratch build, and the probe's answer becomes visible at boot — the desktop grows onto Monitor #2 if the card was found.

| second card | probe | result |
|---|---|---|
| `hercules` | stock | Monitor #2 stays black in POST's text mode |
| `hercules` | `vid_memchk` bypassed | extends — so everything downstream of the probe works |
| `hercules_plus` | **stock, unmodified** | extends, carrying the desktop |

**No kernel change ships here.** `git diff kernel/` against `main` is empty.

## Using it

`make xt-multimon`. The extended desktop is still **off when it boots** (§39.19.1 — the kernel can detect a second card and nothing can detect a second monitor): Control Panel → Display → Desktop: Right or Below, then close the panel with its title-bar box so SYSTEM.CFG keeps it.

## Also

- `.gitignore`: `vm/xt-multimon/nvr/`
- CLAUDE.md and docs/TESTING.md: the target list, a "Two displays at once" matrix row, and a paragraph in "What 86Box is genuinely for".

🤖 Generated with [Claude Code](https://claude.com/claude-code)