### PR TITLE
TeXPad: a two-pane TeX pad, PDF 1.4 and PostScript out (§66)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1125,6 +1125,28 @@ $(BUILD)/notepad.bin: apps/notepad/notepad.asm apps/os88api.inc apps/os88ui.inc 
 $(BUILD)/notepad.o88: $(BUILD)/notepad.bin tools/os88pkg.py
 	python3 tools/os88pkg.py $(BUILD)/notepad.bin -o $@
 
+# TeXPad (SPEC.md 66): source on the left, typeset preview on the right, and
+# File > Export writes PDF 1.4 or PostScript Level 1. Contributed.
+#
+# It ships on the ORDINARY apps disk rather than getting its own the way Word
+# and Frotz did (SPEC.md 65.5/61.9), because the argument that gave them one
+# does not apply: those two need a disk with DOCUMENTS on it - stories, a
+# .DOC - and at 43KB Word does not leave room for the rest of the software on
+# a 360KB floppy anyway. TeXPad is 20KB and its documents are two .TEX files
+# of 3KB together, so it fits beside everything else with room to spare.
+#
+# Three sources, one binary, and each is a prerequisite: the typesetter and
+# the exporter are where the page layout lives, and a stale texpad.bin reads
+# exactly like the layout being wrong.
+$(BUILD)/texpad.bin: apps/texpad/texpad.asm apps/texpad/tpparse.inc \
+                     apps/texpad/tpexport.inc apps/os88api.inc \
+                     apps/os88ui.inc | $(BUILD)
+	$(NASM) -f bin -w+error -I apps/ -o $@ apps/texpad/texpad.asm
+	@echo "texpad: $(call FILESIZE,$@) bytes"
+
+$(BUILD)/texpad.o88: $(BUILD)/texpad.bin tools/os88pkg.py
+	python3 tools/os88pkg.py $(BUILD)/texpad.bin -o $@
+
 # Piano, the fifth shipped package (SPEC.md 36): a colorful playable piano
 # over the SPEC.md 34 tone tier (note viewer, replay, embedded songs).
 $(BUILD)/piano.bin: apps/piano/piano.asm apps/os88api.inc apps/os88ui.inc | $(BUILD)
@@ -2643,7 +2665,8 @@ $(BUILD)/lptlink144.img: $(BUILD)/llboot144.bin $(BUILD)/lptlink.bin \
 # left here is which packages ship and which folder each lands in.
 APPS_TOOLS := $(BUILD)/artful.o88 $(BUILD)/fractal.o88 $(BUILD)/hello.o88 \
               $(BUILD)/modplug.o88 $(BUILD)/notepad.o88 $(BUILD)/paint.o88 \
-              $(BUILD)/piano.o88 $(BUILD)/recorder.o88 $(BUILD)/tracker.o88
+              $(BUILD)/piano.o88 $(BUILD)/recorder.o88 $(BUILD)/texpad.o88 \
+              $(BUILD)/tracker.o88
 APPS_GAMES := $(BUILD)/arkanoid.o88 $(BUILD)/mines.o88 $(BUILD)/missile.o88 \
               $(BUILD)/solitair.o88 $(BUILD)/tamegram.o88
 
@@ -2657,7 +2680,16 @@ APPS_GAMES := $(BUILD)/arkanoid.o88 $(BUILD)/mines.o88 $(BUILD)/missile.o88 \
 # is where a File Open starts (SPEC.md 38.10): the module Tracker and ModPlug
 # were written against is in the folder their Open dialog already opens on,
 # which is the whole point of having a default location at all.
-APPS_DATA := apps/tracker/beverly.mod
+#
+# TeXPad's two documents are here for that same reason, and they are the
+# reason the folder is not just the module's: PAPER.TEX is a short paper that
+# exercises the dialect the typesetter implements, and GUIDE.TEX is the
+# markup written up as a document TeXPad itself sets - so the manual for the
+# markup is a worked example of it. Both are the kernel's default Open
+# location, and both are ASSOCIATED (SPEC.md 66.6), so a double-click on
+# either one opens TeXPad on it without going through APPS/ at all.
+APPS_DATA := apps/tracker/beverly.mod apps/texpad/PAPER.TEX \
+             apps/texpad/GUIDE.TEX
 
 # The Task Manager, in SYSTEM/ and not in the root, because that is where
 # ui_tm_open looks (SPEC.md 28.3). Not in APPS_TOOLS - it is not a program to

--- a/README.md
+++ b/README.md
@@ -107,15 +107,24 @@ a Standard File dialog for opening and saving.
 
 **Software**
 
-Fifteen loadable packages ship on the software disk, all closable and most
+Sixteen loadable packages ship on the software disk, all closable and most
 multi-instance:
 
-- **Apps** — Note Pad (word wrap, DOS-readable text files), Paint,
+- **Apps** — Note Pad (word wrap, DOS-readable text files), TeXPad, Paint,
   ArtfulType, Fractal, Piano, Recorder, Tracker and ModPlug Player (both play
   Amiga MOD files).
 - **Games** — Minesweeper, Solitaire, Arkanoid, Missile Command and TameGram.
 - ...plus the Task Manager itself, and HELLO, a minimal package that exists to
   be the smallest thing the SDK can build.
+
+**TeXPad** is the newest of them and a contributed one: a two-pane pad for a
+small, paper-oriented subset of TeX — source on the left, the typeset page on
+the right, and File > Export writing PDF 1.4 or PostScript Level 1 that a host
+reader opens. The dialect is text, sections, quotes, lists and ruled tables,
+with paper size, margins, gutter, facing pages and page numbers on the menus;
+there is no math engine, no figures and no colour. `PAPER.TEX` and `GUIDE.TEX`
+ride the software disk beside it, and `GUIDE.TEX` is the markup written up as
+a document TeXPad sets.
 
 Timer and Bounce are built into the kernel rather than loaded. **Drivers**
 load the same way packages do — hard disk, sound, and a serial debug

--- a/SPEC.md
+++ b/SPEC.md
@@ -44315,3 +44315,236 @@ text stream §65.4 records it does not have. The page a line falls on is still
 is no printing path in this OS to preview — no printer driver class in §51, no
 slot in the published API. §47's rule: the greyed item is telling the truth
 for nothing.
+
+## 66. TeXPad — the TeX pad (`apps/texpad/texpad.asm`)
+
+A two-pane editor for a small, paper-oriented subset of TeX: the source on the
+left, the typeset page on the right, and File > Export writing PDF 1.4 or
+PostScript Level 1. Contributed, and brought in against the SDK of the day
+(§20) — it needed no kernel change of any kind, which is the claim §20 exists
+to make good. Three sources, one binary, prefix `tp_` throughout: `texpad.asm`
+is the window, the editor and the file paths, `tpparse.inc` is the typesetter,
+`tpexport.inc` is the two writers.
+
+It ships on the ORDINARY apps disk rather than on one of its own. Word and
+Frotz each got a disk (§65.5, §61.9) because each needs DOCUMENTS beside it
+and neither leaves room for the rest of the software on a 360KB floppy;
+TeXPad is under 20KB and its two documents come to 3KB, so the argument does
+not reach it. Those documents ride `MEDIA/` for §38.10's reason — that is
+where a File > Open starts.
+
+### 66.1 Typesetting is an act, not a consequence
+
+**F5 typesets. Nothing else does.** The preview does not track the source as
+it is edited, and that is the design rather than a missing feature: setting
+the document walks the whole source, and on the target machine (PERFORMANCE.md
+— an 8088 at 4.77 MHz) that is not something to do between keystrokes. The
+top bar carries `(edit)` for exactly as long as the preview is older than the
+source, so the staleness is a fact on screen and never a guess.
+
+The preview is redrawn from the typeset OUTPUT — the run and box arrays of
+§66.3 — and never by re-reading the source, so paging, scrolling and resizing
+cost a walk of those arrays and no parse at all. A caret move repaints the
+SOURCE PANE only (`tp_redraw_src`), which is the §11.3 granularity rule
+applied to the one thing that changed.
+
+`tp_redraw` is the internal "paint the whole window" entry and `tp_paint` is
+the WM's callback (§20.5). They are not interchangeable: `tp_paint` takes the
+window in SI the way the WM passes it, and the editing routines that a key
+handler goes through — `tp_go_left`, `tp_up`, `tp_down`, `tp_sol`, `tp_home`,
+`tp_end` — all RETURN a source offset in SI. So `tp_redraw` reloads SI from
+`[tp_win]` itself, and every caller is relieved of a contract it had no way to
+know it was holding. Called with the offset still in SI, `tp_paint` asks
+`OSAPI_WM_CONTENT` where that "window" is and paints the answer, which lands a
+second set of chrome over the menu bar.
+
+### 66.2 The dialect is a paper-oriented subset
+
+Text, sections, quotes, lists and ruled tables; `\documentclass` with
+`letterpaper` / `legalpaper` / `a4paper` / `a5paper`, `10pt` / `11pt` /
+`12pt`, `twoside`, `article` / `book`; `\title` / `\author` / `\date` /
+`\maketitle`; `\section` / `\subsection` / `\chapter`; `\textbf`, `\emph`,
+`\textit`, `\texttt`; `center`, `quote`, `abstract`, `itemize`, `enumerate`,
+`tabular`; and the dimension setters (`\parindent`, `\parskip`,
+`\baselineskip`, `\tabcolsep`, `\oddsidemargin`, `\topmargin`, `\textwidth`).
+
+**There is no math engine, no figure inclusion and no colour.** `$...$` passes
+through as roman text; an unknown command is skipped along with its optional
+`[...]` and its `{...}` group, which is the one behaviour that lets a document
+written for real LaTeX open here and still be readable. `apps/texpad/GUIDE.TEX`
+is that list written as a document TeXPad sets, so the manual for the markup is
+a worked example of it.
+
+The face is the kernel 8×8 monofont (§6.2) and only that, which is why a paper
+looks the same on all three adapters (§39) and why the exports name Courier: a
+monospaced cell is what was measured, so a monospaced face is what must render
+it. Size is carried per run and honoured by scaling the CELL, not by having a
+second face.
+
+### 66.3 The typesetter's output is two bounded arrays
+
+`tp_ts_scan` walks the source once and emits into two fixed arrays in bss —
+`tp_runs` (`TP_MAX_RUNS` = 480 records of 10 bytes: page, style bits, x, y,
+size, length, and an offset into a 5,120-byte text pool) and `tp_boxes`
+(`TP_MAX_BOXES` = 64 of the same size: page, x, y, w, h). A rule, a table grid
+and an underline are all boxes; everything with glyphs in it is a run. Page
+count is capped at `TP_MAX_PAGES` = 16.
+
+**Every one of those limits is enforced at the emitter and not at the caller.**
+`tp_put_run_at` refuses past `TP_MAX_RUNS` and again past the text pool;
+`tp_emit_box` refuses past `TP_MAX_BOXES`; `tp_newpage` pins the page count and
+un-advances the page. A document that overruns any of them is TRUNCATED and
+sets what fits — which is the right failure for a preview, and the reason the
+arrays can be plain bss with no allocation path behind them.
+
+The scan carries two guards that exist because the alternative is a black
+screen rather than a wrong page. `tp_budget` is a hard iteration ceiling of
+source length + 16. `tp_scanat` records the source offset at the top of each
+iteration and the dispatcher compares it at the bottom: a handler that returns
+without consuming its byte would otherwise spin forever under the gfx lock, so
+the scanner consumes one byte on its behalf and continues. Both are cheap and
+neither is reachable by a correct handler; they bound what an INCORRECT one
+costs.
+
+### 66.4 Memory: two claims, and a hand-laid bss
+
+The image is under 20KB and the bss is 12,288 bytes, so the package sits well
+inside `APP_MAX_SIZE` (§33's near model — image plus bss cannot reach 64KB,
+because the offsets are 16 bits). Two heap claims (§50.3) sit outside it:
+
+| claim | size | what it holds |
+|---|---|---|
+| `tp_srcseg` | 8KB | the document source, `TP_SRC_MAX` = 8,190 bytes of it |
+| `tp_expseg` | 24KB | the export buffer, `TP_EXP_MAX` = 24,576 bytes |
+
+The source claim is taken at entry and a launch that cannot get it fails
+(§20.1's CF); the export claim is taken on the first export and never freed,
+so a second export costs nothing. Both are freed with the instance by the
+kernel, so there is no teardown hook.
+
+**The bss is a hand-computed map of `equ`s off `os88_image_end`, and nothing
+checks the offsets against each other.** A new field goes at the END and a
+field that grows moves everything under it. `TP_BSS_LAST` and the `%if` beside
+it catch overflowing the block; they cannot catch two fields OVERLAPPING
+inside it. That is the standing hazard in this package and the reason §66.7's
+ceilings are written as constants next to the copies that use them rather than
+inferred at the call site.
+
+### 66.5 Export: PDF 1.4 and PostScript Level 1
+
+Both writers build the whole file in the export claim and hand it to
+`OSAPI_FILE_WRITE` in one call (§18.4). The PDF is classic xref — no 1.5
+object or xref streams — with uncompressed content streams, `4 + 2n` objects
+for n pages (catalog, pages, font, info, then a page and a contents object
+each), and `/Courier`. The PostScript is DSC-commented Level 1: `moveto` and
+`show` per run, `re`-equivalent line paths for boxes, one `showpage` a page.
+
+**Every byte goes through `tp_xw_al`, which SATURATES at `TP_EXP_MAX` rather
+than growing past it.** That makes the buffer un-overrunnable and makes a
+too-big document a silent truncation instead — a PDF whose xref offsets and
+stream lengths point at bytes that were never written. So `tp_export_do`
+compares the length against the ceiling before it writes anything and refuses
+with 'Export too large'; a file a reader opens and reports as corrupt looks
+like a broken exporter, and a refusal looks like what it is. `tp_pdf_patch5`
+is the one write into the claim that does NOT go through `tp_xw_al` — it goes
+back to fill in five reserved digits of a stream length — so it carries the
+same bound itself.
+
+The PS writer re-selects the face only when the SIZE CHANGES, which is what
+the PDF writer always did. Emitting `/Courier findfont N scalefont setfont` in
+front of every run is 38 bytes each, and a body of ordinary 12pt text is
+hundreds of runs that all ask for the size already in effect: PAPER.TEX
+exported as a 15KB PDF and did not fit 24KB as PostScript on that alone.
+
+### 66.6 The `.TEX` association, and why the load is deferred
+
+The package header claims `TEX` through `OS88_ASSOC16` (§54.5), so a
+double-click on a `.TEX` file launches TeXPad on it once the volume carrying
+both has been mounted. It is NOT one of the four associations baked into the
+kernel (§54.3) — those exist so a document icon costs no disk read on the
+first boot of a machine, and paying kernel bytes for a fifth is a decision for
+whoever wants it, not a consequence of adding an app.
+
+**The entry proc copies the argument's NAME and reads nothing.** `tp_entry`
+calls `OSAPI_ARG_FILE`, stores the name, directory cluster and volume, and
+sets a pending flag; `tp_deferred_ld` does the `OSAPI_FILE_GOTO` + read +
+typeset later, on the first key or click. Reading a floppy from the entry proc
+happens under the loader's lock and freezes the desktop for the length of the
+read — an `int 13h` call is ~400 ms on the target machine, so that is seconds,
+visibly.
+
+The load then owes a FULL repaint rather than the source-pane one the key
+handler was on its way to doing: the byte count in the status strip and the
+page count in the top bar both changed. `tp_ldfull` says so and the handler
+promotes itself, which keeps it to ONE draw — repainting the pane and then the
+window would put the source through twice, and a double draw is invisible in
+an emulator and seconds on an XT.
+
+### 66.7 Every buffer a document can reach is bounded at the copy
+
+The source of this package is a `.TEX` file, and a `.TEX` file is hostile
+input like every other byte read off a disk (§19). The rule here is that the
+CEILING lives at the copy, as a named constant beside it, because the bss
+offsets it is protecting are hand-laid (§66.4):
+
+- `tp_read_group` fills `tp_arg` to `TP_ARG_MAX`; `tp_plain_arg` strips
+  commands out of it into `tp_wbuf` capped at `TP_WBUF_MAX`, and every other
+  writer into `tp_wbuf` uses the same 70.
+- `\title` / `\author` / `\date` copy with `tp_cpatn` under `TP_TITLE_MAX`,
+  `TP_AUTHOR_MAX` and `TP_DATE_MAX` — `tp_date` is the one field smaller than
+  a full `tp_wbuf`.
+- A `\section` or `\subsection` heading is assembled out of several pieces
+  into the 48-byte `tp_nbuf`, and the last piece — the document's own text,
+  the only piece with no length of its own — takes whatever `tp_nbuf_left`
+  says is free. Numbering in front of a `\subsection` title can be eight
+  bytes, so the ceiling is computed rather than assumed.
+- `tp_tab_note` refuses to WRITE past `TP_COL_MAX` columns and `tp_tab_cell`
+  clamps to it before READING: nothing makes a table row agree with its
+  `\begin{tabular}{...}` preamble, so a row with more cells than columns is an
+  ordinary document, and unclamped it lays the cell out from whatever follows
+  `tp_colw` in the bss.
+
+The editor side has one invariant and it is worth naming: **`tp_cur` is an
+offset into the document and never exceeds `tp_srclen`.** `tp_open_gap`
+derives the tail it has to move as `srclen - cur`, which UNDERFLOWS to ~64KB
+when that is violated, and the `std` / `rep movsb` under it then walks
+backwards over the whole segment the 8KB claim sits in — the claim heap above
+it included. `tp_crlf_fix` is what can violate it: it collapses CR LF to LF
+across the whole buffer and knows nothing about the caret, so a paste of CRLF
+text at the end of the document leaves the caret past the end. `tp_clamp_cur`
+runs after it, and `tp_open_gap` refuses an out-of-range offset as well —
+every caller is checked, but that is the one place the damage is unbounded.
+
+A paste also advances by what `OSAPI_CLIP_GET` actually COPIED and not by what
+`OSAPI_CLIP_SIZE` promised. The clipboard belongs to the desktop and this app
+is pre-empted between the two calls (§20.6): another program replacing it with
+a shorter one in between would otherwise splice that many bytes of whatever
+was already in the claim into the document.
+
+### 66.8 Performance posture
+
+The target is PERFORMANCE.md's 8088. What follows from it, beyond §66.1's
+"F5 typesets":
+
+- A caret move repaints the source pane; a page turn or a layout change
+  repaints the window. Nothing repaints on a timer and there is no worker
+  task — TeXPad owns no background task at all (§20.6), so there is no
+  question of a mixer-style redraw racing a paint.
+- A preview row is one `OSAPI_FONT_RUN` per run, which is §6.1's
+  erase-and-letter in one decision per cell; bold is a second transparent
+  strike at x+1, the same trick §65.1 uses.
+- Export is `tp_typeset` plus a linear walk of the run and box arrays plus ONE
+  `OSAPI_FILE_WRITE`. Costing disk work in calls rather than sectors is the
+  whole reason the file is built in RAM first.
+- The refusals are §47's rule: 'Export too large', 'Document full (8K)' and
+  'Need more RAM' are facts the code tested, not guesses about size.
+
+### 66.9 What it deliberately is not
+
+It is not TeX. There is no macro expansion, no `\def`, no hyphenation, no
+ligature handling, no kerning, no math, no floats and no bibliography, and the
+line breaker is greedy rather than Knuth-Plass. Justification is recorded and
+rendered as left. The measure is in whole 8-px cells everywhere including the
+exports, so the PDF has the same loose word spacing the preview does — that is
+the monospaced cell being honest about itself, not a rounding bug to be fixed
+by moving the exports to a proportional face they were not measured for.

--- a/apps/texpad/GUIDE.TEX
+++ b/apps/texpad/GUIDE.TEX
@@ -1,0 +1,45 @@
+\documentclass[letterpaper,12pt]{article}
+\title{TeXPad Markup}
+\author{os8088}
+\date{}
+\begin{document}
+\maketitle
+
+\section{Document}
+Letter paper, ten to twelve point. Article is the default class.
+The book class adds numbered chapters.
+
+\section{Text}
+\textbf{Bold}, \emph{emphasis} and \texttt{typewriter} share the
+system monospaced face. A blank line starts a paragraph.
+
+Special characters: 50\%, A \& B, \$32, file\_name.
+A forced break\\ stays in the same paragraph.
+
+\section{Blocks}
+\begin{quote}
+Quoted extracts are inset from both margins. Use them for a
+sentence taken from another page.
+\end{quote}
+
+\begin{itemize}
+\item F5 typesets the preview.
+\item Layout sets margins, padding and gutter.
+\item Page numbers sit at the bottom centre.
+\end{itemize}
+
+\section{Tables}
+\begin{tabular}{|l|c|r|}
+\hline
+Part & Qty & Notes \\
+\hline
+8088 & 1 & CPU \\
+2764 & 8 & EPROM \\
+\hline
+\end{tabular}
+
+\section{Layout}
+One inch margins on US Letter. The Layout and Page menus set the
+same measures as the source commands.
+
+\end{document}

--- a/apps/texpad/PAPER.TEX
+++ b/apps/texpad/PAPER.TEX
@@ -1,0 +1,67 @@
+\documentclass[letterpaper,12pt]{article}
+\title{A Compact Measure for Working Papers}
+\author{TeXPad / os8088}
+\date{August 2026}
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This note is a short working paper set in one monospaced face on
+US Letter stock. The pad understands enough TeX for text, sections
+and ruled tables. Colour is not used.
+\end{abstract}
+
+\section{Introduction}
+A research note should be readable in hard copy. TeXPad keeps the
+measure, the padding and the page number under the Layout menu, and
+the same values may be written in the source.
+
+Paragraphs wrap to the text width. A blank line starts a new
+paragraph. \textbf{Bold} and \emph{emphasis} are the only faces.
+
+\section{Method}
+\subsection{Page}
+Letter paper is 612 by 792 points. Normal margins are one inch on
+every side. Narrow and wide steps are three-quarter and one-and-a-half
+inches. Compact, normal and loose padding change paragraph skip,
+leading and table cell inset.
+
+\subsection{Tables}
+Columns are \texttt{l}, \texttt{c} or \texttt{r}. A bar in the
+preamble draws a rule. Cell padding follows the padding setting.
+
+\begin{tabular}{|l|c|r|}
+\hline
+Part & Qty & Notes \\
+\hline
+8088 CPU & 1 & 4.77 MHz, 8-bit bus \\
+8259A & 1 & PIC, master \\
+2764 & 8 & 8K EPROM each \\
+\hline
+\end{tabular}
+
+\begin{quote}
+Quoted extracts are inset from both margins. They are meant for a
+sentence taken from another page, not for decoration.
+\end{quote}
+
+\section{Results}
+File, Export PDF and Export PS write a PDF 1.4 or a
+PostScript Level 1 file, which a reader on another machine
+opens. The body is Courier; rules are ordinary path strokes.
+
+The book class adds chapter openings. Article is the default for a
+note of this length.
+
+\newpage
+\section{Notes}
+Special characters: 50\%, A \& B, \$32, file\_name. Line break\\
+stays on the same paragraph.
+
+\begin{itemize}
+\item F5 typesets the preview.
+\item Layout cycles class, margins and padding.
+\item The system 8x8 font is the preview face.
+\end{itemize}
+
+\end{document}

--- a/apps/texpad/texpad.asm
+++ b/apps/texpad/texpad.asm
@@ -1,0 +1,4324 @@
+; =============================================================================
+; TeXPad - black-and-white TeX pad for os8088
+;
+; Source on the left, typeset preview on the right. Letter default, other
+; sizes on the Page menu. Facing/opposing, gutter, units, page numbers.
+; System 8x8 monofont, text + tables. Export is PDF 1.4 / PostScript Level 1.
+; =============================================================================
+
+%include "os88api.inc"
+
+    OS88_HEADER 'TEXPAD', tp_entry, 3
+
+    OS88_ICON16
+    ; mask: portrait page
+    dw 0x3FFC
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x7FFE
+    dw 0x3FFC
+    ; data: page + T + three text rules
+    dw 0x0000
+    dw 0x3FFC
+    dw 0x2004
+    dw 0x27E4
+    dw 0x2124
+    dw 0x2124
+    dw 0x2004
+    dw 0x27E4
+    dw 0x2004
+    dw 0x27E4
+    dw 0x2004
+    dw 0x27E4
+    dw 0x2004
+    dw 0x2004
+    dw 0x3FFC
+    dw 0x0000
+    OS88_ICON16_END
+
+    OS88_ASSOC16
+    db 1
+    OS88_ASSOC_EXT 'TEX'
+    OS88_ASSOC16_END
+
+TP_WIN_W      equ 628
+TP_WIN_H      equ 400
+TP_BAR_H      equ 22
+TP_STAT_H     equ 14
+TP_SPLIT0     equ 200
+TP_SB_W       equ 10
+TP_SRC_KB     equ 8
+TP_SRC_MAX    equ 8190
+TP_EXP_KB     equ 24
+TP_EXP_MAX    equ 24576
+TP_MAX_RUNS   equ 480
+TP_MAX_BOXES  equ 64
+TP_MAX_PAGES  equ 16
+TP_TEXT_MAX   equ 5120
+TP_RUN_SZ     equ 10
+TP_BOX_SZ     equ 10
+TP_ARG_MAX    equ 180
+TP_LINE_MAX   equ 148
+TP_CLINE_MAX  equ 120
+TP_STY_MAX    equ 8
+TP_ENV_MAX    equ 6
+TP_COL_MAX    equ 6
+
+; -----------------------------------------------------------------------------
+tp_entry:
+    cld
+    push si
+    mov si, tp_tpl
+    call OSAPI_WM_CREATE
+    jc .out
+    push si
+    mov si, tp_menus
+    call OSAPI_MENU_SET
+    pop si
+    mov [tp_win], bx
+    mov al, 1
+    call OSAPI_WM_SIZABLE
+    mov al, 1
+    call OSAPI_WM_SNAP
+    push si
+    mov si, tp_onabout
+    call OSAPI_ABOUT_SET
+    pop si
+    mov byte [tp_needld], 1
+    mov byte [tp_margin], 1
+    mov byte [tp_pad], 1
+    mov byte [tp_pstyle], 1     ; footer numbers
+    mov byte [tp_psize], 0      ; Letter
+    mov byte [tp_bind], 0       ; single
+    mov byte [tp_gutter], 1     ; 18pt
+    mov byte [tp_units], 0      ; inches
+    mov byte [tp_fsize], 12
+    mov word [tp_split], TP_SPLIT0
+    call tp_claim_src
+    jc .out
+    ; RAM seed only when not opened on a .TEX. No floppy, no typeset
+    ; under the loader lock (that froze the desktop).
+    mov byte [tp_needld], 0
+    call tp_note_arg
+    cmp byte [tp_needld], 0
+    jne .pend
+    call tp_seed
+    jmp .ready
+.pend:
+    mov word [tp_srclen], 0
+    mov word [tp_cur], 0
+.ready:
+    mov byte [tp_needttl], 1
+    mov byte [tp_needset], 1
+    mov byte [tp_setok], 0
+    clc                         ; entry CF=1 means launch failed
+.out:
+    pop si
+    ret
+
+; Copy ARG_FILE name only. Do not READ or typeset here.
+tp_note_arg:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    call OSAPI_ARG_FILE
+    jc .o
+    mov [tp_dir], dx
+    mov [tp_drv], bl
+    mov ax, KERNEL_SEG
+    mov es, ax
+    mov di, tp_fname
+    mov cx, 13
+.cp:
+    mov al, [es:si]
+    mov [di], al
+    or al, al
+    jz .named
+    inc si
+    inc di
+    loop .cp
+    mov byte [di], 0
+.named:
+    push ds
+    pop es
+    call tp_is_tex
+    jc .o
+    mov byte [tp_needld], 1
+.o:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    clc
+    ret
+
+; Load a pending ARG_FILE. Call from a key/click, not paint.
+tp_deferred_ld:
+    cmp byte [tp_needld], 0
+    je .o
+    mov byte [tp_needld], 0
+    push ax
+    push bx
+    push dx
+    mov dx, [tp_dir]
+    mov bl, [tp_drv]
+    call OSAPI_FILE_GOTO
+    call tp_load
+    pop dx
+    pop bx
+    pop ax
+    jnc .set
+    jmp .ttl
+.set:
+    call tp_typeset
+.ttl:
+    mov byte [tp_needttl], 1
+    call tp_retitle
+    ; A load changes the WHOLE window - the byte count in the status strip and
+    ; the page count in the top bar as much as the text - and the key handler
+    ; that got us here is on its way to repainting the source pane alone. Say
+    ; so, and let it repaint everything ONCE instead: launched on a .TEX, the
+    ; first keypress otherwise left "0/8190" under a document plainly not
+    ; empty, until something unrelated forced a full repaint.
+    mov byte [tp_ldfull], 1
+.o:
+    ret
+
+tp_claim_src:
+    cmp word [tp_srcseg], 0
+    jne .ok
+    mov ax, TP_SRC_KB
+    call OSAPI_MEM_CLAIM
+    jc .bad
+    mov [tp_srcseg], dx
+    mov word [tp_srclen], 0
+.ok:
+    clc
+    ret
+.bad:
+    stc
+    ret
+
+tp_is_tex:
+    push ax
+    push si
+    mov si, tp_fname
+.l:
+    mov al, [si]
+    or al, al
+    jz .no
+    cmp al, '.'
+    je .dot
+    inc si
+    jmp .l
+.dot:
+    inc si
+    mov al, [si]
+    or al, 0x20
+    cmp al, 't'
+    jne .no
+    mov al, [si+1]
+    or al, 0x20
+    cmp al, 'e'
+    jne .no
+    mov al, [si+2]
+    or al, 0x20
+    cmp al, 'x'
+    jne .no
+    pop si
+    pop ax
+    clc
+    ret
+.no:
+    pop si
+    pop ax
+    stc
+    ret
+
+; -----------------------------------------------------------------------------
+tp_paint:
+    cmp byte [tp_needttl], 0
+    je .go
+    mov byte [tp_needttl], 0
+    call tp_retitle
+.go:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov bx, si
+    call OSAPI_WM_CONTENT
+    mov [tp_ox], ax
+    mov [tp_oy], dx
+    mov bx, si
+    call OSAPI_WM_GEOM
+    mov [tp_cw], cx
+    mov [tp_ch], dx
+    call tp_clamp_split
+    call tp_fill
+    cmp byte [tp_abouton], 0
+    je .ui
+    call tp_draw_about
+    jmp .grow
+.ui:
+    call tp_layout
+    call tp_draw_bar
+    call tp_draw_source
+    call tp_draw_preview
+    call tp_draw_stat
+.grow:
+    mov bx, [tp_win]
+    or bx, bx
+    jz .out
+    call OSAPI_WM_GROW
+.out:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_fill:
+    push ax
+    push bx
+    push cx
+    push dx
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    mov ax, [tp_ox]
+    mov bx, [tp_oy]
+    mov cx, ax
+    add cx, [tp_cw]
+    dec cx
+    mov dx, bx
+    add dx, [tp_ch]
+    dec dx
+    call OSAPI_GFX_FILL
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_clamp_split:
+    push ax
+    push bx
+    mov ax, [tp_split]
+    cmp ax, 120
+    jae .lo
+    mov ax, 120
+.lo:
+    mov bx, [tp_cw]
+    sub bx, 140
+    cmp bx, 120
+    jge .hi
+    mov bx, 120
+.hi:
+    cmp ax, bx
+    jbe .ok
+    mov ax, bx
+.ok:
+    mov [tp_split], ax
+    pop bx
+    pop ax
+    ret
+
+tp_layout:
+    push ax
+    push bx
+    push cx
+    push dx
+    push di
+    mov ax, [tp_ox]
+    add ax, 4
+    mov bx, [tp_oy]
+    add bx, 2
+    mov dx, bx
+    add dx, 16
+    mov di, tp_r_set
+    mov cx, ax
+    add cx, 32
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_cls
+    mov cx, ax
+    add cx, 32
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_mar
+    mov cx, ax
+    add cx, 32
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_gut
+    mov cx, ax
+    add cx, 32
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_pad
+    mov cx, ax
+    add cx, 32
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_prev
+    mov cx, ax
+    add cx, 24
+    call tp_setrect
+    mov ax, cx
+    add ax, 4
+    mov di, tp_r_next
+    mov cx, ax
+    add cx, 24
+    call tp_setrect
+    pop di
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_setrect:
+    mov [di], ax
+    mov [di+2], bx
+    mov [di+4], cx
+    mov [di+6], dx
+    ret
+
+; Paper size in points from tp_psize: Letter / Legal / A4 / A5.
+tp_pagesz:
+    push ax
+    mov ax, 612
+    mov word [tp_ph], 792
+    cmp byte [tp_psize], 1
+    je .legal
+    cmp byte [tp_psize], 2
+    je .a4
+    cmp byte [tp_psize], 3
+    je .a5
+    jmp .ok
+.legal:
+    mov word [tp_ph], 1008
+    jmp .ok
+.a4:
+    mov ax, 595
+    mov word [tp_ph], 842
+    jmp .ok
+.a5:
+    mov ax, 420
+    mov word [tp_ph], 595
+.ok:
+    mov [tp_pw], ax
+    pop ax
+    ret
+
+; Left / right / top / bot / text width for [tp_page].
+; Facing: odd (recto) gutter on the inner left; even (verso) inner right.
+; Opposing flips that. Single keeps equal outer margins.
+tp_geom:
+    push ax
+    push bx
+    push cx
+    push dx
+    call tp_pagesz
+    mov ax, 72
+    cmp byte [tp_margin], 0
+    jne .m1
+    mov ax, 54
+    jmp .ms
+.m1:
+    cmp byte [tp_margin], 2
+    jne .ms
+    mov ax, 108
+.ms:
+    mov cx, ax                  ; outer margin
+    xor bx, bx
+    cmp byte [tp_gutter], 1
+    jne .g2
+    mov bx, 18
+    jmp .gs
+.g2:
+    cmp byte [tp_gutter], 2
+    jne .gs
+    mov bx, 36
+.gs:
+    cmp byte [tp_bind], 0
+    je .single
+    mov dx, [tp_page]
+    and dx, 1
+    cmp byte [tp_bind], 2
+    jne .side
+    xor dx, 1
+.side:
+    or dx, dx
+    jnz .verso
+    mov ax, cx
+    add ax, bx
+    mov [tp_left], ax
+    mov [tp_tleft], ax
+    mov ax, [tp_pw]
+    sub ax, cx
+    mov [tp_right], ax
+    jmp .tw
+.verso:
+    mov [tp_left], cx
+    mov [tp_tleft], cx
+    mov ax, [tp_pw]
+    sub ax, cx
+    sub ax, bx
+    mov [tp_right], ax
+    jmp .tw
+.single:
+    mov [tp_left], cx
+    mov [tp_tleft], cx
+    mov ax, [tp_pw]
+    sub ax, cx
+    mov [tp_right], ax
+.tw:
+    mov ax, [tp_right]
+    sub ax, [tp_left]
+    mov [tp_tw], ax
+    mov ax, [tp_ph]
+    sub ax, cx
+    cmp byte [tp_pstyle], 2
+    jne .th
+    sub ax, 14
+.th:
+    mov [tp_ttop], ax
+    mov ax, cx
+    add ax, 18
+    cmp byte [tp_pstyle], 1
+    je .botx
+    cmp byte [tp_pstyle], 3
+    je .botx
+    jmp .tb
+.botx:
+    add ax, 8
+.tb:
+    mov [tp_tbot], ax
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Fit the sheet so 8 screen pixels = [tp_fsize] points (12pt default).
+; Shrinking the whole Letter page into the pane left 8px glyphs looking
+; twice as big as printed 12pt and only ~20 characters on a line.
+tp_fit_sheet:
+    push ax
+    push bx
+    push cx
+    push dx
+    mov ax, [tp_ppage]
+    mov [tp_page], ax
+    call tp_geom
+    mov bl, [tp_fsize]
+    or bl, bl
+    jnz .fs
+    mov bl, 12
+.fs:
+    xor bh, bh
+    mov cx, bx                  ; CX = pt size
+    mov ax, [tp_pw]
+    mov dx, ax
+    shl ax, 1
+    shl ax, 1
+    shl ax, 1                   ; *8
+    xor dx, dx
+    div cx
+    mov bx, ax                  ; BX = sheet w
+    mov ax, [tp_ph]
+    shl ax, 1
+    shl ax, 1
+    shl ax, 1
+    xor dx, dx
+    div cx
+    mov cx, ax                  ; CX = sheet h
+    ; horizontal: center if it fits, else flush left
+    mov ax, [tp_px2]
+    sub ax, [tp_px1]
+    sub ax, 8
+    cmp bx, ax
+    jae .hfull
+    sub ax, bx
+    sar ax, 1
+    add ax, [tp_px1]
+    jmp .hx
+.hfull:
+    mov ax, [tp_px1]
+    add ax, 4
+.hx:
+    mov [tp_sx1], ax
+    add ax, bx
+    mov [tp_sx2], ax
+    ; vertical: top of pane, then scroll
+    mov ax, [tp_py1]
+    add ax, 4
+    sub ax, [tp_pscroll]
+    mov [tp_sy1], ax
+    add ax, cx
+    mov [tp_sy2], ax
+    mov ax, [tp_left]
+    call tp_mapx
+    mov [tp_tx1], ax
+    mov ax, [tp_right]
+    call tp_mapx
+    mov [tp_tx2], ax
+    mov ax, [tp_ttop]
+    call tp_mapy
+    mov [tp_ty1], ax
+    mov ax, [tp_tbot]
+    call tp_mapy
+    mov [tp_ty2], ax
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AX = PDF x -> AX = screen x
+tp_mapx:
+    push bx
+    push cx
+    push dx
+    mov cx, [tp_sx2]
+    sub cx, [tp_sx1]
+    mul cx
+    mov bx, [tp_pw]
+    or bx, bx
+    jnz .d
+    mov bx, 612
+.d:
+    div bx
+    add ax, [tp_sx1]
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+; AX = PDF y (from bottom) -> AX = screen y
+tp_mapy:
+    push bx
+    push cx
+    push dx
+    mov bx, [tp_ph]
+    sub bx, ax
+    mov ax, bx
+    mov cx, [tp_sy2]
+    sub cx, [tp_sy1]
+    mul cx
+    mov bx, [tp_ph]
+    or bx, bx
+    jnz .d
+    mov bx, 792
+.d:
+    div bx
+    add ax, [tp_sy1]
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+; Page, gutter band, text-area frame.
+tp_draw_sheet:
+    push ax
+    push bx
+    push cx
+    push dx
+    ; desk
+    mov ax, [tp_px1]
+    inc ax
+    mov bx, [tp_py1]
+    inc bx
+    mov cx, [tp_px2]
+    dec cx
+    mov dx, [tp_py2]
+    dec dx
+    call OSAPI_GFX_FILL_GRAY
+    ; paper, clipped to the preview pane
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    mov ax, [tp_sx1]
+    mov bx, [tp_sy1]
+    mov cx, [tp_sx2]
+    mov dx, [tp_sy2]
+    call tp_clip_pane
+    jc .gutter
+    call OSAPI_GFX_FILL
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    mov ax, [tp_sx1]
+    mov bx, [tp_sy1]
+    mov cx, [tp_sx2]
+    mov dx, [tp_sy2]
+    call tp_clip_pane
+    jc .gutter
+    call OSAPI_GFX_FRAME
+.gutter:
+    ; gutter
+    cmp byte [tp_bind], 0
+    je .txt
+    xor ax, ax
+    cmp byte [tp_gutter], 1
+    jne .g2
+    mov ax, 18
+    jmp .gw
+.g2:
+    cmp byte [tp_gutter], 2
+    jne .txt
+    mov ax, 36
+.gw:
+    mov bx, [tp_sx2]
+    sub bx, [tp_sx1]
+    mul bx
+    mov bx, [tp_pw]
+    or bx, bx
+    jnz .gd
+    mov bx, 612
+.gd:
+    div bx
+    cmp ax, 4
+    jae .gok
+    mov ax, 4
+.gok:
+    mov cx, ax                  ; gutter px
+    mov al, [tp_ppage]
+    and al, 1
+    cmp byte [tp_bind], 2
+    jne .sd
+    xor al, 1
+.sd:
+    or al, al
+    jnz .rg
+    ; left (recto / inner)
+    mov ax, [tp_sx1]
+    inc ax
+    mov bx, [tp_sy1]
+    inc bx
+    push cx
+    add cx, ax
+    dec cx
+    mov dx, [tp_sy2]
+    dec dx
+    call OSAPI_GFX_FILL_GRAY
+    pop cx
+    jmp .txt
+.rg:
+    mov ax, [tp_sx2]
+    sub ax, cx
+    push ax
+    mov bx, [tp_sy1]
+    inc bx
+    mov cx, [tp_sx2]
+    dec cx
+    mov dx, [tp_sy2]
+    dec dx
+    call OSAPI_GFX_FILL_GRAY
+    pop ax
+.txt:
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Clip AX/BX/CX/DX to the preview pane. CF=1 if the rect is empty.
+tp_clip_pane:
+    push si
+    mov si, [tp_px1]
+    inc si
+    cmp ax, si
+    jge .x1
+    mov ax, si
+.x1:
+    mov si, [tp_px2]
+    dec si
+    cmp cx, si
+    jle .x2
+    mov cx, si
+.x2:
+    cmp cx, ax
+    jl .empty
+    mov si, [tp_py1]
+    inc si
+    cmp bx, si
+    jge .y1
+    mov bx, si
+.y1:
+    mov si, [tp_py2]
+    dec si
+    cmp dx, si
+    jle .y2
+    mov dx, si
+.y2:
+    cmp dx, bx
+    jl .empty
+    pop si
+    clc
+    ret
+.empty:
+    pop si
+    stc
+    ret
+
+; Status: size, margin, bind, gutter, numbers, body size, source used.
+tp_fmt_stat:
+    push ax
+    push si
+    push es
+    push ds
+    pop es
+    mov si, tp_s_letter
+    cmp byte [tp_psize], 0
+    je .nm
+    mov si, tp_s_legal
+    cmp byte [tp_psize], 1
+    je .nm
+    mov si, tp_s_a4s
+    cmp byte [tp_psize], 2
+    je .nm
+    mov si, tp_s_a5s
+.nm:
+    call tp_cpat
+    mov al, ' '
+    stosb
+    cmp byte [tp_units], 0
+    jne .mm
+    mov si, tp_s_u075
+    cmp byte [tp_margin], 0
+    je .mu
+    mov si, tp_s_u10
+    cmp byte [tp_margin], 1
+    je .mu
+    mov si, tp_s_u15
+    jmp .mu
+.mm:
+    mov si, tp_s_m19
+    cmp byte [tp_margin], 0
+    je .mu
+    mov si, tp_s_m25
+    cmp byte [tp_margin], 1
+    je .mu
+    mov si, tp_s_m38
+.mu:
+    call tp_cpat
+    mov al, ' '
+    stosb
+    mov si, tp_s_sgl
+    cmp byte [tp_bind], 0
+    je .bd
+    mov si, tp_s_fac
+    cmp byte [tp_bind], 1
+    je .bd
+    mov si, tp_s_opp
+.bd:
+    call tp_cpat
+    mov al, ' '
+    stosb
+    cmp byte [tp_units], 0
+    jne .gm
+    mov si, tp_s_gi0
+    cmp byte [tp_gutter], 0
+    je .gu
+    mov si, tp_s_gi1
+    cmp byte [tp_gutter], 1
+    je .gu
+    mov si, tp_s_gi2
+    jmp .gu
+.gm:
+    mov si, tp_s_gm0
+    cmp byte [tp_gutter], 0
+    je .gu
+    mov si, tp_s_gm1
+    cmp byte [tp_gutter], 1
+    je .gu
+    mov si, tp_s_gm2
+.gu:
+    call tp_cpat
+    mov al, ' '
+    stosb
+    mov si, tp_s_n0
+    cmp byte [tp_pstyle], 0
+    je .ns
+    mov si, tp_s_n1
+    cmp byte [tp_pstyle], 1
+    je .ns
+    mov si, tp_s_n2
+    cmp byte [tp_pstyle], 2
+    je .ns
+    mov si, tp_s_n3
+.ns:
+    call tp_cpat
+    mov al, ' '
+    stosb
+    mov al, [tp_fsize]
+    xor ah, ah
+    call tp_u16_di
+    mov si, tp_s_pt
+    call tp_cpat
+    mov al, ' '
+    stosb
+    mov ax, [tp_srclen]
+    call tp_u16_di
+    mov al, '/'
+    stosb
+    mov ax, TP_SRC_MAX
+    call tp_u16_di
+    mov byte [di], 0
+    pop es
+    pop si
+    pop ax
+    ret
+
+tp_draw_bar:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov di, OS88UI_FILL
+    mov bx, tp_r_set
+    mov si, tp_s_set
+    call os88ui_btn
+    mov bx, tp_r_cls
+    mov si, tp_s_ltr
+    cmp byte [tp_psize], 0
+    je .sz
+    mov si, tp_s_leg
+    cmp byte [tp_psize], 1
+    je .sz
+    mov si, tp_s_a4s
+    cmp byte [tp_psize], 2
+    je .sz
+    mov si, tp_s_a5s
+.sz:
+    call os88ui_btn
+    mov bx, tp_r_mar
+    mov si, tp_s_sgl
+    cmp byte [tp_bind], 0
+    je .bd
+    mov si, tp_s_fac
+    cmp byte [tp_bind], 1
+    je .bd
+    mov si, tp_s_opp
+.bd:
+    call os88ui_btn
+    mov bx, tp_r_gut
+    mov si, tp_s_g0
+    cmp byte [tp_gutter], 0
+    je .g
+    mov si, tp_s_g1
+    cmp byte [tp_gutter], 1
+    je .g
+    mov si, tp_s_g2
+.g:
+    call os88ui_btn
+    mov bx, tp_r_pad
+    mov si, tp_s_pc
+    cmp byte [tp_pad], 0
+    je .p
+    mov si, tp_s_pn
+    cmp byte [tp_pad], 1
+    je .p
+    mov si, tp_s_pl
+.p:
+    call os88ui_btn
+    mov bx, tp_r_prev
+    mov si, tp_s_lt
+    call os88ui_btn
+    mov bx, tp_r_next
+    mov si, tp_s_gt
+    call os88ui_btn
+    call tp_fmt_bar
+    mov cx, [tp_r_next+4]
+    add cx, 8
+    mov dx, [tp_oy]
+    add dx, 6
+    mov si, tp_status
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    mov ax, [tp_ox]
+    mov bx, [tp_oy]
+    add bx, TP_BAR_H
+    dec bx
+    mov cx, [tp_ox]
+    add cx, [tp_cw]
+    dec cx
+    mov dx, bx
+    call OSAPI_GFX_HLINE
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_fmt_bar:
+    push ax
+    push si
+    push di
+    push es
+    push ds
+    pop es
+    mov di, tp_status
+    mov si, tp_fname
+    cmp byte [si], 0
+    jne .n
+    mov si, tp_s_noload
+.n:
+    call tp_cpat
+    cmp byte [tp_dirty], 0
+    je .pg
+    mov al, '*'
+    stosb
+.pg:
+    mov al, ' '
+    stosb
+    mov ax, [tp_ppage]
+    inc ax
+    call tp_u16_di
+    mov al, '/'
+    stosb
+    mov ax, [tp_npages]
+    or ax, ax
+    jnz .np
+    inc ax
+.np:
+    call tp_u16_di
+    cmp byte [tp_needset], 0
+    je .z
+    mov al, ' '
+    stosb
+    mov si, tp_s_stale
+    call tp_cpat
+.z:
+    mov byte [di], 0
+    pop es
+    pop di
+    pop si
+    pop ax
+    ret
+
+tp_draw_stat:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    mov ax, [tp_ox]
+    mov bx, [tp_oy]
+    add bx, [tp_ch]
+    sub bx, TP_STAT_H
+    mov cx, [tp_ox]
+    add cx, [tp_cw]
+    dec cx
+    mov dx, bx
+    call OSAPI_GFX_HLINE
+    mov di, tp_nbuf
+    push di
+    call tp_fmt_stat
+    pop si
+    mov cx, [tp_ox]
+    add cx, 6
+    mov dx, [tp_oy]
+    add dx, [tp_ch]
+    sub dx, 11
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_draw_about:
+    push ax
+    push cx
+    push dx
+    push si
+    mov cx, [tp_ox]
+    add cx, 16
+    mov dx, [tp_oy]
+    add dx, 16
+    mov si, tp_s_a1
+    call tp_about_line
+    mov si, tp_s_a2
+    call tp_about_line
+    mov si, tp_s_a3
+    call tp_about_line
+    mov si, tp_s_a4
+    call tp_about_line
+    mov si, tp_s_a5
+    call tp_about_line
+    mov si, tp_s_a6
+    call tp_about_line
+    mov si, tp_s_a7
+    call tp_about_line
+    mov si, tp_s_a8
+    call tp_about_line
+    mov si, tp_s_a9
+    call tp_about_line
+    mov si, tp_s_a10
+    call tp_about_line
+    mov si, tp_s_a11
+    call tp_about_line
+    pop si
+    pop dx
+    pop cx
+    pop ax
+    ret
+
+tp_about_line:
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    add dx, 14
+    ret
+
+; The internal "paint the whole window" entry, as against tp_paint, which is
+; the WM's callback and takes the window in SI the way the WM passes it.
+;
+; SI IS RELOADED FROM [tp_win] HERE, and that is the whole reason this exists
+; as more than a jmp: an event handler reaches a redraw through the editing
+; routines, and tp_go_left / tp_up / tp_down / tp_sol / tp_home / tp_end all
+; RETURN a source offset in SI. So SI at the point of the call is a byte
+; offset into the document, not a window - and tp_paint asks WM_CONTENT where
+; that "window" is and paints the answer, which put a second set of chrome
+; over the menu bar. Every caller was correct about its own registers; the
+; contract was the thing that could not survive being called from two places.
+tp_redraw:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov si, [tp_win]
+    or si, si
+    jz .o                       ; before WM_CREATE there is nothing to paint
+    call tp_paint
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_onabout:
+    xor byte [tp_abouton], 1
+    call tp_redraw
+    ret
+
+; ---- panes -----------------------------------------------------------------
+tp_edit_box:
+    ; out: tp_ex1/ey1/ex2/ey2 inclusive
+    push ax
+    mov ax, [tp_ox]
+    inc ax
+    mov [tp_ex1], ax
+    add ax, [tp_split]
+    dec ax
+    mov [tp_r_ssb+4], ax        ; sbar x2
+    sub ax, TP_SB_W
+    mov [tp_r_ssb], ax          ; sbar x1
+    dec ax
+    mov [tp_ex2], ax            ; text right of sbar
+    mov ax, [tp_oy]
+    add ax, TP_BAR_H
+    inc ax
+    mov [tp_ey1], ax
+    mov [tp_r_ssb+2], ax
+    mov ax, [tp_oy]
+    add ax, [tp_ch]
+    sub ax, TP_STAT_H
+    dec ax
+    mov [tp_ey2], ax
+    mov [tp_r_ssb+6], ax
+    pop ax
+    ret
+
+tp_prev_box:
+    push ax
+    mov ax, [tp_ox]
+    add ax, [tp_split]
+    add ax, 5
+    mov [tp_px1], ax
+    mov ax, [tp_ox]
+    add ax, [tp_cw]
+    dec ax
+    dec ax
+    mov [tp_r_psb+4], ax        ; preview sbar x2
+    sub ax, TP_SB_W
+    mov [tp_r_psb], ax
+    dec ax
+    mov [tp_px2], ax
+    mov ax, [tp_oy]
+    add ax, TP_BAR_H
+    inc ax
+    mov [tp_py1], ax
+    mov [tp_r_psb+2], ax
+    mov ax, [tp_oy]
+    add ax, [tp_ch]
+    sub ax, TP_STAT_H
+    dec ax
+    mov [tp_py2], ax
+    mov [tp_r_psb+6], ax
+    pop ax
+    ret
+
+tp_draw_source:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    call tp_edit_box
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    mov ax, [tp_ex1]
+    mov bx, [tp_ey1]
+    mov cx, [tp_r_ssb+4]
+    mov dx, [tp_ey2]
+    call OSAPI_GFX_FRAME
+    cmp byte [tp_focus], 0
+    jne .nf
+    dec ax
+    dec bx
+    inc cx
+    inc dx
+    call OSAPI_GFX_FRAME
+.nf:
+    call tp_draw_ssb
+    mov ax, [tp_srcseg]
+    or ax, ax
+    jz .out
+    mov es, ax
+    mov ax, [tp_ey2]
+    sub ax, [tp_ey1]
+    sub ax, 4
+    js .out
+    mov bl, 8
+    div bl
+    xor ah, ah
+    mov [tp_erows], ax
+    mov ax, [tp_ex2]
+    sub ax, [tp_ex1]
+    sub ax, 6
+    js .out
+    mov bl, 8
+    div bl
+    xor ah, ah
+    mov [tp_ecols], ax
+    xor di, di                  ; visible row
+    mov ax, [tp_vscroll]
+    mov [tp_tline], ax
+.row:
+    mov ax, di
+    cmp ax, [tp_erows]
+    jae .caret
+    mov ax, [tp_tline]
+    call tp_line_at
+    jc .caret
+    ; SI = start, CX = length
+    push di
+    mov ax, [tp_hscroll]
+    cmp cx, ax
+    ja .clip
+    xor cx, cx
+    jmp .copy
+.clip:
+    add si, ax
+    sub cx, ax
+.copy:
+    cmp cx, [tp_ecols]
+    jbe .okc
+    mov cx, [tp_ecols]
+.okc:
+    push es
+    push si
+    push cx
+    push ds
+    pop es
+    mov di, tp_linebuf
+    pop cx
+    pop si
+    push cx
+    push ds
+    mov ax, [tp_srcseg]
+    mov ds, ax
+    jcxz .nul
+    rep movsb
+.nul:
+    pop ds
+    pop cx
+    pop es
+    mov bx, cx
+    mov byte [tp_linebuf+bx], 0
+    pop di                      ; visible row
+    mov cx, [tp_ex1]
+    add cx, 3
+    mov dx, [tp_ey1]
+    add dx, 3
+    mov ax, di
+    mov bl, 8
+    mul bl
+    add dx, ax
+    mov si, tp_linebuf
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    inc word [tp_tline]
+    inc di
+    jmp .row
+.caret:
+    cmp byte [tp_focus], 0
+    jne .out
+    call tp_caret_xy
+    jc .out
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    ; invert caret cell
+    mov ax, [tp_cxp]
+    mov bx, [tp_cyp]
+    mov cx, ax
+    add cx, 7
+    mov dx, bx
+    add dx, 7
+    call OSAPI_GFX_XOR_FILL
+.out:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AX = line index. CF=1 past end. SI=start, CX=len (no NL)
+tp_line_at:
+    push ax
+    push bx
+    push dx
+    push es
+    mov es, [tp_srcseg]
+    xor si, si
+    mov dx, ax
+    mov bx, [tp_srclen]
+.walk:
+    or dx, dx
+    jz .found
+    cmp si, bx
+    jae .miss
+    mov al, [es:si]
+    inc si
+    cmp al, 10
+    je .nl
+    cmp al, 13
+    jne .walk
+    cmp si, bx
+    jae .nl
+    cmp byte [es:si], 10
+    jne .nl
+    inc si
+.nl:
+    dec dx
+    jmp .walk
+.found:
+    cmp si, bx
+    ja .miss
+    push si
+.len:
+    cmp si, bx
+    jae .e
+    mov al, [es:si]
+    cmp al, 10
+    je .e
+    cmp al, 13
+    je .e
+    inc si
+    jmp .len
+.e:
+    mov cx, si
+    pop si
+    sub cx, si
+    clc
+    jmp .o
+.miss:
+    stc
+.o:
+    pop es
+    pop dx
+    pop bx
+    pop ax
+    ret
+
+tp_count_lines:
+    push bx
+    push cx
+    push si
+    push es
+    mov es, [tp_srcseg]
+    xor ax, ax
+    xor si, si
+    mov bx, [tp_srclen]
+    or bx, bx
+    jz .o
+    inc ax
+.w:
+    cmp si, bx
+    jae .o
+    mov cl, [es:si]
+    inc si
+    cmp cl, 10
+    je .nl
+    cmp cl, 13
+    jne .w
+    cmp si, bx
+    jae .nl
+    cmp byte [es:si], 10
+    jne .nl
+    inc si
+.nl:
+    cmp si, bx
+    jae .o
+    inc ax
+    jmp .w
+.o:
+    pop es
+    pop si
+    pop cx
+    pop bx
+    ret
+
+; caret -> tp_cxp/tp_cyp. CF=1 off screen
+tp_caret_xy:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push es
+    call tp_cur_lc
+    ; AX=line BX=col
+    mov dx, ax
+    sub dx, [tp_vscroll]
+    js .off
+    cmp dx, [tp_erows]
+    jae .off
+    mov cx, bx
+    sub cx, [tp_hscroll]
+    js .off
+    cmp cx, [tp_ecols]
+    ja .off
+    mov al, 8
+    mul dl
+    mov dx, ax
+    add dx, [tp_ey1]
+    add dx, 3
+    mov [tp_cyp], dx
+    mov ax, cx
+    mov bl, 8
+    mul bl
+    add ax, [tp_ex1]
+    add ax, 3
+    mov [tp_cxp], ax
+    clc
+    jmp .o
+.off:
+    stc
+.o:
+    pop es
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; out AX=line BX=col of cursor
+tp_cur_lc:
+    push cx
+    push dx
+    push si
+    push es
+    mov es, [tp_srcseg]
+    xor ax, ax
+    xor bx, bx
+    xor si, si
+    mov dx, [tp_cur]
+    cmp dx, [tp_srclen]
+    jbe .w
+    mov dx, [tp_srclen]
+.w:
+    cmp si, dx
+    jae .o
+    mov cl, [es:si]
+    inc si
+    cmp cl, 10
+    je .nl
+    cmp cl, 13
+    jne .ch
+    cmp si, dx
+    jae .nl
+    cmp si, [tp_srclen]
+    jae .nl
+    cmp byte [es:si], 10
+    jne .nl
+    inc si
+.nl:
+    inc ax
+    xor bx, bx
+    jmp .w
+.ch:
+    inc bx
+    jmp .w
+.o:
+    pop es
+    pop si
+    pop dx
+    pop cx
+    ret
+
+; White-fill the source pane and redraw it. Used for caret motion so
+; the preview walker is not re-entered on every arrow key.
+tp_redraw_src:
+    push ax
+    push bx
+    push cx
+    push dx
+    call tp_edit_box
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    mov ax, [tp_ex1]
+    mov bx, [tp_ey1]
+    mov cx, [tp_ex2]
+    mov dx, [tp_ey2]
+    call OSAPI_GFX_FILL
+    call tp_draw_source
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_draw_preview:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    call tp_prev_box
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    mov ax, [tp_px1]
+    mov bx, [tp_py1]
+    mov cx, [tp_px2]
+    mov dx, [tp_py2]
+    call OSAPI_GFX_FRAME
+    cmp byte [tp_focus], 1
+    jne .nf
+    dec ax
+    dec bx
+    inc cx
+    inc dx
+    call OSAPI_GFX_FRAME
+.nf:
+    ; splitter
+    mov ax, [tp_ox]
+    add ax, [tp_split]
+    inc ax
+    mov bx, [tp_py1]
+    mov dx, [tp_py2]
+    call OSAPI_GFX_VLINE
+    call tp_fit_sheet
+    call tp_draw_sheet
+    call tp_draw_psb
+    cmp byte [tp_setok], 0
+    je .empty
+    call tp_paint_runs
+    call tp_paint_boxes
+    call tp_draw_folio
+    jmp .out
+.empty:
+    mov cx, [tp_tx1]
+    add cx, 4
+    mov dx, [tp_ty1]
+    add dx, 8
+    mov si, tp_s_noset
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    call tp_draw_folio
+.out:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; Linear preview: walk the source once, always advance SI, wrap in the pane.
+; Never calls the typesetter. Safe under the paint lock.
+; Page number on the sheet. Default (style 1) is bottom center.
+tp_draw_folio:
+    cmp byte [tp_pstyle], 0
+    je .o
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    pop es
+    mov di, tp_nbuf
+    mov ax, [tp_ppage]
+    inc ax
+    call tp_u16_di
+    mov byte [di], 0
+    mov si, tp_nbuf
+    xor cx, cx
+.ln:
+    cmp byte [si], 0
+    je .ld
+    inc cx
+    inc si
+    jmp .ln
+.ld:
+    mov ax, cx
+    mov cl, 3
+    shl ax, cl                  ; *8 screen
+    mov bx, ax                  ; number width
+    ; Y: bottom center (default), or header
+    mov dx, [tp_sy2]
+    sub dx, 18
+    cmp byte [tp_pstyle], 2
+    jne .yok
+    mov dx, [tp_sy1]
+    add dx, 4
+.yok:
+    cmp byte [tp_pstyle], 3
+    je .outer
+    ; center on the sheet
+    mov ax, [tp_sx1]
+    add ax, [tp_sx2]
+    sub ax, bx
+    sar ax, 1
+    jmp .put
+.outer:
+    mov ax, [tp_ppage]
+    and ax, 1
+    jnz .ol
+    mov ax, [tp_sx2]
+    sub ax, bx
+    sub ax, 6
+    jmp .put
+.ol:
+    mov ax, [tp_sx1]
+    add ax, 6
+.put:
+    cmp dx, [tp_py1]
+    jb .done
+    cmp dx, [tp_py2]
+    jae .done
+    add ax, 7
+    and ax, 0xFFF8
+    mov cx, ax
+    mov si, tp_nbuf
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+.done:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+.o:
+    ret
+
+tp_scr_cw:
+    ; body char width used for screen mapping
+    push bx
+    mov al, [tp_tsize]
+    xor ah, ah
+    or ax, ax
+    jnz .s
+    mov al, 12
+.s:
+    mov bl, 6
+    mul bl
+    mov bl, 10
+    div bl
+    xor ah, ah
+    cmp al, 4
+    jae .o
+    mov al, 4
+.o:
+    pop bx
+    ret
+
+tp_map_xy_i:
+    ; AX=x BX=y -> CX DX. uses tp_tsize, tp_tlead, tp_tleft, tp_ttop
+    push ax
+    push bx
+    push si
+    push di
+    mov di, ax                  ; di = pdf x
+    call tp_scr_cw
+    mov si, ax                  ; si = cw
+    or si, si
+    jnz .cw
+    mov si, 7
+.cw:
+    mov ax, di
+    sub ax, [tp_tleft]
+    jns .xok
+    xor ax, ax
+.xok:
+    mov cx, 8
+    mul cx                      ; DX:AX = dx*8
+    xor dx, dx
+    div si                      ; AX = cols*8/cw? wait AX = (x-left)*8/cw
+    add ax, [tp_px1]
+    add ax, 6
+    mov cx, ax                  ; sx
+    ; y: (ttop - y) * 8 / lead
+    mov ax, [tp_ttop]
+    sub ax, bx
+    jns .yok
+    xor ax, ax
+.yok:
+    mov si, [tp_tlead]
+    or si, si
+    jnz .ld
+    mov si, 14
+.ld:
+    mov bx, 8
+    mul bx
+    xor dx, dx
+    div si
+    sub ax, [tp_pscroll]
+    add ax, [tp_py1]
+    add ax, 6
+    mov dx, ax
+    pop di
+    pop si
+    pop bx
+    pop ax
+    ret
+
+tp_paint_runs:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    ; Place each run at its typeset (x,y). The sheet is already scaled
+    ; so 8px = body point size; packing into a fitted pane made 12pt
+    ; look huge and crushed the measure to ~20 characters.
+    xor si, si
+.lp:
+    cmp si, [tp_nruns]
+    jae .o
+    mov ax, si
+    mov cx, TP_RUN_SZ
+    mul cx
+    mov bx, ax
+    add bx, tp_runs
+    mov al, [bx]
+    xor ah, ah
+    cmp ax, [tp_ppage]
+    jne .n
+    mov al, [bx+7]
+    or al, al
+    jz .n
+    cmp word [bx+4], 40
+    jb .n
+    mov ax, [bx+2]
+    call tp_mapx
+    mov cx, ax
+    mov ax, [bx+4]
+    call tp_mapy
+    mov dx, ax
+    cmp dx, [tp_py1]
+    jb .n
+    cmp dx, [tp_py2]
+    jae .n
+    cmp cx, [tp_px2]
+    jae .n
+    cmp cx, [tp_px1]
+    jae .xok
+    mov cx, [tp_px1]
+    add cx, 2
+.xok:
+    mov [tp_tmp], cx
+    push si
+    push bx
+    push ds
+    pop es
+    mov si, [bx+8]
+    add si, tp_text
+    mov di, tp_linebuf
+    xor ch, ch
+    mov cl, [bx+7]
+    cmp cx, 80
+    jbe .cp
+    mov cx, 80
+.cp:
+    jcxz .z
+    push cx
+    rep movsb
+    pop cx
+.z:
+    mov di, tp_linebuf
+    add di, cx
+    mov byte [di], 0
+    mov si, tp_linebuf
+    mov cx, [tp_tmp]
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_RUN
+    pop bx
+    test byte [bx+1], 1
+    jnz .bd
+    cmp byte [bx+6], 14
+    jb .un
+.bd:
+    inc cx
+    mov si, tp_linebuf
+    mov al, CBLACK
+    mov ah, CWHITE
+    call OSAPI_FONT_STR
+.un:
+    pop si
+.n:
+    inc si
+    jmp .lp
+.o:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_paint_boxes:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    xor si, si
+    mov di, [tp_nboxes]
+.lp:
+    cmp si, di
+    jae .o
+    mov ax, si
+    mov cx, TP_BOX_SZ
+    mul cx
+    mov bx, ax
+    add bx, tp_boxes
+    mov al, [bx]
+    xor ah, ah
+    cmp ax, [tp_ppage]
+    jne .n
+    push si
+    push di
+    ; top-left: (x, y+h)
+    mov ax, [bx+2]
+    call tp_mapx
+    mov [tp_tmp], ax
+    mov ax, [bx+4]
+    add ax, [bx+8]
+    call tp_mapy
+    mov [tp_tmp2], ax
+    ; bottom-right: (x+w, y)
+    mov ax, [bx+2]
+    add ax, [bx+6]
+    call tp_mapx
+    mov cx, ax
+    mov ax, [bx+4]
+    call tp_mapy
+    mov dx, ax
+    mov ax, [tp_tmp]
+    mov bx, [tp_tmp2]
+    cmp ax, cx
+    jle .xok
+    xchg ax, cx
+.xok:
+    cmp bx, dx
+    jle .yok
+    xchg bx, dx
+.yok:
+    cmp ax, [tp_px2]
+    jg .sk
+    cmp cx, [tp_px1]
+    jl .sk
+    cmp bx, [tp_py2]
+    jg .sk
+    cmp dx, [tp_py1]
+    jl .sk
+    cmp ax, [tp_px1]
+    jge .a1
+    mov ax, [tp_px1]
+.a1:
+    cmp bx, [tp_py1]
+    jge .b1
+    mov bx, [tp_py1]
+.b1:
+    cmp cx, [tp_px2]
+    jle .c1
+    mov cx, [tp_px2]
+.c1:
+    cmp dx, [tp_py2]
+    jle .d1
+    mov dx, [tp_py2]
+.d1:
+    cmp bx, dx
+    jne .notht
+    ; 1-row box: a horizontal rule
+    push ax
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    pop ax
+    mov bx, cx
+    call OSAPI_GFX_HLINE
+    jmp .sk
+.notht:
+    cmp ax, cx
+    jne .rect
+    push ax
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_VLINE
+    jmp .sk
+.rect:
+    call OSAPI_GFX_FRAME
+.sk:
+    pop di
+    pop si
+.n:
+    inc si
+    jmp .lp
+.o:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+tp_onkey:
+    call tp_deferred_ld
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov bl, al
+    mov bh, ah
+    cmp byte [tp_abouton], 0
+    je .k
+    mov byte [tp_abouton], 0
+    jmp .draw
+.k:
+    cmp bh, 0x3F
+    je .kset
+    cmp bl, 27
+    je .kesc
+    cmp bl, 19                  ; Ctrl+S
+    je .ksave
+    cmp bl, 15                  ; Ctrl+O
+    je .kopen
+    cmp bl, 14                  ; Ctrl+N
+    je .knew
+    cmp bl, 3                   ; Ctrl+C
+    je .kcopy
+    cmp bl, 22                  ; Ctrl+V
+    je .kpaste
+    cmp bl, 24                  ; Ctrl+X
+    je .kcut
+    cmp bl, '['
+    je .kprev
+    cmp bl, ']'
+    je .knext
+    cmp byte [tp_focus], 0
+    je .ed
+    jmp .pv
+.kset:
+    call tp_typeset
+    jmp .draw
+.kesc:
+    call tp_typeset
+    mov byte [tp_focus], 1
+    jmp .draw
+.ksave:
+    call tp_save
+    jmp .draw
+.kopen:
+    mov byte [tp_dlgmode], 0
+    mov al, FDLG_OPEN
+    call tp_dlg
+    jmp .out
+.knew:
+    call tp_seed
+    jmp .draw
+.kcopy:
+    call tp_copy_all
+    jmp .draw
+.kpaste:
+    call tp_paste
+    jmp .draw
+.kcut:
+    call tp_cut_line
+    jmp .draw
+.kprev:
+    call tp_prev_page
+    jmp .draw
+.knext:
+    call tp_next_page
+    jmp .draw
+.ed:
+    cmp bl, 8
+    je .kbs
+    cmp bl, 127
+    je .kdel
+    cmp bh, 0x53
+    je .kdel
+    cmp bl, 13
+    je .knl
+    cmp bl, 9
+    je .ktab
+    cmp bh, 0x4B
+    je .kleft
+    cmp bh, 0x4D
+    je .kright
+    cmp bh, 0x48
+    je .kup
+    cmp bh, 0x50
+    je .kdn
+    cmp bh, 0x47
+    je .khome
+    cmp bh, 0x4F
+    je .kend
+    cmp bh, 0x49
+    je .kpgup
+    cmp bh, 0x51
+    je .kpgdn
+    cmp bl, 32
+    jb .out
+    cmp bl, 126
+    ja .out
+    mov al, bl
+    call tp_ins
+    jmp .edraw
+.kbs:
+    call tp_backsp
+    jmp .edraw
+.kdel:
+    call tp_delete
+    jmp .edraw
+.knl:
+    mov al, 10
+    call tp_ins
+    jmp .edraw
+.ktab:
+    mov al, ' '
+    call tp_ins
+    mov al, ' '
+    call tp_ins
+    jmp .edraw
+.kleft:
+    call tp_go_left
+    jmp .edraw
+.kright:
+    call tp_go_right
+    jmp .edraw
+.kup:
+    call tp_up
+    jmp .edraw
+.kdn:
+    call tp_down
+    jmp .edraw
+.khome:
+    call tp_home
+    jmp .edraw
+.kend:
+    call tp_end
+    jmp .edraw
+.kpgup:
+    call tp_pgup
+    jmp .edraw
+.kpgdn:
+    call tp_pgdn
+    jmp .edraw
+.edraw:
+    call tp_keep_caret
+    ; the source pane alone, UNLESS a deferred load just landed - see
+    ; tp_deferred_ld. Promoting is what keeps this to one draw: repainting the
+    ; pane and then the window would put the source through twice, which is
+    ; PERFORMANCE.md's double-draw and shows on an XT and on nothing else.
+    cmp byte [tp_ldfull], 0
+    jne .draw
+    call tp_redraw_src
+    jmp .out
+.pv:
+    cmp bh, 0x48
+    je .psu
+    cmp bh, 0x50
+    je .psd
+    cmp bh, 0x49
+    je .kprev
+    cmp bh, 0x51
+    je .knext
+    cmp bh, 0x4B
+    je .kprev
+    cmp bh, 0x4D
+    je .knext
+    jmp .out
+.psu:
+    cmp word [tp_pscroll], 0
+    je .draw
+    sub word [tp_pscroll], 24
+    jnc .draw
+    mov word [tp_pscroll], 0
+    jmp .draw
+.psd:
+    add word [tp_pscroll], 24
+    jmp .draw
+.draw:
+    mov byte [tp_ldfull], 0
+    call tp_keep_caret
+    call tp_redraw
+    jmp .done
+.out:
+    ; a key that changed nothing still owes a repaint if a load came in under
+    ; it - an unhandled key is the one path here that draws nothing at all.
+    cmp byte [tp_ldfull], 0
+    jne .draw
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+tp_onclick:
+    call tp_deferred_ld
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push cx
+    push dx
+    mov bx, si
+    call OSAPI_WM_CONTENT
+    mov [tp_ox], ax
+    mov [tp_oy], dx
+    mov bx, si
+    call OSAPI_WM_GEOM
+    mov [tp_cw], cx
+    mov [tp_ch], dx
+    call tp_clamp_split
+    call tp_layout
+    call tp_edit_box
+    call tp_prev_box
+    pop dx
+    pop cx
+    mov byte [tp_abouton], 0
+    mov bx, tp_r_set
+    call os88ui_bhit
+    jnc .set
+    mov bx, tp_r_cls
+    call os88ui_bhit
+    jnc .sz
+    mov bx, tp_r_mar
+    call os88ui_bhit
+    jnc .bd
+    mov bx, tp_r_gut
+    call os88ui_bhit
+    jnc .gut
+    mov bx, tp_r_pad
+    call os88ui_bhit
+    jnc .pad
+    mov bx, tp_r_prev
+    call os88ui_bhit
+    jnc .prev
+    mov bx, tp_r_next
+    call os88ui_bhit
+    jnc .next
+    mov bx, tp_r_ssb
+    call os88ui_bhit
+    jnc .ssb
+    mov bx, tp_r_psb
+    call os88ui_bhit
+    jnc .psb
+    ; panes
+    cmp dx, [tp_ey1]
+    jb .out
+    cmp dx, [tp_ey2]
+    ja .out
+    cmp cx, [tp_ex2]
+    jbe .src
+    cmp cx, [tp_px1]
+    jae .prv
+    jmp .out
+.src:
+    mov byte [tp_focus], 0
+    call tp_click_caret
+    jmp .draw
+.prv:
+    mov byte [tp_focus], 1
+    jmp .draw
+.set:
+    call tp_typeset
+    jmp .draw
+.sz:
+    mov al, [tp_psize]
+    inc al
+    cmp al, 4
+    jb .szok
+    xor al, al
+.szok:
+    mov [tp_psize], al
+    jmp .rely
+.bd:
+    mov al, [tp_bind]
+    inc al
+    cmp al, 3
+    jb .bdok
+    xor al, al
+.bdok:
+    mov [tp_bind], al
+    jmp .rely
+.gut:
+    mov al, [tp_gutter]
+    inc al
+    cmp al, 3
+    jb .gok
+    xor al, al
+.gok:
+    mov [tp_gutter], al
+    jmp .rely
+.pad:
+    mov al, [tp_pad]
+    inc al
+    cmp al, 3
+    jb .ps
+    xor al, al
+.ps:
+    mov [tp_pad], al
+.rely:
+    mov byte [tp_needset], 1
+    jmp .draw
+.prev:
+    call tp_prev_page
+    jmp .draw
+.next:
+    call tp_next_page
+    jmp .draw
+.ssb:
+    mov byte [tp_focus], 0
+    call tp_ssb_click
+    jmp .draw
+.psb:
+    mov byte [tp_focus], 1
+    call tp_psb_click
+.draw:
+    mov byte [tp_ldfull], 0     ; this IS the full repaint the flag asks for
+    call tp_redraw
+    jmp .done
+.out:
+    cmp byte [tp_ldfull], 0     ; a click on nothing, with a load under it
+    jne .draw
+.done:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_click_caret:
+    push ax
+    push bx
+    push cx
+    push dx
+    ; row
+    mov ax, dx
+    sub ax, [tp_ey1]
+    sub ax, 3
+    jns .r
+    xor ax, ax
+.r:
+    mov bl, 8
+    div bl
+    xor ah, ah
+    add ax, [tp_vscroll]
+    mov [tp_tline], ax
+    ; col
+    mov ax, cx
+    sub ax, [tp_ex1]
+    sub ax, 3
+    jns .c
+    xor ax, ax
+.c:
+    mov bl, 8
+    div bl
+    xor ah, ah
+    add ax, [tp_hscroll]
+    mov [tp_wantcol], ax
+    mov ax, [tp_tline]
+    call tp_goto_lc
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AX=line, tp_wantcol=col
+tp_goto_lc:
+    push ax
+    push bx
+    push cx
+    push si
+    call tp_line_at
+    jc .eof
+    ; SI start CX len
+    mov ax, [tp_wantcol]
+    cmp ax, cx
+    jbe .ok
+    mov ax, cx
+.ok:
+    add si, ax
+    mov [tp_cur], si
+    jmp .o
+.eof:
+    mov ax, [tp_srclen]
+    mov [tp_cur], ax
+.o:
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_prev_page:
+    cmp word [tp_ppage], 0
+    je .o
+    dec word [tp_ppage]
+    mov word [tp_pscroll], 0
+.o:
+    ret
+
+tp_next_page:
+    mov ax, [tp_npages]
+    or ax, ax
+    jz .o
+    dec ax
+    cmp [tp_ppage], ax
+    jae .o
+    inc word [tp_ppage]
+    mov word [tp_pscroll], 0
+.o:
+    ret
+
+; -----------------------------------------------------------------------------
+tp_oncmd:
+    call tp_deferred_ld
+    cmp ah, 0
+    je .file
+    cmp ah, 1
+    je .edit
+    cmp ah, 2
+    je .lay
+    cmp ah, 3
+    je .page
+    cmp ah, 4
+    je .view
+    ret
+.file:
+    cmp al, 0
+    je .new
+    cmp al, 1
+    je .open
+    cmp al, 2
+    je .save
+    cmp al, 3
+    je .saveas
+    cmp al, 4
+    je .epdf
+    cmp al, 5
+    je .eps
+    ret
+.new:
+    call tp_seed
+    call tp_redraw
+    ret
+.open:
+    mov byte [tp_dlgmode], 0
+    mov al, FDLG_OPEN
+    call tp_dlg
+    ret
+.save:
+    call tp_save
+    call tp_redraw
+    ret
+.saveas:
+    mov byte [tp_dlgmode], 1
+    mov al, FDLG_SAVE
+    call tp_dlg
+    ret
+.epdf:
+    mov byte [tp_dlgmode], 2
+    mov al, FDLG_SAVE
+    call tp_dlg
+    ret
+.eps:
+    mov byte [tp_dlgmode], 3
+    mov al, FDLG_SAVE
+    call tp_dlg
+    ret
+.edit:
+    cmp al, 0
+    je .copy
+    cmp al, 1
+    je .paste
+    cmp al, 2
+    je .cut
+    ret
+.copy:
+    call tp_copy_all
+    call tp_redraw
+    ret
+.paste:
+    call tp_paste
+    call tp_redraw
+    ret
+.cut:
+    call tp_cut_line
+    call tp_redraw
+    ret
+.lay:
+    cmp al, 0
+    je .art
+    cmp al, 1
+    je .book
+    cmp al, 2
+    je .mn
+    cmp al, 3
+    je .m1
+    cmp al, 4
+    je .mw
+    cmp al, 5
+    je .pc
+    cmp al, 6
+    je .pn
+    cmp al, 7
+    je .pl
+    cmp al, 8
+    je .sgl
+    cmp al, 9
+    je .fac
+    cmp al, 10
+    je .opp
+    ret
+.art:
+    mov byte [tp_class], 0
+    mov byte [tp_bind], 0
+    jmp .rely
+.book:
+    mov byte [tp_class], 1
+    cmp byte [tp_bind], 2
+    je .rely
+    mov byte [tp_bind], 1
+    jmp .rely
+.mn:
+    mov byte [tp_margin], 0
+    jmp .rely
+.m1:
+    mov byte [tp_margin], 1
+    jmp .rely
+.mw:
+    mov byte [tp_margin], 2
+    jmp .rely
+.pc:
+    mov byte [tp_pad], 0
+    jmp .rely
+.pn:
+    mov byte [tp_pad], 1
+    jmp .rely
+.pl:
+    mov byte [tp_pad], 2
+    jmp .rely
+.sgl:
+    mov byte [tp_bind], 0
+    jmp .rely
+.fac:
+    mov byte [tp_bind], 1
+    jmp .rely
+.opp:
+    mov byte [tp_bind], 2
+    jmp .rely
+.page:
+    cmp al, 0
+    je .ltr
+    cmp al, 1
+    je .leg
+    cmp al, 2
+    je .a4
+    cmp al, 3
+    je .a5
+    cmp al, 4
+    je .g0
+    cmp al, 5
+    je .g1
+    cmp al, 6
+    je .g2
+    cmp al, 7
+    je .uin
+    cmp al, 8
+    je .umm
+    cmp al, 9
+    je .n0
+    cmp al, 10
+    je .n1
+    cmp al, 11
+    je .n2
+    cmp al, 12
+    je .n3
+    ret
+.ltr:
+    mov byte [tp_psize], 0
+    jmp .rely
+.leg:
+    mov byte [tp_psize], 1
+    jmp .rely
+.a4:
+    mov byte [tp_psize], 2
+    jmp .rely
+.a5:
+    mov byte [tp_psize], 3
+    jmp .rely
+.g0:
+    mov byte [tp_gutter], 0
+    jmp .rely
+.g1:
+    mov byte [tp_gutter], 1
+    jmp .rely
+.g2:
+    mov byte [tp_gutter], 2
+    jmp .rely
+.uin:
+    mov byte [tp_units], 0
+    jmp .rely
+.umm:
+    mov byte [tp_units], 1
+    jmp .rely
+.n0:
+    mov byte [tp_pstyle], 0
+    jmp .rely
+.n1:
+    mov byte [tp_pstyle], 1
+    jmp .rely
+.n2:
+    mov byte [tp_pstyle], 2
+    jmp .rely
+.n3:
+    mov byte [tp_pstyle], 3
+.rely:
+    mov byte [tp_needset], 1
+    call tp_redraw
+    ret
+.view:
+    cmp al, 0
+    je .set
+    cmp al, 1
+    je .vp
+    cmp al, 2
+    je .vn
+    cmp al, 3
+    je .ws
+    cmp al, 4
+    je .wp
+    ret
+.set:
+    call tp_typeset
+    call tp_redraw
+    ret
+.vp:
+    call tp_prev_page
+    call tp_redraw
+    ret
+.vn:
+    call tp_next_page
+    call tp_redraw
+    ret
+.ws:
+    add word [tp_split], 24
+    call tp_clamp_split
+    call tp_redraw
+    ret
+.wp:
+    sub word [tp_split], 24
+    call tp_clamp_split
+    call tp_redraw
+    ret
+
+tp_dlg:
+    push bx
+    push si
+    push di
+    mov bx, [tp_win]
+    or bx, bx
+    jnz .w
+    mov bx, si
+.w:
+    mov di, tp_ondlg
+    mov si, tp_fname
+    cmp byte [si], 0
+    jne .nm
+    mov si, tp_s_hello
+.nm:
+    call OSAPI_FILE_DLG
+    pop di
+    pop si
+    pop bx
+    ret
+
+tp_ondlg:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov ax, KERNEL_SEG
+    mov es, ax
+    mov si, di
+    mov di, tp_dlgname
+    mov cx, 13
+.cp:
+    mov al, [es:si]
+    mov [di], al
+    or al, al
+    jz .named
+    inc si
+    inc di
+    loop .cp
+    mov byte [di], 0
+.named:
+    push ds
+    pop es
+    call OSAPI_FILE_HERE
+    mov [tp_dir], dx
+    mov [tp_drv], bl
+    mov al, [tp_dlgmode]
+    or al, al
+    je .open
+    cmp al, 1
+    je .save
+    cmp al, 2
+    je .pdf
+    cmp al, 3
+    je .ps
+    jmp .fin
+.open:
+    mov si, tp_dlgname
+    mov di, tp_fname
+    call tp_cpat
+    mov byte [di], 0
+    call tp_load
+    jc .fin
+    call tp_typeset
+    jmp .fin
+.save:
+    mov si, tp_dlgname
+    mov di, tp_fname
+    call tp_cpat
+    mov byte [di], 0
+    call tp_save
+    jmp .fin
+.pdf:
+    mov si, tp_dlgname
+    call tp_export_pdf
+    jmp .fin
+.ps:
+    mov si, tp_dlgname
+    call tp_export_ps
+.fin:
+    call tp_retitle
+    call tp_redraw              ; SI is tp_redraw's own business now
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+tp_load:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push es
+    call tp_claim_src
+    jc .nomem
+    mov es, [tp_srcseg]
+    xor bx, bx
+    mov cx, TP_SRC_MAX
+    xor dx, dx
+    mov si, tp_fname
+    call OSAPI_FILE_READ
+    jc .err
+    cmp ax, TP_SRC_MAX
+    jbe .ok
+    mov ax, TP_SRC_MAX
+.ok:
+    mov [tp_srclen], ax
+    call tp_crlf_fix
+    mov word [tp_cur], 0
+    mov word [tp_vscroll], 0
+    mov word [tp_hscroll], 0
+    mov byte [tp_dirty], 0
+    mov byte [tp_needset], 1
+    mov si, tp_s_loaded
+    call tp_toast
+    clc
+    jmp .out
+.nomem:
+    mov si, tp_s_nomem
+    call tp_toast
+    stc
+    jmp .out
+.err:
+    mov si, tp_s_err
+    call tp_toast
+    stc
+.out:
+    pop es
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_crlf_fix:
+    ; collapse CR LF -> LF, lone CR -> LF
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+    push es
+    mov es, [tp_srcseg]
+    xor si, si
+    xor di, di
+    mov cx, [tp_srclen]
+    jcxz .z
+.lp:
+    mov al, [es:si]
+    inc si
+    cmp al, 13
+    jne .st
+    mov al, 10
+    cmp si, [tp_srclen]
+    jae .st
+    cmp byte [es:si], 10
+    jne .st
+    inc si
+.st:
+    mov [es:di], al
+    inc di
+    cmp si, [tp_srclen]
+    jb .lp
+    mov [tp_srclen], di
+.z:
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_save:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push es
+    push ds
+    pop es
+    cmp byte [tp_fname], 0
+    jne .nm
+    mov si, tp_s_paper
+    mov di, tp_fname
+    call tp_cpat
+    mov byte [di], 0
+.nm:
+    call tp_claim_src
+    jc .err
+    mov es, [tp_srcseg]
+    xor bx, bx
+    mov cx, [tp_srclen]
+    cmp cx, TP_SRC_MAX
+    jbe .len
+    mov cx, TP_SRC_MAX
+.len:
+    xor dx, dx
+    mov si, tp_fname
+    call OSAPI_FILE_WRITE
+    jc .err
+    mov byte [tp_dirty], 0
+    call tp_retitle
+    mov si, tp_s_saved
+    call tp_toast
+    jmp .out
+.err:
+    mov si, tp_s_werr
+    call tp_toast
+.out:
+    pop es
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_seed:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    call tp_claim_src
+    jc .o
+    mov es, [tp_srcseg]
+    mov si, tp_seed_s
+    xor di, di
+.cp:
+    lodsb
+    mov [es:di], al
+    inc di
+    or al, al
+    jnz .cp
+    dec di
+    mov [tp_srclen], di
+    mov word [tp_cur], 0
+    mov word [tp_vscroll], 0
+    mov word [tp_hscroll], 0
+    mov si, tp_s_untitled
+    mov di, tp_fname
+    call tp_cpat
+    mov byte [di], 0
+    mov byte [tp_dirty], 0
+    mov byte [tp_needset], 1
+.o:
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+tp_copy_all:
+    push ax
+    push cx
+    push si
+    push es
+    mov ax, [tp_srcseg]
+    or ax, ax
+    jz .o
+    mov es, ax
+    xor si, si
+    mov cx, [tp_srclen]
+    call OSAPI_CLIP_PUT
+    mov si, tp_s_copied
+    call tp_toast
+.o:
+    pop es
+    pop si
+    pop cx
+    pop ax
+    ret
+
+tp_paste:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    call tp_clamp_cur
+    call OSAPI_CLIP_SIZE
+    jc .o
+    or ax, ax
+    jz .o
+    mov cx, ax
+    mov ax, [tp_srclen]
+    add ax, cx
+    cmp ax, TP_SRC_MAX
+    ja .big
+    ; insert CX bytes at cursor: grow then get into a hole
+    ; paste at end of a gap we open
+    mov bx, [tp_cur]
+    mov dx, cx                  ; paste len
+    ; move tail
+    call tp_open_gap            ; BX=cur DX=len
+    jc .o
+    mov es, [tp_srcseg]
+    mov di, [tp_cur]
+    mov cx, dx
+    call OSAPI_CLIP_GET
+    ; CX is what CLIP_GET actually COPIED, not what CLIP_SIZE promised. The
+    ; clipboard belongs to the desktop and this app is pre-empted between the
+    ; two calls (SPEC.md 20.6), so another program may have replaced it with a
+    ; shorter one in between. Advancing by DX would splice that many bytes of
+    ; whatever was already in the claim into the document.
+    mov dx, cx
+    add [tp_cur], dx
+    add [tp_srclen], dx
+    call tp_crlf_fix
+    ; crlf_fix SHRINKS srclen by one byte per CR LF pair it collapses and knows
+    ; nothing about the caret, so a paste of CRLF text at the end of the buffer
+    ; leaves tp_cur PAST tp_srclen. The next tp_ins then hands tp_open_gap an
+    ; offset beyond the end - see the guard there for what that used to do.
+    call tp_clamp_cur
+    mov byte [tp_dirty], 1
+    mov byte [tp_needset], 1
+    jmp .o
+.big:
+    mov si, tp_s_full
+    call tp_toast
+.o:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; The caret is an offset into the document and every path that shortens the
+; document has to bring it back inside, or the next edit works from an offset
+; that is past the end. Cheap enough to call unconditionally.
+tp_clamp_cur:
+    push ax
+    mov ax, [tp_srclen]
+    cmp [tp_cur], ax
+    jbe .o
+    mov [tp_cur], ax
+.o:
+    pop ax
+    ret
+
+; BX = offset, DX = bytes to open. CF=1 no room
+tp_open_gap:
+    push ax
+    push cx
+    push si
+    push di
+    push ds
+    push es
+    mov ax, [tp_srclen]
+    add ax, dx
+    cmp ax, TP_SRC_MAX
+    ja .bad
+    ; BX PAST the end is the caller's bug, and refusing is the only safe answer
+    ; to it: the tail length below is srclen - BX, which UNDERFLOWS to ~64KB
+    ; when BX is bigger, and the std/rep movsb under it then walks backwards
+    ; over the whole 64KB segment the 8KB claim sits in - the claim heap above
+    ; it included (SPEC.md 50.3). Every caller is checked, but this is the one
+    ; place the damage is unbounded, so the check lives here too.
+    cmp bx, [tp_srclen]
+    ja .bad
+    mov cx, [tp_srclen]
+    sub cx, bx
+    jz .ok
+    mov si, [tp_srclen]
+    dec si
+    mov di, si
+    add di, dx
+    mov ax, [tp_srcseg]
+    mov ds, ax
+    mov es, ax
+    std
+    rep movsb
+    cld
+.ok:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop cx
+    pop ax
+    clc
+    ret
+.bad:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop cx
+    pop ax
+    stc
+    ret
+
+tp_cut_line:
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+    push es
+    call tp_cur_lc
+    ; AX=line
+    call tp_line_at
+    jc .o
+    ; SI start CX len; include following NL
+    mov bx, si
+    add si, cx
+    mov es, [tp_srcseg]
+    cmp si, [tp_srclen]
+    jae .cut
+    cmp byte [es:si], 13
+    jne .lf
+    inc si
+    inc cx
+    cmp si, [tp_srclen]
+    jae .cut
+.lf:
+    cmp byte [es:si], 10
+    jne .cut
+    inc cx
+.cut:
+    ; clipboard the line
+    mov es, [tp_srcseg]
+    push cx
+    mov cx, cx
+    pop cx
+    push bx
+    mov si, bx
+    call OSAPI_CLIP_PUT
+    pop bx
+    mov [tp_tmp3], cx
+    call tp_del_range2
+    mov [tp_cur], bx
+    mov byte [tp_dirty], 1
+    mov byte [tp_needset], 1
+.o:
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_del_range2:
+    ; BX=off, [tp_tmp3]=count
+    push ax
+    push cx
+    push si
+    push di
+    push ds
+    push es
+    mov cx, [tp_srclen]
+    cmp bx, cx
+    jae .none
+    mov ax, bx
+    add ax, [tp_tmp3]
+    jnc .sum
+    mov ax, cx
+.sum:
+    cmp ax, cx
+    jbe .ok
+    mov ax, cx
+.ok:
+    sub ax, bx
+    mov [tp_tmp3], ax           ; clamped count
+    or ax, ax
+    jz .none
+    mov si, bx
+    add si, ax                  ; first kept byte
+    mov di, bx
+    mov cx, [tp_srclen]
+    sub cx, si                  ; tail
+    jnc .tail
+    xor cx, cx
+.tail:
+    mov ax, [tp_srcseg]
+    mov ds, ax
+    mov es, ax
+    cld
+    jcxz .z
+    rep movsb
+.z:
+    pop es
+    pop ds
+    mov ax, [tp_srclen]
+    sub ax, [tp_tmp3]
+    mov [tp_srclen], ax
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+.none:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; AL = char to insert
+tp_ins:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    push ds
+    call tp_claim_src
+    jc .o
+    call tp_clamp_cur
+    mov bx, [tp_srclen]
+    cmp bx, TP_SRC_MAX
+    jae .full
+    mov dx, 1
+    mov bx, [tp_cur]
+    mov [tp_tmp5], al
+    call tp_open_gap
+    jc .full
+    mov es, [tp_srcseg]
+    mov di, [tp_cur]
+    mov al, [tp_tmp5]
+    mov [es:di], al
+    inc word [tp_cur]
+    inc word [tp_srclen]
+    mov byte [tp_dirty], 1
+    mov byte [tp_needset], 1
+    jmp .o
+.full:
+    mov si, tp_s_full
+    call tp_toast
+.o:
+    pop ds
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_backsp:
+    cmp word [tp_cur], 0
+    je .o
+    dec word [tp_cur]
+    call tp_delete
+.o:
+    ret
+
+tp_delete:
+    push ax
+    push bx
+    push cx
+    push si
+    push es
+    mov ax, [tp_cur]
+    cmp ax, [tp_srclen]
+    jae .o
+    mov bx, ax
+    mov word [tp_tmp3], 1
+    mov es, [tp_srcseg]
+    mov si, bx
+    mov al, [es:si]
+    cmp al, 13
+    jne .one
+    inc si
+    cmp si, [tp_srclen]
+    jae .one
+    cmp byte [es:si], 10
+    jne .one
+    mov word [tp_tmp3], 2
+.one:
+    call tp_del_range2
+    mov byte [tp_dirty], 1
+    mov byte [tp_needset], 1
+.o:
+    pop es
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_go_left:
+    cmp word [tp_cur], 0
+    je .o
+    dec word [tp_cur]
+    push es
+    mov es, [tp_srcseg]
+    mov si, [tp_cur]
+    cmp byte [es:si], 10
+    jne .d
+    or si, si
+    jz .d
+    dec si
+    cmp byte [es:si], 13
+    jne .d
+    mov [tp_cur], si
+.d:
+    pop es
+    call tp_cur_lc
+    mov [tp_wantcol], bx
+.o:
+    ret
+
+tp_go_right:
+    mov ax, [tp_cur]
+    cmp ax, [tp_srclen]
+    jae .o
+    push es
+    mov es, [tp_srcseg]
+    mov si, ax
+    mov al, [es:si]
+    inc si
+    cmp al, 13
+    jne .d
+    cmp si, [tp_srclen]
+    jae .d
+    cmp byte [es:si], 10
+    jne .d
+    inc si
+.d:
+    mov [tp_cur], si
+    pop es
+    call tp_cur_lc
+    mov [tp_wantcol], bx
+.o:
+    ret
+
+; SI = start of the line that contains tp_cur
+tp_sol:
+    push ax
+    push bx
+    push es
+    mov es, [tp_srcseg]
+    mov si, [tp_cur]
+    mov bx, [tp_srclen]
+    cmp si, bx
+    jbe .ok
+    mov si, bx
+.ok:
+    or si, si
+    jz .d
+.lp:
+    dec si
+    mov al, [es:si]
+    cmp al, 10
+    je .aft
+    cmp al, 13
+    je .aft
+    or si, si
+    jnz .lp
+    jmp .d
+.aft:
+    inc si
+.d:
+    pop es
+    pop bx
+    pop ax
+    ret
+
+tp_up:
+    push ax
+    push bx
+    push cx
+    push si
+    push es
+    call tp_cur_lc
+    mov [tp_wantcol], bx
+    call tp_sol
+    or si, si
+    jz .o
+    dec si
+    ; land on previous line; skip CR of CRLF
+    mov es, [tp_srcseg]
+    cmp byte [es:si], 13
+    jne .back
+    or si, si
+    jz .back
+    dec si
+    cmp byte [es:si], 10
+    je .back
+    inc si
+.back:
+    ; walk back to start of previous line
+    or si, si
+    jz .at
+.w:
+    dec si
+    mov al, [es:si]
+    cmp al, 10
+    je .aft
+    cmp al, 13
+    je .aft
+    or si, si
+    jnz .w
+    jmp .at
+.aft:
+    inc si
+.at:
+    mov cx, [tp_wantcol]
+    mov bx, [tp_srclen]
+.fwd:
+    or cx, cx
+    jz .set
+    cmp si, bx
+    jae .set
+    mov al, [es:si]
+    cmp al, 10
+    je .set
+    cmp al, 13
+    je .set
+    inc si
+    dec cx
+    jmp .fwd
+.set:
+    mov [tp_cur], si
+.o:
+    pop es
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_down:
+    push ax
+    push bx
+    push cx
+    push si
+    push es
+    call tp_cur_lc
+    mov [tp_wantcol], bx
+    mov es, [tp_srcseg]
+    mov si, [tp_cur]
+    mov bx, [tp_srclen]
+.sk:
+    cmp si, bx
+    jae .o
+    mov al, [es:si]
+    inc si
+    cmp al, 10
+    je .at
+    cmp al, 13
+    jne .sk
+    cmp si, bx
+    jae .at
+    cmp byte [es:si], 10
+    jne .at
+    inc si
+.at:
+    mov cx, [tp_wantcol]
+.fwd:
+    or cx, cx
+    jz .set
+    cmp si, bx
+    jae .set
+    mov al, [es:si]
+    cmp al, 10
+    je .set
+    cmp al, 13
+    je .set
+    inc si
+    dec cx
+    jmp .fwd
+.set:
+    mov [tp_cur], si
+.o:
+    pop es
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_home:
+    call tp_sol
+    mov [tp_cur], si
+    mov word [tp_wantcol], 0
+    ret
+
+tp_end:
+    push ax
+    push bx
+    push si
+    push es
+    call tp_sol
+    mov es, [tp_srcseg]
+    mov bx, [tp_srclen]
+.lp:
+    cmp si, bx
+    jae .s
+    mov al, [es:si]
+    cmp al, 10
+    je .s
+    cmp al, 13
+    je .s
+    inc si
+    jmp .lp
+.s:
+    mov [tp_cur], si
+    mov word [tp_wantcol], 255
+    pop es
+    pop si
+    pop bx
+    pop ax
+    ret
+
+tp_clamp_vs:
+    push ax
+    push bx
+    call tp_count_lines
+    mov bx, [tp_erows]
+    or bx, bx
+    jnz .e
+    mov bx, 8
+.e:
+    sub ax, bx
+    jnc .ok
+    xor ax, ax
+.ok:
+    cmp [tp_vscroll], ax
+    jbe .o
+    mov [tp_vscroll], ax
+.o:
+    pop bx
+    pop ax
+    ret
+
+tp_pgup:
+    mov ax, [tp_erows]
+    or ax, ax
+    jnz .s
+    mov ax, 8
+.s:
+    sub [tp_vscroll], ax
+    jnc .g
+    mov word [tp_vscroll], 0
+.g:
+    call tp_clamp_vs
+    call tp_cur_lc
+    mov ax, [tp_vscroll]
+    call tp_goto_lc
+    ret
+
+tp_pgdn:
+    mov ax, [tp_erows]
+    or ax, ax
+    jnz .s
+    mov ax, 8
+.s:
+    add [tp_vscroll], ax
+    call tp_clamp_vs
+    call tp_cur_lc
+    mov ax, [tp_vscroll]
+    add ax, [tp_erows]
+    dec ax
+    jns .g
+    xor ax, ax
+.g:
+    call tp_goto_lc
+    ret
+
+tp_draw_ssb:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov ax, [tp_r_ssb]
+    mov bx, [tp_r_ssb+2]
+    mov cx, [tp_r_ssb+4]
+    mov dx, [tp_r_ssb+6]
+    cmp cx, ax
+    jbe .o
+    cmp dx, bx
+    jbe .o
+    mov al, CLGRAY
+    call OSAPI_SET_COLOR
+    mov ax, [tp_r_ssb]
+    mov bx, [tp_r_ssb+2]
+    mov cx, [tp_r_ssb+4]
+    mov dx, [tp_r_ssb+6]
+    call OSAPI_GFX_FILL
+    call tp_count_lines
+    mov si, ax                  ; lines
+    mov bx, [tp_erows]
+    or bx, bx
+    jnz .er
+    mov bx, 8
+.er:
+    cmp si, bx
+    jbe .o
+    mov ax, [tp_r_ssb+6]
+    sub ax, [tp_r_ssb+2]
+    sub ax, 4
+    cmp ax, 8
+    jl .o
+    ; thumb_h = erows * track / lines, min 8
+    push ax
+    mul bx
+    xor dx, dx
+    div si
+    cmp ax, 8
+    jae .th
+    mov ax, 8
+.th:
+    pop dx                      ; track
+    cmp ax, dx
+    jbe .th2
+    mov ax, dx
+.th2:
+    mov cx, ax                  ; thumb_h
+    sub dx, cx                  ; slack
+    mov ax, si
+    sub ax, bx                  ; max scroll
+    or ax, ax
+    jz .top
+    push cx
+    mov cx, ax
+    mov ax, [tp_vscroll]
+    mul dx
+    xor dx, dx
+    div cx
+    pop cx
+    jmp .got
+.top:
+    xor ax, ax
+.got:
+    add ax, [tp_r_ssb+2]
+    add ax, 2
+    mov bx, ax
+    add ax, cx
+    dec ax
+    mov dx, ax
+    mov ax, [tp_r_ssb]
+    inc ax
+    mov cx, [tp_r_ssb+4]
+    dec cx
+    cmp dx, bx
+    jae .okt
+    mov dx, bx
+.okt:
+    push ax
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_FILL
+    push ax
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_FRAME
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AX = distinct body lines on the current typeset page.
+tp_page_nlines:
+    push bx
+    push cx
+    push dx
+    push si
+    xor ax, ax
+    mov dx, 0xFFFF
+    xor si, si
+.lp:
+    cmp si, [tp_nruns]
+    jae .o
+    push ax
+    mov ax, si
+    mov cx, TP_RUN_SZ
+    mul cx
+    mov bx, ax
+    add bx, tp_runs
+    pop ax
+    mov cl, [bx]
+    xor ch, ch
+    cmp cx, [tp_ppage]
+    jne .n
+    cmp word [bx+4], 48
+    jb .n
+    mov cx, [bx+4]
+    cmp cx, dx
+    je .n
+    mov dx, cx
+    inc ax
+.n:
+    inc si
+    jmp .lp
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+tp_draw_psb:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov ax, [tp_r_psb]
+    mov bx, [tp_r_psb+2]
+    mov cx, [tp_r_psb+4]
+    mov dx, [tp_r_psb+6]
+    cmp cx, ax
+    jbe .o
+    cmp dx, bx
+    jbe .o
+    mov al, CLGRAY
+    call OSAPI_SET_COLOR
+    mov ax, [tp_r_psb]
+    mov bx, [tp_r_psb+2]
+    mov cx, [tp_r_psb+4]
+    mov dx, [tp_r_psb+6]
+    call OSAPI_GFX_FILL
+    cmp byte [tp_setok], 0
+    je .o
+    ; Scroll the sheet, not packed lines: 8px = body point size.
+    mov si, [tp_sy2]
+    sub si, [tp_sy1]
+    mov bx, [tp_py2]
+    sub bx, [tp_py1]
+    sub bx, 8
+    cmp bx, 16
+    jae .ph
+    mov bx, 16
+.ph:
+    cmp si, bx
+    jbe .o
+    mov ax, [tp_r_psb+6]
+    sub ax, [tp_r_psb+2]
+    sub ax, 4
+    cmp ax, 8
+    jl .o
+    push ax
+    mul bx
+    xor dx, dx
+    div si
+    cmp ax, 8
+    jae .th
+    mov ax, 8
+.th:
+    pop dx
+    cmp ax, dx
+    jbe .th2
+    mov ax, dx
+.th2:
+    mov cx, ax                  ; thumb
+    sub dx, cx                  ; slack
+    mov ax, si
+    sub ax, bx                  ; max pscroll
+    or ax, ax
+    jz .top
+    push cx
+    mov cx, ax
+    mov ax, [tp_pscroll]
+    mul dx
+    xor dx, dx
+    div cx
+    pop cx
+    jmp .got
+.top:
+    xor ax, ax
+.got:
+    add ax, [tp_r_psb+2]
+    add ax, 2
+    mov bx, ax
+    add ax, cx
+    dec ax
+    mov dx, ax
+    mov ax, [tp_r_psb]
+    inc ax
+    mov cx, [tp_r_psb+4]
+    dec cx
+    cmp dx, bx
+    jae .okt
+    mov dx, bx
+.okt:
+    push ax
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_FILL
+    push ax
+    mov al, CBLACK
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_FRAME
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_psb_click:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    cmp byte [tp_setok], 0
+    je .o
+    mov si, [tp_sy2]
+    sub si, [tp_sy1]
+    mov bx, [tp_py2]
+    sub bx, [tp_py1]
+    sub bx, 8
+    cmp si, bx
+    jbe .z
+    sub si, bx                  ; max pscroll
+    mov cx, dx
+    sub cx, [tp_r_psb+2]
+    jns .y
+    xor cx, cx
+.y:
+    mov ax, [tp_r_psb+6]
+    sub ax, [tp_r_psb+2]
+    or ax, ax
+    jz .o
+    xchg ax, si                 ; AX=max SI=track
+    mul cx
+    div si
+    mov [tp_pscroll], ax
+    jmp .o
+.z:
+    mov word [tp_pscroll], 0
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; DX = click y. Set vscroll from track position.
+tp_ssb_click:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    call tp_count_lines
+    mov bx, [tp_erows]
+    or bx, bx
+    jnz .e
+    mov bx, 8
+.e:
+    cmp ax, bx
+    jbe .o
+    sub ax, bx                  ; AX = max vscroll
+    mov cx, dx
+    sub cx, [tp_r_ssb+2]
+    jns .y
+    xor cx, cx
+.y:
+    mov si, [tp_r_ssb+6]
+    sub si, [tp_r_ssb+2]
+    or si, si
+    jz .o
+    mul cx                      ; DX:AX = max * yrel
+    div si                      ; AX = vscroll
+    mov [tp_vscroll], ax
+    call tp_clamp_vs
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_keep_caret:
+    push ax
+    push bx
+    call tp_cur_lc
+    ; AX line BX col
+    cmp ax, [tp_vscroll]
+    jae .dn
+    mov [tp_vscroll], ax
+    jmp .h
+.dn:
+    mov dx, [tp_erows]
+    or dx, dx
+    jnz .er
+    mov dx, 8
+.er:
+    add dx, [tp_vscroll]
+    or dx, dx
+    jz .h
+    dec dx
+    cmp ax, dx
+    jbe .h
+    sub ax, [tp_erows]
+    inc ax
+    jns .sv
+    xor ax, ax
+.sv:
+    mov [tp_vscroll], ax
+.h:
+    call tp_cur_lc
+    cmp bx, [tp_hscroll]
+    jae .hr
+    mov [tp_hscroll], bx
+    jmp .o
+.hr:
+    mov ax, [tp_hscroll]
+    add ax, [tp_ecols]
+    or ax, ax
+    jz .o
+    dec ax
+    cmp bx, ax
+    jbe .o
+    sub bx, [tp_ecols]
+    inc bx
+    jns .sh
+    xor bx, bx
+.sh:
+    mov [tp_hscroll], bx
+.o:
+    call tp_clamp_vs
+    pop bx
+    pop ax
+    ret
+
+tp_retitle:
+    push ax
+    push si
+    push di
+    push es
+    push ds
+    pop es
+    mov di, tp_ttlbuf
+    mov si, tp_s_name
+    call tp_cpat
+    mov al, ' '
+    stosb
+    mov al, '-'
+    stosb
+    mov al, ' '
+    stosb
+    mov si, tp_fname
+    cmp byte [si], 0
+    jne .n
+    mov si, tp_s_noload
+.n:
+    call tp_cpat
+    cmp byte [tp_dirty], 0
+    je .z
+    mov al, '*'
+    stosb
+.z:
+    mov byte [di], 0
+    mov bx, [tp_win]
+    or bx, bx
+    jz .o
+    mov ax, tp_ttlbuf
+    call OSAPI_WM_TITLE
+.o:
+    pop es
+    pop di
+    pop si
+    pop ax
+    ret
+
+tp_toast:
+    push ax
+    push cx
+    push es
+    push ds
+    pop es
+    mov cx, 54
+    call OSAPI_TOAST
+    pop es
+    pop cx
+    pop ax
+    ret
+
+tp_cpat:
+    push ax
+    push ds
+    pop es
+.l:
+    lodsb
+    or al, al
+    jz .d
+    stosb
+    jmp .l
+.d:
+    pop ax
+    ret
+
+; tp_cpat with a ceiling: CX = the most bytes to copy. Out CX = what is left of
+; it, so several of these can fill one buffer between them, and DI stops where
+; the copy stopped. The NUL is the caller's, as with tp_cpat.
+;
+; Every destination here is a fixed bss field and most of the sources are
+; DOCUMENT text, which is as long as whoever wrote the file made it - so a
+; plain tp_cpat into a 48-byte field is a buffer overrun with the length under
+; the file's control. This is what those call sites use instead.
+tp_cpatn:
+    push ax
+.l:
+    jcxz .d
+    lodsb
+    or al, al
+    jz .d
+    stosb
+    dec cx
+    jmp .l
+.d:
+    pop ax
+    ret
+
+tp_u16_di:
+    push ax
+    push bx
+    push cx
+    push dx
+    push ds
+    pop es
+    mov bx, 10
+    xor cx, cx
+    or ax, ax
+    jnz .d
+    mov al, '0'
+    stosb
+    jmp .o
+.d:
+    xor dx, dx
+    div bx
+    push dx
+    inc cx
+    or ax, ax
+    jnz .d
+.p:
+    pop ax
+    add al, '0'
+    stosb
+    loop .p
+.o:
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+    %include "texpad/tpparse.inc"
+    %include "texpad/tpexport.inc"
+
+; -----------------------------------------------------------------------------
+tp_tpl:
+    dw 6, 22, TP_WIN_W, TP_WIN_H
+    dw tp_ttl, tp_paint, tp_onkey, tp_onclick
+
+    OS88_MENUSET tp_menus, tp_s_name, tp_oncmd
+        OS88_MENU tp_m_file, tp_i_file, 6
+        OS88_MENU tp_m_edit, tp_i_edit, 3
+        OS88_MENU tp_m_lay, tp_i_lay, 11
+        OS88_MENU tp_m_page, tp_i_page, 13
+        OS88_MENU tp_m_view, tp_i_view, 5
+    OS88_MENUSET_END tp_menus
+
+tp_s_name:      db 'TeXPad', 0
+tp_m_file:      db 'File', 0
+tp_m_edit:      db 'Edit', 0
+tp_m_lay:       db 'Layout', 0
+tp_m_page:      db 'Page', 0
+tp_m_view:      db 'View', 0
+tp_i_file:      dw tp_it_new, tp_it_open, tp_it_save, tp_it_saveas, tp_it_pdf, tp_it_ps
+tp_i_edit:      dw tp_it_copy, tp_it_paste, tp_it_cut
+tp_i_lay:       dw tp_it_art, tp_it_book, tp_it_mn, tp_it_m1, tp_it_mw
+                dw tp_it_pc, tp_it_pn, tp_it_pl
+                dw tp_it_sgl, tp_it_fac, tp_it_opp
+tp_i_page:      dw tp_it_ltr, tp_it_leg, tp_it_a4, tp_it_a5
+                dw tp_it_g0, tp_it_g1, tp_it_g2
+                dw tp_it_uin, tp_it_umm
+                dw tp_it_n0, tp_it_n1, tp_it_n2, tp_it_n3
+tp_i_view:      dw tp_it_set, tp_it_vp, tp_it_vn, tp_it_ws, tp_it_wp
+tp_it_new:      db 'New', 0
+tp_it_open:     db 'Open...', 0
+tp_it_save:     db 'Save', 0
+tp_it_saveas:   db 'Save As...', 0
+tp_it_pdf:      db 'Export PDF...', 0
+tp_it_ps:       db 'Export PS...', 0
+tp_it_copy:     db 'Copy All', 0
+tp_it_paste:    db 'Paste', 0
+tp_it_cut:      db 'Cut Line', 0
+tp_it_art:      db 'Article', 0
+tp_it_book:     db 'Book', 0
+tp_it_mn:       db 'Narrow Margins', 0
+tp_it_m1:       db 'Normal Margins', 0
+tp_it_mw:       db 'Wide Margins', 0
+tp_it_pc:       db 'Compact Padding', 0
+tp_it_pn:       db 'Normal Padding', 0
+tp_it_pl:       db 'Loose Padding', 0
+tp_it_sgl:      db 'Single Pages', 0
+tp_it_fac:      db 'Facing Pages', 0
+tp_it_opp:      db 'Opposing Pages', 0
+tp_it_ltr:      db 'Letter 8.5 x 11 in', 0
+tp_it_leg:      db 'Legal 8.5 x 14 in', 0
+tp_it_a4:       db 'A4 210 x 297 mm', 0
+tp_it_a5:       db 'A5 148 x 210 mm', 0
+tp_it_g0:       db 'Gutter Off', 0
+tp_it_g1:       db 'Gutter Narrow', 0
+tp_it_g2:       db 'Gutter Wide', 0
+tp_it_uin:      db 'Inches', 0
+tp_it_umm:      db 'Millimetres', 0
+tp_it_n0:       db 'Numbers Off', 0
+tp_it_n1:       db 'Numbers Bottom Center', 0
+tp_it_n2:       db 'Numbers Header', 0
+tp_it_n3:       db 'Numbers Outer', 0
+tp_it_set:      db 'Typeset', 0
+tp_it_vp:       db 'Prev Page', 0
+tp_it_vn:       db 'Next Page', 0
+tp_it_ws:       db 'Wider Source', 0
+tp_it_wp:       db 'Wider Preview', 0
+
+tp_ttl:         db 'TeXPad', 0
+tp_s_hello:     db 'HELLO.TEX', 0
+tp_s_paper:     db 'PAPER.TEX', 0
+tp_s_untitled:  db 'UNTITLED.TEX', 0
+tp_s_noload:    db '(new)', 0
+tp_s_set:       db 'Set', 0
+tp_s_ltr:       db 'Ltr', 0
+tp_s_leg:       db 'Leg', 0
+tp_s_a4s:       db 'A4', 0
+tp_s_a5s:       db 'A5', 0
+tp_s_sgl:       db '1pg', 0
+tp_s_fac:       db 'Fac', 0
+tp_s_opp:       db 'Opp', 0
+tp_s_g0:        db 'G0', 0
+tp_s_g1:        db 'G+', 0
+tp_s_g2:        db 'G++', 0
+tp_s_pc:        db 'Pad-', 0
+tp_s_pn:        db 'Pad', 0
+tp_s_pl:        db 'Pad+', 0
+tp_s_lt:        db '<', 0
+tp_s_gt:        db '>', 0
+tp_s_stale:     db '(edit)', 0
+tp_s_letter:    db 'Letter', 0
+tp_s_legal:     db 'Legal', 0
+tp_s_pt:        db 'pt', 0
+tp_s_u075:      db '.75in', 0
+tp_s_u10:       db '1in', 0
+tp_s_u15:       db '1.5in', 0
+tp_s_m19:       db '19mm', 0
+tp_s_m25:       db '25mm', 0
+tp_s_m38:       db '38mm', 0
+tp_s_gi0:       db 'G0', 0
+tp_s_gi1:       db 'G.25in', 0
+tp_s_gi2:       db 'G.5in', 0
+tp_s_gm0:       db 'G0', 0
+tp_s_gm1:       db 'G6mm', 0
+tp_s_gm2:       db 'G13mm', 0
+tp_s_n0:        db 'No#', 0
+tp_s_n1:        db 'Ft', 0
+tp_s_n2:        db 'Hd', 0
+tp_s_n3:        db 'Out', 0
+tp_s_noset:     db 'F5 typesets the preview', 0
+tp_s_loaded:    db 'Loaded', 0
+tp_s_saved:     db 'Saved', 0
+tp_s_copied:    db 'Copied', 0
+tp_s_err:       db 'Read error - new document', 0
+tp_s_werr:      db 'Write error', 0
+tp_s_nomem:     db 'Need more RAM', 0
+tp_s_full:      db 'Document full (8K)', 0
+tp_s_xok:       db 'Exported', 0
+tp_s_xerr:      db 'Export failed', 0
+tp_s_xbig:      db 'Export too large', 0
+; The About card, in the shape apps/paint and apps/modplug use it: what the
+; program is, who contributed it, and one honest line about what is NOT in
+; here. A reader who has met TeX should not be left thinking this is TeX.
+tp_s_a1:        db 'TeXPad for os8088', 0
+tp_s_a2:        db 'a TeX pad for the 8086', 0
+tp_s_a3:        db 0
+tp_s_a4:        db 'contributed by Jason Page', 0
+tp_s_a5:        db 'amfile.org', 0
+tp_s_a6:        db 0
+tp_s_a7:        db 'A paper-oriented SUBSET of the markup, set in', 0
+tp_s_a8:        db 'the kernel 8x8 monofont. No math engine, no', 0
+tp_s_a9:        db 'figures, no colour - see SPEC.md 66.2.', 0
+tp_s_a10:       db 0
+tp_s_a11:       db 'F5 typesets.  File exports PDF 1.4 and PostScript.', 0
+
+tp_seed_s:
+    db '\documentclass[letterpaper,12pt]{article}', 10
+    db '\title{Untitled}', 10
+    db '\author{}', 10
+    db '\date{}', 10
+    db '\begin{document}', 10
+    db '\maketitle', 10
+    db '\section{Introduction}', 10
+    db 10
+    db 'Type on the left. F5 typesets the preview.', 10
+    db 10
+    db '\end{document}', 10
+    db 0
+
+    %include "os88ui.inc"
+
+TP_BSS_TOTAL equ 12288
+    OS88_BSS TP_BSS_TOTAL
+    OS88_IMAGE_END
+
+; ---- bss --------------------------------------------------------------------
+tp_win      equ os88_image_end + 0
+tp_ox       equ os88_image_end + 2
+tp_oy       equ os88_image_end + 4
+tp_cw       equ os88_image_end + 6
+tp_ch       equ os88_image_end + 8
+tp_srcseg   equ os88_image_end + 10
+tp_srclen   equ os88_image_end + 12
+tp_expseg   equ os88_image_end + 14
+tp_explen   equ os88_image_end + 16
+tp_dir      equ os88_image_end + 18
+tp_drv      equ os88_image_end + 20
+tp_cur      equ os88_image_end + 22
+tp_wantcol  equ os88_image_end + 24
+tp_vscroll  equ os88_image_end + 26
+tp_hscroll  equ os88_image_end + 28
+tp_pscroll  equ os88_image_end + 30
+tp_ppage    equ os88_image_end + 32
+tp_npages   equ os88_image_end + 34
+tp_split    equ os88_image_end + 36
+tp_focus    equ os88_image_end + 38
+tp_dirty    equ os88_image_end + 39
+tp_needset  equ os88_image_end + 40
+tp_setok    equ os88_image_end + 41
+tp_needld   equ os88_image_end + 42
+tp_abouton  equ os88_image_end + 43
+tp_dlgmode  equ os88_image_end + 44
+tp_class    equ os88_image_end + 45
+tp_margin   equ os88_image_end + 46
+tp_pad      equ os88_image_end + 47
+tp_pstyle   equ os88_image_end + 48
+tp_fsize    equ os88_image_end + 49
+tp_ex1      equ os88_image_end + 50
+tp_ey1      equ os88_image_end + 52
+tp_ex2      equ os88_image_end + 54
+tp_ey2      equ os88_image_end + 56
+tp_px1      equ os88_image_end + 58
+tp_py1      equ os88_image_end + 60
+tp_px2      equ os88_image_end + 62
+tp_py2      equ os88_image_end + 64
+tp_erows    equ os88_image_end + 66
+tp_ecols    equ os88_image_end + 68
+tp_tline    equ os88_image_end + 70
+tp_cxp      equ os88_image_end + 72
+tp_cyp      equ os88_image_end + 74
+tp_tmp      equ os88_image_end + 76
+tp_tmp2     equ os88_image_end + 78
+tp_tmp3     equ os88_image_end + 80
+tp_tmp4     equ os88_image_end + 82
+tp_tmp5     equ os88_image_end + 84
+; typesetter
+tp_page     equ os88_image_end + 86
+tp_x        equ os88_image_end + 88
+tp_y        equ os88_image_end + 90
+tp_left     equ os88_image_end + 92
+tp_right    equ os88_image_end + 94
+tp_tleft    equ os88_image_end + 96
+tp_ttop     equ os88_image_end + 98
+tp_tbot     equ os88_image_end + 100
+tp_tlead    equ os88_image_end + 102
+tp_tsize    equ os88_image_end + 104
+tp_indent   equ os88_image_end + 106
+tp_inpara   equ os88_image_end + 108
+tp_needind  equ os88_image_end + 109
+tp_bold     equ os88_image_end + 110
+tp_under    equ os88_image_end + 111
+tp_align    equ os88_image_end + 112
+tp_csize    equ os88_image_end + 113
+tp_parind   equ os88_image_end + 114
+tp_parskip  equ os88_image_end + 116
+tp_tabsep   equ os88_image_end + 118
+tp_stretch  equ os88_image_end + 120
+tp_tw       equ os88_image_end + 122
+tp_chno     equ os88_image_end + 124
+tp_secno    equ os88_image_end + 126
+tp_subno    equ os88_image_end + 128
+tp_itemn    equ os88_image_end + 130
+tp_made     equ os88_image_end + 132
+tp_nruns    equ os88_image_end + 134
+tp_nboxes   equ os88_image_end + 136
+tp_tused    equ os88_image_end + 138
+tp_si       equ os88_image_end + 140
+tp_se       equ os88_image_end + 142
+tp_sty_n    equ os88_image_end + 144
+tp_env_n    equ os88_image_end + 145
+tp_clen     equ os88_image_end + 146
+tp_pw       equ os88_image_end + 148
+tp_ph       equ os88_image_end + 150
+tp_cmdn     equ os88_image_end + 152
+tp_argn     equ os88_image_end + 154
+tp_exp_i    equ os88_image_end + 156
+tp_nobj     equ os88_image_end + 158
+tp_xkind    equ os88_image_end + 160
+tp_fname    equ os88_image_end + 162          ; 14
+tp_dlgname  equ os88_image_end + 176          ; 14
+tp_ttlbuf   equ os88_image_end + 190          ; 32
+tp_status   equ os88_image_end + 222          ; 80
+tp_nbuf     equ os88_image_end + 302          ; 48
+tp_cmd      equ os88_image_end + 350          ; 32
+tp_arg      equ os88_image_end + 382          ; 182
+tp_wbuf     equ os88_image_end + 564          ; 82
+tp_linebuf  equ os88_image_end + 646          ; 150
+tp_cline    equ os88_image_end + 796          ; 122
+tp_title    equ os88_image_end + 918          ; 80
+tp_author   equ os88_image_end + 998          ; 80
+tp_date     equ os88_image_end + 1078         ; 40
+tp_sty      equ os88_image_end + 1118         ; 32
+tp_env      equ os88_image_end + 1150         ; 24
+tp_envsv    equ os88_image_end + 1174         ; 36
+tp_colw     equ os88_image_end + 1210         ; 12
+tp_colk     equ os88_image_end + 1222         ; 6
+tp_colbar   equ os88_image_end + 1228         ; 8
+tp_objoff   equ os88_image_end + 1236         ; 80
+tp_r_set    equ os88_image_end + 1316
+tp_r_cls    equ os88_image_end + 1324
+tp_r_mar    equ os88_image_end + 1332
+tp_r_pad    equ os88_image_end + 1340
+tp_r_prev   equ os88_image_end + 1348
+tp_r_next   equ os88_image_end + 1356
+tp_runs     equ os88_image_end + 1364         ; 4800
+tp_boxes    equ os88_image_end + 6164         ; 640
+tp_text     equ os88_image_end + 6804         ; 5120  -> 11924
+tp_rx       equ os88_image_end + 11924
+tp_ry       equ os88_image_end + 11926
+tp_fs_ret   equ os88_image_end + 11928
+tp_fs_need  equ os88_image_end + 11930
+tp_needttl  equ os88_image_end + 11932
+tp_scanat   equ os88_image_end + 11934
+tp_budget   equ os88_image_end + 11936
+tp_psize    equ os88_image_end + 11938   ; 0 Letter 1 Legal 2 A4 3 A5
+tp_bind     equ os88_image_end + 11939   ; 0 single 1 facing 2 opposing
+tp_gutter   equ os88_image_end + 11940   ; 0 off 1 18pt 2 36pt
+tp_units    equ os88_image_end + 11941   ; 0 in 1 mm
+tp_r_gut    equ os88_image_end + 11942   ; 8
+tp_sx1      equ os88_image_end + 11950
+tp_sy1      equ os88_image_end + 11952
+tp_sx2      equ os88_image_end + 11954
+tp_sy2      equ os88_image_end + 11956
+tp_tx1      equ os88_image_end + 11958
+tp_ty1      equ os88_image_end + 11960
+tp_tx2      equ os88_image_end + 11962
+tp_ty2      equ os88_image_end + 11964
+tp_r_ssb    equ os88_image_end + 11966   ; 8
+tp_onpage   equ os88_image_end + 11974
+tp_r_psb    equ os88_image_end + 11976   ; 8
+tp_tabtop   equ os88_image_end + 11984
+tp_tabbot   equ os88_image_end + 11986
+tp_tabw     equ os88_image_end + 11988
+tp_tabn     equ os88_image_end + 11990
+tp_rowh     equ os88_image_end + 11992
+tp_ldfull   equ os88_image_end + 11994   ; a deferred load landed: the next
+                                         ; handler owes a FULL repaint, not a
+                                         ; source-pane one (tp_deferred_ld)
+; remainder to 12288. Every name above is a hand-computed offset and nothing
+; checks them against each other, so a new field goes at the END and a field
+; that grows moves everything under it - the assertion below is the only
+; automatic part, and it catches overflowing the block, not overlapping inside
+; it. TP_BSS_LAST is the high-water mark; keep it pointing at the last field.
+TP_BSS_LAST equ 11994 + 1
+%if TP_BSS_LAST > TP_BSS_TOTAL
+    %error "texpad bss map overflows OS88_BSS"
+%endif

--- a/apps/texpad/tpexport.inc
+++ b/apps/texpad/tpexport.inc
@@ -1,0 +1,988 @@
+; =============================================================================
+; tpexport.inc - PDF 1.4 and PostScript Level 1 writers
+;
+; PDF 1.4, classic xref (no 1.5 object/xref streams). Uncompressed content
+; streams, and Courier: what os8088 measured is an 8x8 monospaced cell, so a
+; monospaced face is the only one that can render it back (SPEC.md 66.2).
+; The whole file is built in the export claim and written in ONE call.
+; =============================================================================
+
+tp_claim_exp:
+    cmp word [tp_expseg], 0
+    jne .ok
+    mov ax, TP_EXP_KB
+    call OSAPI_MEM_CLAIM
+    jc .bad
+    mov [tp_expseg], dx
+.ok:
+    mov word [tp_explen], 0
+    clc
+    ret
+.bad:
+    stc
+    ret
+
+; SI = 8.3 name
+tp_export_pdf:
+    mov byte [tp_xkind], 0
+    call tp_typeset
+    call tp_export_do
+    ret
+
+tp_export_ps:
+    mov byte [tp_xkind], 1
+    call tp_typeset
+    call tp_export_do
+    ret
+
+tp_export_do:
+    ; SI = name
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov di, tp_xname
+    call tp_cpat
+    mov byte [di], 0
+    call tp_claim_exp
+    jc .nomem
+    cmp byte [tp_xkind], 0
+    jne .ps
+    call tp_write_pdf
+    jmp .chk
+.ps:
+    call tp_write_ps
+.chk:
+    jc .fail
+    cmp word [tp_explen], 0
+    je .fail
+    ; tp_xw_al DROPS bytes once the claim is full rather than growing past it,
+    ; so a saturated buffer is a document that did not fit - the xref offsets
+    ; and the stream lengths in it point at bytes that were never written. Say
+    ; so; writing it out gives a file a reader opens and reports as corrupt,
+    ; which reads as a bug in the exporter rather than as a document too big.
+    cmp word [tp_explen], TP_EXP_MAX
+    jae .toobig
+    mov es, [tp_expseg]
+    xor bx, bx
+    mov cx, [tp_explen]
+    xor dx, dx
+    mov si, tp_xname
+    call OSAPI_FILE_WRITE
+    jc .fail
+    mov si, tp_s_xok
+    call tp_toast
+    jmp .out
+.nomem:
+    mov si, tp_s_nomem
+    call tp_toast
+    jmp .out
+.toobig:
+    mov si, tp_s_xbig
+    call tp_toast
+    jmp .out
+.fail:
+    mov si, tp_s_xerr
+    call tp_toast
+.out:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; patch the public wrappers to use tp_export_do
+; (tp_export_pdf / ps already call tp_export - redirect)
+
+; ---- buffer writes (ES = expseg) -------------------------------------------
+tp_xw_al:
+    push di
+    push es
+    mov es, [tp_expseg]
+    mov di, [tp_explen]
+    cmp di, TP_EXP_MAX
+    jae .o
+    mov [es:di], al
+    inc word [tp_explen]
+.o:
+    pop es
+    pop di
+    ret
+
+tp_xw_str:
+    ; DS:SI NUL
+    push ax
+    push si
+.lp:
+    lodsb
+    or al, al
+    jz .o
+    call tp_xw_al
+    jmp .lp
+.o:
+    pop si
+    pop ax
+    ret
+
+tp_xw_num:
+    ; AX unsigned
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov bx, 10
+    xor cx, cx
+    or ax, ax
+    jnz .d
+    mov al, '0'
+    call tp_xw_al
+    jmp .o
+.d:
+    xor dx, dx
+    div bx
+    push dx
+    inc cx
+    or ax, ax
+    jnz .d
+.p:
+    pop ax
+    add al, '0'
+    call tp_xw_al
+    loop .p
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_xw_cr:
+    push ax
+    mov al, 10
+    call tp_xw_al
+    pop ax
+    ret
+
+; write (escaped) string from DS:SI
+tp_xw_esc:
+    push ax
+    push si
+    mov al, '('
+    call tp_xw_al
+.lp:
+    lodsb
+    or al, al
+    jz .z
+    cmp al, '('
+    je .bs
+    cmp al, ')'
+    je .bs
+    cmp al, '\'
+    je .bs
+    cmp al, 32
+    jb .oct
+    cmp al, 126
+    ja .oct
+    call tp_xw_al
+    jmp .lp
+.bs:
+    push ax
+    mov al, '\'
+    call tp_xw_al
+    pop ax
+    call tp_xw_al
+    jmp .lp
+.oct:
+    push ax
+    mov al, '\'
+    call tp_xw_al
+    pop ax
+    ; 3 octal digits
+    push ax
+    push cx
+    xor ah, ah
+    mov cl, 6
+    shr al, cl
+    and al, 7
+    add al, '0'
+    call tp_xw_al
+    pop cx
+    pop ax
+    push ax
+    push cx
+    xor ah, ah
+    mov cl, 3
+    shr al, cl
+    and al, 7
+    add al, '0'
+    call tp_xw_al
+    pop cx
+    pop ax
+    and al, 7
+    add al, '0'
+    call tp_xw_al
+    jmp .lp
+.z:
+    mov al, ')'
+    call tp_xw_al
+    pop si
+    pop ax
+    ret
+
+tp_mark_obj:
+    ; AX = obj number 1-based. store offset. AX preserved.
+    push ax
+    push bx
+    dec ax
+    shl ax, 1
+    mov bx, ax
+    mov ax, [tp_explen]
+    mov [tp_objoff+bx], ax
+    pop bx
+    pop ax
+    ret
+
+tp_write_pdf:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov word [tp_explen], 0
+    mov si, tp_pdf_magic
+    call tp_xw_str
+    ; obj 1 catalog
+    mov ax, 1
+    call tp_mark_obj
+    mov si, tp_pdf_cat
+    call tp_xw_str
+    ; obj 2 pages
+    mov ax, 2
+    call tp_mark_obj
+    mov si, tp_pdf_pg0
+    call tp_xw_str
+    mov ax, [tp_npages]
+    or ax, ax
+    jnz .np
+    inc ax
+.np:
+    mov [tp_tmp], ax            ; n
+    ; kids: page object = 5 + bx*2 (1 cat, 2 pages, 3 font, 4 info)
+    xor bx, bx
+.kd:
+    cmp bx, [tp_tmp]
+    jae .kdz
+    mov ax, bx
+    shl ax, 1
+    add ax, 5
+    call tp_xw_num
+    mov si, tp_pdf_ref
+    call tp_xw_str
+    inc bx
+    jmp .kd
+.kdz:
+    mov si, tp_pdf_pg1
+    call tp_xw_str
+    mov ax, [tp_tmp]
+    call tp_xw_num
+    mov si, tp_pdf_pg2
+    call tp_xw_str
+    ; obj 3 font
+    mov ax, 3
+    call tp_mark_obj
+    mov si, tp_pdf_font
+    call tp_xw_str
+    ; obj 4 document info
+    mov ax, 4
+    call tp_mark_obj
+    mov si, tp_pdf_info
+    call tp_xw_str
+    ; pages + contents
+    xor bx, bx
+.pg:
+    cmp bx, [tp_tmp]
+    jae .xref
+    ; page object
+    mov ax, bx
+    shl ax, 1
+    add ax, 5
+    call tp_mark_obj
+    call tp_xw_num
+    mov si, tp_pdf_pobj
+    call tp_xw_str
+    mov ax, [tp_pw]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [tp_ph]
+    call tp_xw_num
+    mov si, tp_pdf_mbox
+    call tp_xw_str
+    ; contents id
+    mov ax, bx
+    shl ax, 1
+    add ax, 6
+    call tp_xw_num
+    mov si, tp_pdf_pobj2
+    call tp_xw_str
+    ; contents: build length first into a side pass
+    ; write a dummy length then... we build stream in scratch then emit
+    call tp_pdf_page_stream     ; uses BX = page, result in explen growth
+    inc bx
+    jmp .pg
+.xref:
+    mov ax, [tp_explen]
+    mov [tp_tmp2], ax           ; xref offset
+    mov si, tp_pdf_xref
+    call tp_xw_str
+    ; real objs: 4 + 2*npages (catalog, pages, font, info, page+contents)
+    mov ax, [tp_tmp]
+    shl ax, 1
+    add ax, 4
+    mov [tp_nobj], ax
+    inc ax                      ; including object 0
+    call tp_xw_num
+    call tp_xw_cr
+    mov si, tp_pdf_free
+    call tp_xw_str
+    xor bx, bx
+.xo:
+    cmp bx, [tp_nobj]
+    jae .tr
+    shl bx, 1
+    mov ax, [tp_objoff+bx]
+    shr bx, 1
+    call tp_pdf_off10
+    mov si, tp_pdf_n
+    call tp_xw_str
+    inc bx
+    jmp .xo
+.tr:
+    mov si, tp_pdf_trl
+    call tp_xw_str
+    mov ax, [tp_nobj]
+    inc ax
+    call tp_xw_num
+    mov si, tp_pdf_trl2
+    call tp_xw_str
+    mov ax, [tp_tmp2]
+    call tp_xw_num
+    mov si, tp_pdf_eof
+    call tp_xw_str
+    clc
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_pdf_zeros:   db '00000', 0
+
+; AX = value, patch 5 digits at tp_tmp3 in the export buffer.
+;
+; This is the ONE write into the export claim that does not go through
+; tp_xw_al, so it is the one that has to bound itself. tp_xw_al saturates
+; [tp_explen] at TP_EXP_MAX rather than growing past it, so on a document big
+; enough to fill 24KB the five zeros this comes back to overwrite were never
+; written - and patching them anyway puts five bytes past the end of the claim,
+; into whatever the heap handed out next (SPEC.md 50.3). Refuse instead: the
+; caller turns a truncated export into an error rather than a bad PDF.
+tp_pdf_patch5:
+    push ax
+    push bx
+    push cx
+    push dx
+    push di
+    push es
+    mov di, [tp_tmp3]
+    add di, 4
+    cmp di, TP_EXP_MAX
+    jae .o
+    mov es, [tp_expseg]
+    mov bx, 10
+    mov cx, 5
+.d:
+    xor dx, dx
+    div bx
+    add dl, '0'
+    mov [es:di], dl
+    dec di
+    loop .d
+.o:
+    pop es
+    pop di
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_pdf_off10:
+    ; write AX as 10-digit
+    push ax
+    push bx
+    push cx
+    push dx
+    mov bx, 10
+    mov cx, 10
+    xor dx, dx
+    ; push 10 digits
+    mov cx, 10
+.d:
+    xor dx, dx
+    div bx
+    push dx
+    loop .d
+    mov cx, 10
+.p:
+    pop ax
+    add al, '0'
+    call tp_xw_al
+    loop .p
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; BX = page index. write contents object 6+2*bx
+tp_pdf_page_stream:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    ; mark contents obj
+    mov ax, bx
+    shl ax, 1
+    add ax, 6
+    push ax
+    call tp_mark_obj
+    call tp_xw_num
+    mov si, tp_pdf_st0
+    call tp_xw_str
+    mov ax, [tp_explen]
+    mov [tp_tmp3], ax           ; offset of length digits
+    mov si, tp_pdf_zeros
+    call tp_xw_str
+    mov si, tp_pdf_st1
+    call tp_xw_str
+    mov ax, [tp_explen]
+    mov [tp_tmp2], ax           ; stream start
+    call tp_pdf_stream_body
+    mov ax, [tp_explen]
+    sub ax, [tp_tmp2]
+    call tp_pdf_patch5
+    mov si, tp_pdf_st2
+    call tp_xw_str
+    pop ax
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_pdf_stream_body:
+    ; page BX
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov si, tp_pdf_bt
+    call tp_xw_str
+    mov si, tp_pdf_tf
+    call tp_xw_str
+    mov byte [tp_tmp5], 12      ; last size
+    xor cx, cx
+.r:
+    cmp cx, [tp_nruns]
+    jae .et
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov al, [si]
+    xor ah, ah
+    cmp ax, bx
+    jne .rn
+    mov al, [si+6]
+    cmp al, [tp_tmp5]
+    je .tm
+    mov [tp_tmp5], al
+    mov si, tp_pdf_f1
+    call tp_xw_str
+    mov al, [tp_tmp5]
+    xor ah, ah
+    call tp_xw_num
+    mov si, tp_pdf_tf2
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+.tm:
+    mov al, '1'
+    call tp_xw_al
+    mov al, ' '
+    call tp_xw_al
+    mov al, '0'
+    call tp_xw_al
+    mov al, ' '
+    call tp_xw_al
+    mov al, '0'
+    call tp_xw_al
+    mov al, ' '
+    call tp_xw_al
+    mov al, '1'
+    call tp_xw_al
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+2]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    call tp_xw_num
+    mov si, tp_pdf_tm
+    call tp_xw_str
+    ; text
+    push si
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov di, [si+8]
+    add di, tp_text
+    push cx
+    xor ch, ch
+    mov cl, [si+7]
+    call tp_xw_esc_n
+    pop cx
+    pop si
+    mov si, tp_pdf_tj
+    call tp_xw_str
+    ; bold overprint
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    test byte [si+1], 1
+    jz .un
+    mov ax, [si+2]
+    inc ax
+    push ax
+    mov al, '1'
+    call tp_xw_al
+    mov si, tp_pdf_tm1
+    call tp_xw_str
+    pop ax
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov ax, [si+4]
+    call tp_xw_num
+    mov si, tp_pdf_tm
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov di, [si+8]
+    add di, tp_text
+    push cx
+    xor ch, ch
+    mov cl, [si+7]
+    call tp_xw_esc_n
+    pop cx
+    mov si, tp_pdf_tj
+    call tp_xw_str
+.un:
+    test byte [si+1], 2
+    ; underline is a box; handled in boxes? we draw as line in boxes list
+    ; skip here
+.rn:
+    inc cx
+    jmp .r
+.et:
+    mov si, tp_pdf_et
+    call tp_xw_str
+    ; boxes
+    xor cx, cx
+.b:
+    cmp cx, [tp_nboxes]
+    jae .o
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov al, [si]
+    xor ah, ah
+    cmp ax, bx
+    jne .bn
+    mov ax, [si+2]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+6]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+8]
+    call tp_xw_num
+    mov si, tp_pdf_re
+    call tp_xw_str
+.bn:
+    inc cx
+    jmp .b
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; DI = bytes, CL = len (CH may be trash)
+tp_xw_esc_n:
+    push ax
+    push cx
+    push si
+    mov al, '('
+    call tp_xw_al
+    xor ch, ch
+    jcxz .z
+    mov si, di
+.lp:
+    lodsb
+    cmp al, '('
+    je .bs
+    cmp al, ')'
+    je .bs
+    cmp al, '\'
+    je .bs
+    cmp al, 32
+    jb .dot
+    cmp al, 126
+    ja .dot
+    call tp_xw_al
+    jmp .n
+.bs:
+    push ax
+    mov al, '\'
+    call tp_xw_al
+    pop ax
+    call tp_xw_al
+    jmp .n
+.dot:
+    mov al, '?'
+    call tp_xw_al
+.n:
+    loop .lp
+.z:
+    mov al, ')'
+    call tp_xw_al
+    pop si
+    pop cx
+    pop ax
+    ret
+
+tp_write_ps:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov word [tp_explen], 0
+    mov si, tp_ps_hdr
+    call tp_xw_str
+    mov ax, [tp_pw]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [tp_ph]
+    call tp_xw_num
+    mov si, tp_ps_hdr2
+    call tp_xw_str
+    mov ax, [tp_npages]
+    or ax, ax
+    jnz .n
+    inc ax
+.n:
+    call tp_xw_num
+    call tp_xw_cr
+    mov si, tp_ps_endc
+    call tp_xw_str
+    xor bx, bx
+.pg:
+    cmp bx, [tp_npages]
+    jae .eof
+    cmp word [tp_npages], 0
+    jne .p1
+    jmp .eof
+.p1:
+    mov si, tp_ps_page
+    call tp_xw_str
+    ; "%%Page: label ordinal", and DSC wants the SAME number twice here. The
+    ; separator has to be pushed around, because `mov al, ' '` leaves AX =
+    ; 0x0020 and the second tp_xw_num then printed the space as the number:
+    ; every page came out "%%Page: N 32".
+    mov ax, bx
+    inc ax
+    call tp_xw_num
+    push ax
+    mov al, ' '
+    call tp_xw_al
+    pop ax
+    call tp_xw_num
+    call tp_xw_cr
+    mov si, tp_ps_font
+    call tp_xw_str
+    mov byte [tp_tmp5], 12      ; ...which is the size now in effect
+    ; runs
+    xor cx, cx
+.r:
+    cmp cx, [tp_nruns]
+    jae .bx
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov al, [si]
+    xor ah, ah
+    cmp ax, bx
+    jne .rn
+    ; Re-select the face only when the SIZE CHANGES, which is what
+    ; tp_pdf_stream_body already does with its own [tp_tmp5] and what this
+    ; did not: "/Courier findfont N scalefont setfont" in front of every run
+    ; is 38 bytes each, and a body of ordinary 12pt text is hundreds of runs
+    ; that all ask for the size already set. PAPER.TEX exported as a 15KB PDF
+    ; and blew the 24KB buffer as PostScript on that alone - and before the
+    ; saturation check in tp_export_do it did so SILENTLY, writing a .PS that
+    ; stops mid-document.
+    mov al, [si+6]
+    cmp al, [tp_tmp5]
+    je .sized
+    mov [tp_tmp5], al
+    mov si, tp_ps_ff
+    call tp_xw_str
+    mov al, [tp_tmp5]
+    xor ah, ah
+    call tp_xw_num
+    mov si, tp_ps_sf
+    call tp_xw_str
+.sized:
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov ax, [si+2]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    call tp_xw_num
+    mov si, tp_ps_mt
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov si, ax
+    add si, tp_runs
+    mov di, [si+8]
+    add di, tp_text
+    push cx
+    xor ch, ch
+    mov cl, [si+7]
+    call tp_xw_esc_n
+    pop cx
+    mov si, tp_ps_sh
+    call tp_xw_str
+.rn:
+    inc cx
+    jmp .r
+.bx:
+    xor cx, cx
+.b:
+    cmp cx, [tp_nboxes]
+    jae .sp
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov al, [si]
+    xor ah, ah
+    cmp ax, bx
+    jne .bn
+    mov si, tp_ps_np
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov ax, [si+2]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    call tp_xw_num
+    mov si, tp_ps_mt
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov ax, [si+2]
+    add ax, [si+6]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    call tp_xw_num
+    mov si, tp_ps_lt
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov ax, [si+2]
+    add ax, [si+6]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    add ax, [si+8]
+    call tp_xw_num
+    mov si, tp_ps_lt
+    call tp_xw_str
+    mov ax, cx
+    mov dx, TP_BOX_SZ
+    mul dx
+    mov si, ax
+    add si, tp_boxes
+    mov ax, [si+2]
+    call tp_xw_num
+    mov al, ' '
+    call tp_xw_al
+    mov ax, [si+4]
+    add ax, [si+8]
+    call tp_xw_num
+    mov si, tp_ps_lt
+    call tp_xw_str
+    mov si, tp_ps_cp
+    call tp_xw_str
+.bn:
+    inc cx
+    jmp .b
+.sp:
+    mov si, tp_ps_sp
+    call tp_xw_str
+    inc bx
+    jmp .pg
+.eof:
+    mov si, tp_ps_eof
+    call tp_xw_str
+    clc
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_xname:       times 14 db 0
+
+tp_pdf_magic:   db '%PDF-1.4', 10, '%', 0xE2, 0xE3, 0xCF, 0xD3, 10, 0
+tp_pdf_cat:     db '1 0 obj', 10
+                db '<< /Type /Catalog /Version /1.4 /Pages 2 0 R '
+                db '/ViewerPreferences << /DisplayDocTitle true >> >>', 10
+                db 'endobj', 10, 0
+tp_pdf_pg0:     db '2 0 obj', 10, '<< /Type /Pages /Kids [ ', 0
+tp_pdf_ref:     db ' 0 R ', 0
+tp_pdf_pg1:     db '] /Count ', 0
+tp_pdf_pg2:     db ' >>', 10, 'endobj', 10, 0
+tp_pdf_font:    db '3 0 obj', 10
+                db '<< /Type /Font /Subtype /Type1 /BaseFont /Courier '
+                db '/Encoding /StandardEncoding >>', 10, 'endobj', 10, 0
+tp_pdf_info:    db '4 0 obj', 10
+                db '<< /Title (TeXPad) /Creator (TeXPad) '
+                db '/Producer (os8088 TeXPad) >>', 10
+                db 'endobj', 10, 0
+tp_pdf_pobj:    db ' 0 obj', 10, '<< /Type /Page /Parent 2 0 R '
+                db '/MediaBox [ 0 0 ', 0
+tp_pdf_mbox:    db ' ] /Contents ', 0
+tp_pdf_pobj2:   db ' 0 R /Resources << /Font << /F1 3 0 R >> >> >>', 10
+                db 'endobj', 10, 0
+tp_pdf_st0:     db ' 0 obj', 10, '<< /Length ', 0
+tp_pdf_st1:     db ' >>', 10, 'stream', 10, 0
+tp_pdf_st2:     db 10, 'endstream', 10, 'endobj', 10, 0
+tp_pdf_xref:    db 'xref', 10, '0 ', 0
+tp_pdf_free:    db '0000000000 65535 f ', 10, 0
+tp_pdf_n:       db ' 00000 n ', 10, 0
+tp_pdf_trl:     db 'trailer', 10, '<< /Size ', 0
+tp_pdf_trl2:    db ' /Root 1 0 R /Info 4 0 R '
+                db '/ID [<54655850616431345465585061643134> '
+                db '<54655850616431345465585061643134>] >>', 10
+                db 'startxref', 10, 0
+tp_pdf_eof:     db 10, '%%EOF', 10, 0
+tp_pdf_bt:      db 'BT', 10, 0
+tp_pdf_tf:      db '/F1 12 Tf', 10, 0
+tp_pdf_f1:      db '/F1 ', 0
+tp_pdf_tf2:     db ' Tf', 10, 0
+tp_pdf_tm:      db ' Tm', 10, 0
+tp_pdf_tm1:     db ' 0 0 1 ', 0
+tp_pdf_tj:      db ' Tj', 10, 0
+tp_pdf_et:      db 'ET', 10, 0
+tp_pdf_re:      db ' re S', 10, 0
+
+tp_ps_hdr:      db '%!PS-Adobe-1.0', 10, '%%Title: TeXPad', 10
+                db '%%Creator: os8088 TeXPad', 10
+                db '%%BoundingBox: 0 0 ', 0
+tp_ps_hdr2:     db 10, '%%Pages: ', 0
+tp_ps_endc:     db '%%EndComments', 10, 0
+tp_ps_page:     db '%%Page: ', 0
+tp_ps_font:     db '/Courier findfont 12 scalefont setfont', 10, 0
+tp_ps_ff:       db '/Courier findfont ', 0
+tp_ps_sf:       db ' scalefont setfont', 10, 0
+tp_ps_mt:       db ' moveto', 10, 0
+tp_ps_sh:       db ' show', 10, 0
+tp_ps_np:       db 'newpath', 10, 0
+tp_ps_lt:       db ' lineto', 10, 0
+tp_ps_cp:       db 'closepath stroke', 10, 0
+tp_ps_sp:       db 'showpage', 10, 0
+tp_ps_eof:      db '%%EOF', 10, 0

--- a/apps/texpad/tpparse.inc
+++ b/apps/texpad/tpparse.inc
@@ -1,0 +1,3293 @@
+; =============================================================================
+; tpparse.inc - TeXPad typesetter (text, sections, tables, Letter, B&W)
+; =============================================================================
+
+tp_typeset:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    call tp_claim_src
+    jc .fail
+    call tp_ts_init
+    call tp_ts_scan
+    call tp_ts_end
+    mov byte [tp_setok], 1
+    mov byte [tp_needset], 0
+    mov word [tp_ppage], 0
+    mov word [tp_pscroll], 0
+    jmp .out
+.fail:
+    mov byte [tp_setok], 0
+.out:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_ts_init:
+    push ax
+    push ds
+    pop es
+    mov word [tp_nruns], 0
+    mov word [tp_nboxes], 0
+    mov word [tp_tused], 0
+    mov word [tp_npages], 1
+    mov word [tp_page], 0
+    call tp_geom
+    mov byte [tp_chno], 0
+    mov byte [tp_secno], 0
+    mov byte [tp_subno], 0
+    mov byte [tp_itemn], 0
+    mov byte [tp_made], 0
+    mov byte [tp_sty_n], 0
+    mov byte [tp_env_n], 0
+    mov byte [tp_clen], 0
+    mov byte [tp_inpara], 0
+    mov byte [tp_needind], 1
+    mov byte [tp_bold], 0
+    mov byte [tp_under], 0
+    mov byte [tp_align], 0
+    mov word [tp_chno], 0
+    mov word [tp_secno], 0
+    mov word [tp_subno], 0
+    mov byte [tp_title], 0
+    mov byte [tp_author], 0
+    mov byte [tp_date], 0
+    mov byte [tp_onpage], 0
+    ; padding
+    mov word [tp_parind], 24
+    mov word [tp_parskip], 6
+    mov word [tp_tlead], 14
+    mov word [tp_tabsep], 6
+    mov word [tp_stretch], 12
+    cmp byte [tp_pad], 0
+    jne .p1
+    mov word [tp_parind], 16
+    mov word [tp_parskip], 0
+    mov word [tp_tlead], 12
+    mov word [tp_tabsep], 3
+    mov word [tp_stretch], 10
+    jmp .fs
+.p1:
+    cmp byte [tp_pad], 2
+    jne .fs
+    mov word [tp_parind], 28
+    mov word [tp_parskip], 10
+    mov word [tp_tlead], 16
+    mov word [tp_tabsep], 8
+    mov word [tp_stretch], 14
+.fs:
+    mov al, [tp_fsize]
+    or al, al
+    jnz .fsok
+    mov al, 12
+.fsok:
+    mov [tp_csize], al
+    mov [tp_tsize], al
+    mov ax, [tp_left]
+    mov [tp_x], ax
+    mov ax, [tp_ttop]
+    mov [tp_y], ax
+    mov word [tp_si], 0
+    mov ax, [tp_srclen]
+    mov [tp_se], ax
+    pop ax
+    ret
+
+tp_ts_end:
+    call tp_flush_c
+    call tp_endpara
+    cmp byte [tp_onpage], 0
+    jne .foot
+    cmp word [tp_npages], 1
+    jbe .foot
+    dec word [tp_npages]
+    dec word [tp_page]
+    ret
+.foot:
+    call tp_footer
+    ret
+
+tp_ts_scan:
+    push ax
+    push bx
+    push cx
+    push si
+    push es
+    mov es, [tp_srcseg]
+    mov ax, [tp_se]
+    add ax, 16
+    mov [tp_budget], ax
+.lp:
+    dec word [tp_budget]
+    jz .done
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .done
+    mov [tp_scanat], si         ; detect a stalled cursor
+    mov al, [es:si]
+    cmp al, '%'
+    je .com
+    cmp al, '\'
+    je .cmd
+    cmp al, '{'
+    je .psh
+    cmp al, '}'
+    je .pop
+    cmp al, 10
+    je .nl
+    cmp al, 13
+    je .nl
+    cmp al, ' '
+    je .sp
+    cmp al, 9
+    je .sp
+    cmp al, '$'
+    je .math
+    cmp al, '~'
+    je .nbsp
+    cmp al, '&'
+    je .amp
+    call tp_ts_word
+    jmp .adv
+.com:
+    call tp_skip_com
+    jmp .adv
+.cmd:
+    call tp_ts_cmd
+    jmp .adv
+.psh:
+    inc word [tp_si]
+    call tp_sty_push
+    jmp .adv
+.pop:
+    inc word [tp_si]
+    call tp_sty_pop
+    jmp .adv
+.nl:
+    call tp_eat_nl
+    cmp al, 2
+    jb .spnl
+    call tp_endpara
+    jmp .adv
+.spnl:
+    call tp_space
+    jmp .adv
+.sp:
+    inc word [tp_si]
+    call tp_space
+    jmp .adv
+.math:
+    inc word [tp_si]
+    jmp .adv
+.nbsp:
+    inc word [tp_si]
+    mov al, ' '
+    mov cx, 1
+    mov si, tp_s_spch
+    mov byte [tp_s_spch], ' '
+    call tp_emit_str
+    jmp .adv
+.amp:
+    inc word [tp_si]
+    mov si, tp_s_amp
+    call tp_emit_csi
+    jmp .adv
+.adv:
+    ; A handler that does not consume the current byte would spin
+    ; forever under the gfx lock and the screen goes black.
+    mov ax, [tp_si]
+    cmp ax, [tp_scanat]
+    jne .lp
+    inc word [tp_si]
+    jmp .lp
+.done:
+    pop es
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_skip_com:
+    push ax
+    push es
+    mov es, [tp_srcseg]
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .o
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, 10
+    je .o
+    cmp al, 13
+    jne .lp
+.o:
+    pop es
+    pop ax
+    ret
+
+; AL = number of newlines consumed (1 or 2+)
+tp_eat_nl:
+    push bx
+    push es
+    mov es, [tp_srcseg]
+    xor bl, bl
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .d
+    mov al, [es:si]
+    cmp al, 13
+    je .cr
+    cmp al, 10
+    je .lf
+    jmp .d
+.cr:
+    inc word [tp_si]
+    inc si
+    cmp si, [tp_se]
+    jae .one
+    cmp byte [es:si], 10
+    jne .one
+    inc word [tp_si]
+.one:
+    inc bl
+    jmp .lp
+.lf:
+    inc word [tp_si]
+    inc bl
+    jmp .lp
+.d:
+    mov al, bl
+    pop es
+    pop bx
+    ret
+
+tp_ts_word:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    mov es, [tp_srcseg]
+    mov di, tp_wbuf
+    xor cx, cx
+    mov si, [tp_si]
+    cmp byte [es:si], '\'
+    jne .notbs
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    jmp tp_ts_cmd
+.notbs:
+    ; dashes / quotes
+    mov al, [es:si]
+    cmp al, '-'
+    jne .q
+    inc si
+    cmp si, [tp_se]
+    jae .ch0
+    cmp byte [es:si], '-'
+    jne .ch0
+    inc si
+    cmp si, [tp_se]
+    jae .em
+    cmp byte [es:si], '-'
+    jne .em
+    inc si
+.em:
+    mov [tp_si], si
+    mov si, tp_s_dash
+    call tp_emit_csi
+    jmp .o
+.q:
+    cmp al, '`'
+    je .qq
+    cmp al, 39
+    jne .coll
+    inc si
+    cmp si, [tp_se]
+    jae .ch0
+    cmp byte [es:si], 39
+    jne .ch0
+    inc si
+    mov [tp_si], si
+    mov al, '"'
+    mov [tp_wbuf], al
+    mov byte [tp_wbuf+1], 0
+    mov si, tp_wbuf
+    call tp_emit_csi
+    jmp .o
+.qq:
+    inc si
+    cmp si, [tp_se]
+    jae .ch0
+    cmp byte [es:si], '`'
+    jne .ch0
+    inc si
+    mov [tp_si], si
+    mov al, '"'
+    mov [tp_wbuf], al
+    mov byte [tp_wbuf+1], 0
+    mov si, tp_wbuf
+    call tp_emit_csi
+    jmp .o
+.ch0:
+    mov si, [tp_si]
+.coll:
+    cmp si, [tp_se]
+    jae .ew
+    mov al, [es:si]
+    call tp_is_wordc
+    jc .ew
+    cmp cx, 70
+    jae .ew
+    mov [di], al
+    inc di
+    inc cx
+    inc si
+    jmp .coll
+.ew:
+    mov [tp_si], si
+    mov byte [di], 0
+    or cx, cx
+    jnz .emitw
+    ; breaker with no word: still consume one byte
+    mov ax, [tp_si]
+    cmp ax, [tp_se]
+    jae .o
+    inc word [tp_si]
+    jmp .o
+.emitw:
+    mov si, tp_wbuf
+    call tp_emit_csi
+.o:
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; CF=1 if AL is a breaker
+tp_is_wordc:
+    cmp al, ' '
+    je .no
+    cmp al, 9
+    je .no
+    cmp al, 10
+    je .no
+    cmp al, 13
+    je .no
+    cmp al, '\'
+    je .no
+    cmp al, '{'
+    je .no
+    cmp al, '}'
+    je .no
+    cmp al, '%'
+    je .no
+    cmp al, '$'
+    je .no
+    cmp al, '&'
+    je .no
+    cmp al, '~'
+    je .no
+    cmp al, '['
+    je .no
+    cmp al, ']'
+    je .no
+    clc
+    ret
+.no:
+    stc
+    ret
+
+; AL = source byte at tp_si. CF=1 at end. Does not advance.
+tp_srcb:
+    push es
+    push si
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .e
+    mov al, [es:si]
+    pop si
+    pop es
+    clc
+    ret
+.e:
+    xor al, al
+    pop si
+    pop es
+    stc
+    ret
+
+tp_ts_cmd:
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+    push es
+    mov es, [tp_srcseg]
+    inc word [tp_si]            ; consume the backslash
+    call tp_srcb
+    jc .o
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    ; \\ is a line break, not two printable slashes
+    cmp al, '\'
+    jne .notnl
+    inc word [tp_si]
+    call tp_nl
+    jmp .o
+.notnl:
+    ; force command-name collect on any ASCII letter
+    cmp al, 'A'
+    jb .one
+    cmp al, 'Z'
+    jbe .word
+    cmp al, 'a'
+    jb .one
+    cmp al, 'z'
+    jbe .word
+.one:
+    inc word [tp_si]
+    cmp al, '\'
+    je .nl
+    cmp al, '%'
+    je .lit
+    cmp al, '&'
+    je .lit
+    cmp al, '$'
+    je .lit
+    cmp al, '#'
+    je .lit
+    cmp al, '_'
+    je .lit
+    cmp al, '{'
+    je .lit
+    cmp al, '}'
+    je .lit
+    cmp al, ' '
+    je .sp
+    cmp al, ','
+    je .sp
+    jmp .o
+.nl:
+    call tp_nl
+    jmp .o
+.sp:
+    call tp_space
+    jmp .o
+.lit:
+    mov [tp_wbuf], al
+    mov byte [tp_wbuf+1], 0
+    mov si, tp_wbuf
+    call tp_emit_csi
+    jmp .o
+.word:
+    mov di, tp_cmd
+    xor cx, cx
+.cl:
+    cmp si, [tp_se]
+    jae .cd
+    mov al, [es:si]
+    cmp al, 'A'
+    jb .cd
+    cmp al, 'Z'
+    jbe .let
+    cmp al, 'a'
+    jb .cd
+    cmp al, 'z'
+    ja .cd
+.let:
+    cmp cx, 24
+    jae .cd
+    mov [di], al
+    inc di
+    inc si
+    inc cx
+    jmp .cl
+.cd:
+    mov [tp_si], si
+    mov byte [di], 0
+    mov [tp_cmdn], cx
+    ; swallow one space
+    cmp si, [tp_se]
+    jae .disp
+    mov al, [es:si]
+    cmp al, ' '
+    je .sw
+    cmp al, 9
+    jne .disp
+.sw:
+    inc word [tp_si]
+.disp:
+    call tp_cmd_disp
+.o:
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_isalpha:
+    cmp al, 'A'
+    jb .no
+    cmp al, 'Z'
+    jbe .yes
+    cmp al, 'a'
+    jb .no
+    cmp al, 'z'
+    jbe .yes
+.no:
+    stc
+    ret
+.yes:
+    clc
+    ret
+
+tp_cmd_disp:
+    push bx
+    push si
+    push di
+    mov bx, tp_cmdtab
+.lp:
+    mov si, [bx]
+    or si, si
+    jz .unk
+    mov di, tp_cmd
+    call tp_streq
+    je .hit
+    add bx, 4
+    jmp .lp
+.hit:
+    mov ax, [bx+2]
+    pop di
+    pop si
+    pop bx
+    push ds
+    pop es
+    call ax
+    ret
+.unk:
+    pop di
+    pop si
+    pop bx
+    call tp_skip_opt
+    call tp_peek
+    cmp al, '{'
+    jne .o
+    call tp_read_group
+.o:
+    ret
+
+; ZF=1 if DS:SI == DS:DI (NUL strings)
+tp_streq:
+    push ax
+    push si
+    push di
+.lp:
+    mov al, [si]
+    cmp al, [di]
+    jne .no
+    inc si
+    inc di
+    or al, al
+    jnz .lp
+    pop di
+    pop si
+    pop ax
+    xor ax, ax
+    ret
+.no:
+    pop di
+    pop si
+    pop ax
+    or al, 1
+    ret
+
+tp_c_nop:
+    ret
+
+tp_c_dclass:
+    call tp_skip_opt_store
+    ; look at tp_arg for 10pt/11pt/12pt
+    mov si, tp_arg
+    mov di, tp_k_10pt
+    call tp_has
+    jne .a11
+    mov byte [tp_fsize], 10
+    mov byte [tp_csize], 10
+    mov byte [tp_tsize], 10
+    mov word [tp_tlead], 12
+    jmp .paper
+.a11:
+    mov si, tp_arg
+    mov di, tp_k_11pt
+    call tp_has
+    jne .paper
+    mov byte [tp_fsize], 11
+    mov byte [tp_csize], 11
+    mov byte [tp_tsize], 11
+    mov word [tp_tlead], 13
+.paper:
+    mov si, tp_arg
+    mov di, tp_k_legal
+    call tp_has
+    jne .a4
+    mov byte [tp_psize], 1
+    jmp .side
+.a4:
+    mov si, tp_arg
+    mov di, tp_k_a4
+    call tp_has
+    jne .a5
+    mov byte [tp_psize], 2
+    jmp .side
+.a5:
+    mov si, tp_arg
+    mov di, tp_k_a5
+    call tp_has
+    jne .ltr
+    mov byte [tp_psize], 3
+    jmp .side
+.ltr:
+    mov si, tp_arg
+    mov di, tp_k_letter
+    call tp_has
+    jne .side
+    mov byte [tp_psize], 0
+.side:
+    mov si, tp_arg
+    mov di, tp_k_twoside
+    call tp_has
+    jne .cls
+    mov byte [tp_bind], 1
+.cls:
+    call tp_read_group
+    mov si, tp_arg
+    mov di, tp_k_book
+    call tp_has
+    jne .geo
+    mov byte [tp_class], 1
+    cmp byte [tp_bind], 2
+    je .geo
+    mov byte [tp_bind], 1
+.geo:
+    call tp_geom
+    ret
+
+tp_c_skipg:
+    call tp_skip_opt
+    call tp_read_group
+    ret
+
+; \title, \author and \date all land in a fixed bss field, and the text going
+; into them is the document's - so each copy carries the field's own ceiling,
+; one short of the size in the bss map at the foot of texpad.asm. tp_date is
+; the one that is actually smaller than a full tp_wbuf.
+TP_TITLE_MAX  equ 79            ; tp_title, 80
+TP_AUTHOR_MAX equ 79            ; tp_author, 80
+TP_DATE_MAX   equ 39            ; tp_date, 40
+
+; CX = how much of tp_nbuf is still free with DI where it is, so a heading can
+; be assembled out of several pieces and the LAST one - the document's own
+; text, the only piece with no length of its own - takes whatever is left.
+; tp_nbuf is 48 bytes and the numbering in front of a \subsection title can be
+; eight of them, so the ceiling has to be computed rather than assumed.
+TP_NBUF_MAX equ 47              ; tp_nbuf, 48, less the NUL
+
+tp_nbuf_left:
+    mov cx, tp_nbuf + TP_NBUF_MAX
+    sub cx, di
+    jnc .o
+    xor cx, cx
+.o:
+    ret
+
+tp_c_title:
+    call tp_read_group
+    call tp_plain_arg
+    mov si, tp_wbuf
+    mov di, tp_title
+    mov cx, TP_TITLE_MAX
+    call tp_cpatn
+    mov byte [di], 0
+    ret
+
+tp_c_author:
+    call tp_read_group
+    call tp_plain_arg
+    mov si, tp_wbuf
+    mov di, tp_author
+    mov cx, TP_AUTHOR_MAX
+    call tp_cpatn
+    mov byte [di], 0
+    ret
+
+tp_c_date:
+    call tp_read_group
+    call tp_plain_arg
+    mov si, tp_wbuf
+    mov di, tp_date
+    mov cx, TP_DATE_MAX
+    call tp_cpatn
+    mov byte [di], 0
+    ret
+
+tp_c_maketitle:
+    cmp byte [tp_made], 0
+    jne .done
+    call tp_endpara
+    sub word [tp_y], 12
+    cmp byte [tp_title], 0
+    je .au
+    mov al, 18
+    mov [tp_csize], al
+    mov byte [tp_align], 1
+    mov si, tp_title
+    call tp_emit_line
+    call tp_nl
+    add word [tp_y], 0
+    sub word [tp_y], 6
+.au:
+    mov al, [tp_tsize]
+    mov [tp_csize], al
+    cmp byte [tp_author], 0
+    je .dt
+    mov byte [tp_align], 1
+    mov si, tp_author
+    call tp_emit_line
+    call tp_nl
+.dt:
+    cmp byte [tp_date], 0
+    je .rule
+    mov byte [tp_align], 1
+    mov si, tp_date
+    call tp_emit_line
+    call tp_nl
+.rule:
+    mov byte [tp_align], 0
+    mov ax, [tp_left]
+    mov bx, [tp_y]
+    mov cx, [tp_tw]
+    xor dx, dx
+    call tp_emit_box
+    sub word [tp_y], 16
+    mov byte [tp_made], 1
+    mov byte [tp_needind], 1
+.done:
+    ret
+
+tp_c_begin:
+    call tp_read_group
+    mov si, tp_arg
+    mov di, tp_k_document
+    call tp_has
+    jne .ctr
+    ; Only \maketitle builds the title block. Auto-running it here
+    ; printed "Hello" / GUIDE titles twice.
+    jmp .o
+.ctr:
+    mov si, tp_arg
+    mov di, tp_k_center
+    call tp_has
+    jne .quo
+    call tp_endpara
+    call tp_sty_push
+    mov byte [tp_align], 1
+    mov al, 1
+    call tp_env_push
+    jmp .o
+.quo:
+    mov si, tp_arg
+    mov di, tp_k_quote
+    call tp_has
+    je .doq
+    mov si, tp_arg
+    mov di, tp_k_abstract
+    call tp_has
+    jne .itm
+    call tp_endpara
+    mov byte [tp_align], 1
+    mov si, tp_s_abs
+    call tp_emit_line
+    call tp_nl
+    mov byte [tp_align], 0
+.doq:
+    call tp_endpara
+    mov al, 2
+    call tp_env_push
+    add word [tp_left], 36
+    sub word [tp_right], 36
+    mov byte [tp_needind], 0
+    jmp .o
+.itm:
+    mov si, tp_arg
+    mov di, tp_k_itemize
+    call tp_has
+    je .doi
+    mov si, tp_arg
+    mov di, tp_k_enumerate
+    call tp_has
+    jne .tab
+    mov al, 4
+    jmp .doi2
+.doi:
+    mov al, 3
+.doi2:
+    call tp_endpara
+    call tp_env_push
+    add word [tp_left], 18
+    mov byte [tp_itemn], 0
+    mov byte [tp_needind], 0
+    jmp .o
+.tab:
+    mov si, tp_arg
+    mov di, tp_k_tabular
+    call tp_has
+    jne .tbl
+    call tp_skip_opt
+    call tp_read_group
+    call tp_do_tabular
+    jmp .o
+.tbl:
+    mov si, tp_arg
+    mov di, tp_k_table
+    call tp_has
+    jne .o
+    call tp_skip_opt
+    mov al, 5
+    call tp_env_push
+.o:
+    ret
+
+tp_c_end:
+    call tp_read_group
+    mov si, tp_arg
+    mov di, tp_k_document
+    call tp_has
+    jne .ctr
+    mov ax, [tp_se]
+    mov [tp_si], ax
+    jmp .o
+.ctr:
+    mov si, tp_arg
+    mov di, tp_k_center
+    call tp_has
+    jne .quo
+    call tp_endpara
+    call tp_sty_pop
+    call tp_env_pop
+    jmp .o
+.quo:
+    mov si, tp_arg
+    mov di, tp_k_quote
+    call tp_has
+    je .unq
+    mov si, tp_arg
+    mov di, tp_k_abstract
+    call tp_has
+    jne .itm
+.unq:
+    call tp_endpara
+    call tp_env_pop
+    sub word [tp_left], 36
+    add word [tp_right], 36
+    jmp .o
+.itm:
+    mov si, tp_arg
+    mov di, tp_k_itemize
+    call tp_has
+    je .uni
+    mov si, tp_arg
+    mov di, tp_k_enumerate
+    call tp_has
+    jne .o
+.uni:
+    call tp_endpara
+    call tp_env_pop
+    sub word [tp_left], 18
+.o:
+    ret
+
+tp_c_section:
+    call tp_skip_opt
+    call tp_read_group
+    call tp_plain_arg
+    call tp_endpara
+    sub word [tp_y], 10
+    inc byte [tp_secno]
+    mov byte [tp_subno], 0
+    mov di, tp_nbuf
+    mov al, [tp_secno]
+    xor ah, ah
+    call tp_u16_di
+    mov al, '.'
+    stosb
+    mov al, ' '
+    stosb
+    mov si, tp_wbuf
+    call tp_nbuf_left
+    call tp_cpatn
+    mov byte [di], 0
+    mov al, 14
+    mov [tp_csize], al
+    mov byte [tp_align], 0
+    mov si, tp_nbuf
+    call tp_emit_line
+    mov al, [tp_tsize]
+    mov [tp_csize], al
+    call tp_nl
+    sub word [tp_y], 4
+    mov byte [tp_needind], 1
+    ret
+
+tp_c_subsec:
+    call tp_skip_opt
+    call tp_read_group
+    call tp_plain_arg
+    call tp_endpara
+    sub word [tp_y], 6
+    inc byte [tp_subno]
+    mov di, tp_nbuf
+    mov al, [tp_secno]
+    xor ah, ah
+    call tp_u16_di
+    mov al, '.'
+    stosb
+    mov al, [tp_subno]
+    xor ah, ah
+    call tp_u16_di
+    mov al, ' '
+    stosb
+    mov si, tp_wbuf
+    call tp_nbuf_left
+    call tp_cpatn
+    mov byte [di], 0
+    mov si, tp_nbuf
+    call tp_emit_line
+    call tp_nl
+    sub word [tp_y], 2
+    mov byte [tp_needind], 1
+    ret
+
+tp_c_chapter:
+    call tp_skip_opt
+    call tp_read_group
+    call tp_plain_arg
+    call tp_endpara
+    call tp_newpage
+    inc byte [tp_chno]
+    mov byte [tp_secno], 0
+    mov di, tp_nbuf
+    mov si, tp_s_chap
+    call tp_cpat
+    mov al, [tp_chno]
+    xor ah, ah
+    call tp_u16_di
+    mov byte [di], 0
+    mov byte [tp_align], 1
+    mov si, tp_nbuf
+    call tp_emit_line
+    call tp_nl
+    mov al, 18
+    mov [tp_csize], al
+    mov si, tp_wbuf
+    call tp_emit_line
+    mov al, [tp_tsize]
+    mov [tp_csize], al
+    mov byte [tp_align], 0
+    call tp_nl
+    sub word [tp_y], 12
+    mov byte [tp_needind], 1
+    ret
+
+tp_c_para:
+    call tp_read_group
+    call tp_plain_arg
+    call tp_endpara
+    mov byte [tp_needind], 0
+    mov byte [tp_bold], 1
+    mov si, tp_wbuf
+    call tp_emit_csi
+    mov byte [tp_bold], 0
+    call tp_space
+    ret
+
+tp_c_textbf:
+    call tp_read_group
+    mov al, [tp_bold]
+    push ax
+    mov byte [tp_bold], 1
+    call tp_feed_arg
+    pop ax
+    mov [tp_bold], al
+    ret
+
+tp_c_emph:
+    call tp_read_group
+    mov al, [tp_under]
+    push ax
+    mov byte [tp_under], 1
+    call tp_feed_arg
+    pop ax
+    mov [tp_under], al
+    ret
+
+tp_c_texttt:
+    call tp_read_group
+    call tp_feed_arg
+    ret
+
+; \textbackslash plus following letters is one token ("\title"), so
+; wrap cannot leave a lone backslash on the line.
+tp_c_bslash:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    mov di, tp_wbuf
+    mov al, '\'
+    stosb
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    xor cx, cx
+.gl:
+    cmp si, [tp_se]
+    jae .ge
+    mov al, [es:si]
+    cmp al, 'A'
+    jb .ge
+    cmp al, 'Z'
+    jbe .let
+    cmp al, 'a'
+    jb .ge
+    cmp al, 'z'
+    ja .ge
+.let:
+    cmp cx, 24
+    jae .ge
+    stosb
+    inc si
+    inc cx
+    jmp .gl
+.ge:
+    mov [tp_si], si
+    mov byte [di], 0
+    mov si, tp_wbuf
+    call tp_emit_csi
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+tp_c_nl:
+    call tp_nl
+    ret
+
+tp_c_par:
+    call tp_endpara
+    ret
+
+tp_c_noindent:
+    mov byte [tp_needind], 0
+    ret
+
+tp_c_newpage:
+    call tp_endpara
+    call tp_newpage
+    ret
+
+tp_c_vspace:
+    call tp_read_group
+    call tp_parse_dim
+    call tp_endpara
+    sub [tp_y], ax
+    mov ax, [tp_y]
+    cmp ax, [tp_tbot]
+    jae .o
+    call tp_newpage
+.o:
+    ret
+
+tp_c_big:
+    call tp_endpara
+    sub word [tp_y], 12
+    ret
+
+tp_c_med:
+    call tp_endpara
+    sub word [tp_y], 8
+    ret
+
+tp_c_sma:
+    call tp_endpara
+    sub word [tp_y], 4
+    ret
+
+tp_c_centering:
+    mov byte [tp_align], 1
+    ret
+
+tp_c_item:
+    call tp_endpara
+    mov byte [tp_needind], 0
+    mov byte [tp_inpara], 1
+    mov ax, [tp_left]
+    sub ax, 14
+    mov [tp_x], ax
+    ; enumerate vs itemize: env top
+    cmp byte [tp_env_n], 0
+    je .bul
+    mov bl, [tp_env_n]
+    dec bl
+    xor bh, bh
+    mov al, [tp_env+bx]
+    cmp al, 4
+    jne .bul
+    inc byte [tp_itemn]
+    mov di, tp_nbuf
+    mov al, [tp_itemn]
+    xor ah, ah
+    call tp_u16_di
+    mov al, '.'
+    stosb
+    mov byte [di], 0
+    mov si, tp_nbuf
+    call tp_emit_csi
+    jmp .x
+.bul:
+    mov si, tp_s_bullet
+    call tp_emit_csi
+.x:
+    mov ax, [tp_left]
+    mov [tp_x], ax
+    ret
+
+tp_c_caption:
+    call tp_read_group
+    call tp_plain_arg
+    call tp_endpara
+    mov byte [tp_align], 1
+    mov al, 10
+    mov [tp_csize], al
+    mov si, tp_wbuf
+    call tp_emit_line
+    mov al, [tp_tsize]
+    mov [tp_csize], al
+    mov byte [tp_align], 0
+    call tp_nl
+    ret
+
+tp_c_cite:
+    call tp_read_group
+    call tp_plain_arg
+    mov si, tp_s_lbr
+    call tp_emit_csi
+    mov si, tp_wbuf
+    call tp_emit_csi
+    mov si, tp_s_rbr
+    call tp_emit_csi
+    ret
+
+tp_c_pstyle:
+    call tp_read_group
+    mov si, tp_arg
+    mov di, tp_k_empty
+    call tp_has
+    jne .plain
+    mov byte [tp_pstyle], 0
+    jmp .o
+.plain:
+    mov si, tp_arg
+    mov di, tp_k_head
+    call tp_has
+    jne .my
+    mov byte [tp_pstyle], 2
+    jmp .o
+.my:
+    mov si, tp_arg
+    mov di, tp_k_myhead
+    call tp_has
+    jne .on
+    mov byte [tp_pstyle], 3
+    jmp .o
+.on:
+    mov byte [tp_pstyle], 1
+.o:
+    ret
+
+tp_needgrp:
+    call tp_skip_ws
+    call tp_peek
+    cmp al, '{'
+    je .y
+    stc
+    ret
+.y:
+    clc
+    ret
+
+tp_emit_bsname:
+    push si
+    mov si, tp_s_bsl
+    call tp_emit_csi
+    mov si, tp_cmd
+    call tp_emit_csi
+    pop si
+    ret
+
+tp_c_oddm:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    cmp ax, 36
+    jae .a
+    add ax, 72
+.a:
+    mov [tp_left], ax
+    mov [tp_tleft], ax
+    add ax, [tp_tw]
+    mov [tp_right], ax
+    ret
+
+tp_c_topm:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    cmp ax, 36
+    jae .a
+    add ax, 72
+.a:
+    mov bx, [tp_ph]
+    sub bx, ax
+    mov [tp_ttop], bx
+    ret
+
+tp_c_tw:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    mov [tp_tw], ax
+    mov bx, [tp_left]
+    add bx, ax
+    mov [tp_right], bx
+    ret
+
+tp_c_th:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    ret
+
+tp_c_pind:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    mov [tp_parind], ax
+    ret
+
+tp_c_pskip:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    mov [tp_parskip], ax
+    ret
+
+tp_c_base:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    mov [tp_tlead], ax
+    ret
+
+tp_c_tsep:
+    call tp_needgrp
+    jc tp_emit_bsname
+    call tp_read_group
+    call tp_parse_dim
+    mov [tp_tabsep], ax
+    ret
+
+tp_c_large:
+    mov al, [tp_tsize]
+    add al, 2
+    mov [tp_csize], al
+    ret
+
+tp_c_Large:
+    mov al, [tp_tsize]
+    add al, 4
+    mov [tp_csize], al
+    ret
+
+tp_c_small:
+    mov al, [tp_tsize]
+    sub al, 2
+    cmp al, 8
+    jae .o
+    mov al, 8
+.o:
+    mov [tp_csize], al
+    ret
+
+tp_c_norm:
+    mov al, [tp_tsize]
+    mov [tp_csize], al
+    ret
+
+tp_c_tex:
+    mov si, tp_s_tex
+    call tp_emit_csi
+    ret
+
+tp_c_latex:
+    mov si, tp_s_latex
+    call tp_emit_csi
+    ret
+
+tp_c_today:
+    mov si, tp_s_today
+    call tp_emit_csi
+    ret
+
+; ---- group / opt / dim ------------------------------------------------------
+tp_peek:
+    push si
+    push es
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    xor al, al
+    cmp si, [tp_se]
+    jae .o
+    mov al, [es:si]
+.o:
+    pop es
+    pop si
+    ret
+
+tp_skip_ws:
+    push ax
+    push es
+    mov es, [tp_srcseg]
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .o
+    mov al, [es:si]
+    cmp al, ' '
+    je .s
+    cmp al, 9
+    jne .o
+.s:
+    inc word [tp_si]
+    jmp .lp
+.o:
+    pop es
+    pop ax
+    ret
+
+tp_skip_opt:
+    call tp_skip_ws
+    call tp_peek
+    cmp al, '['
+    jne .o
+    inc word [tp_si]
+    push ax
+    push cx
+    push es
+    mov es, [tp_srcseg]
+    mov cx, 1
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .d
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, '['
+    jne .rb
+    inc cx
+    jmp .lp
+.rb:
+    cmp al, ']'
+    jne .lp
+    dec cx
+    jnz .lp
+.d:
+    pop es
+    pop cx
+    pop ax
+.o:
+    ret
+
+tp_skip_opt_store:
+    mov byte [tp_arg], 0
+    call tp_skip_ws
+    call tp_peek
+    cmp al, '['
+    jne .o
+    inc word [tp_si]
+    push ax
+    push cx
+    push di
+    push es
+    mov es, [tp_srcseg]
+    mov di, tp_arg
+    mov cx, 1
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .d
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, '['
+    jne .rb
+    inc cx
+    jmp .st
+.rb:
+    cmp al, ']'
+    jne .st
+    dec cx
+    jz .d
+.st:
+    cmp di, tp_arg + TP_ARG_MAX - 2
+    jae .lp
+    mov [di], al
+    inc di
+    jmp .lp
+.d:
+    mov byte [di], 0
+    pop es
+    pop di
+    pop cx
+    pop ax
+.o:
+    ret
+
+tp_read_group:
+    call tp_skip_ws
+    call tp_peek
+    cmp al, '{'
+    je .br
+    ; one char / command
+    mov byte [tp_arg], 0
+    ret
+.br:
+    inc word [tp_si]
+    push ax
+    push cx
+    push di
+    push es
+    mov es, [tp_srcseg]
+    mov di, tp_arg
+    mov cx, 1
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .d
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, '\'
+    je .esc
+    cmp al, '{'
+    je .ob
+    cmp al, '}'
+    je .cb
+    jmp .st
+.esc:
+    cmp di, tp_arg + TP_ARG_MAX - 3
+    jae .lp
+    mov [di], al
+    inc di
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .lp
+    mov al, [es:si]
+    inc word [tp_si]
+    jmp .st
+.ob:
+    inc cx
+    jmp .st
+.cb:
+    dec cx
+    jz .d
+.st:
+    cmp di, tp_arg + TP_ARG_MAX - 2
+    jae .lp
+    mov [di], al
+    inc di
+    jmp .lp
+.d:
+    mov byte [di], 0
+    pop es
+    pop di
+    pop cx
+    pop ax
+    ret
+
+; strip commands from tp_arg -> tp_wbuf
+;
+; The source is tp_arg, which tp_read_group fills to TP_ARG_MAX (180) from the
+; document, and the destination is the 82-byte tp_wbuf that every other writer
+; in here caps at 70. So the copy is capped at 70 as well: without it a
+; \title{...} of more than 82 characters runs off the end of tp_wbuf and into
+; tp_linebuf, with the overrun length under the .TEX file's control.
+TP_WBUF_MAX equ 70
+
+tp_plain_arg:
+    push ax
+    push cx
+    push si
+    push di
+    mov si, tp_arg
+    mov di, tp_wbuf
+    mov cx, TP_WBUF_MAX
+.lp:
+    jcxz .z
+    lodsb
+    or al, al
+    jz .z
+    cmp al, '\'
+    je .cmd
+    cmp al, '{'
+    je .lp
+    cmp al, '}'
+    je .lp
+    cmp al, 10
+    je .sp
+    cmp al, 13
+    je .sp
+    cmp al, 9
+    je .sp
+    stosb
+    dec cx
+    jmp .lp
+.sp:
+    mov al, ' '
+    stosb
+    dec cx
+    jmp .lp
+.cmd:
+    lodsb
+    or al, al
+    jz .z
+    call tp_isalpha
+    jc .esc
+    ; named command: textbackslash -> '\'; else skip. CX is the tp_wbuf budget
+    ; from .lp, and this inner loop needs a counter of its own - so it borrows
+    ; CX and puts it back, rather than the budget silently becoming a command
+    ; name's length.
+    dec si
+    push cx
+    push di
+    mov di, tp_cmd
+    xor cx, cx
+.en:
+    mov al, [si]
+    or al, al
+    jz .ed
+    call tp_isalpha
+    jc .ed
+    cmp cx, 24
+    jae .ed
+    mov [di], al
+    inc di
+    inc si
+    inc cx
+    jmp .en
+.ed:
+    mov byte [di], 0
+    pop di
+    pop cx
+    push si
+    mov si, tp_cmd
+    push di
+    mov di, tp_cn_bsl
+    call tp_streq
+    pop di
+    pop si
+    jne .grp
+    mov al, '\'
+    stosb
+    dec cx
+    jmp .lp
+.esc:
+    stosb
+    dec cx
+    jmp .lp
+.grp:
+    cmp byte [si], '{'
+    jne .lp
+    inc si
+    jmp .lp
+.z:
+    mov byte [di], 0
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; parse number+unit in tp_arg -> AX points
+tp_parse_dim:
+    push bx
+    push cx
+    push dx
+    push si
+    mov si, tp_arg
+    xor ax, ax
+    xor bx, bx
+    xor cx, cx                  ; 1 if seen digit
+.lp:
+    mov bl, [si]
+    or bl, bl
+    jz .num
+    cmp bl, '0'
+    jb .unit
+    cmp bl, '9'
+    ja .unit
+    inc si
+    mov ch, 1
+    mov cl, 10
+    mul cl
+    xor bh, bh
+    sub bl, '0'
+    add ax, bx
+    jmp .lp
+.unit:
+    cmp bl, ' '
+    jne .u
+    inc si
+    jmp .lp
+.u:
+    ; in / em / pt
+    cmp byte [si], 'i'
+    je .in
+    cmp byte [si], 'e'
+    je .em
+    jmp .num
+.in:
+    mov bx, 72
+    mul bx
+    jmp .done
+.em:
+    mov bl, [tp_csize]
+    xor bh, bh
+    mul bx
+    jmp .done
+.num:
+    or ax, ax
+    jnz .done
+    mov ax, 12
+.done:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+; SI = haystack, DI = needle (both NUL). ZF=1 if needle occurs in haystack.
+tp_has:
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+    mov bx, di
+    mov cx, 200
+.scan:
+    dec cx
+    jz .no
+    mov al, [si]
+    or al, al
+    jz .no
+    push si
+    push di
+.cmp:
+    mov al, [di]
+    or al, al
+    jz .yes
+    cmp al, [si]
+    jne .nx
+    inc si
+    inc di
+    jmp .cmp
+.nx:
+    pop di
+    pop si
+    inc si
+    jmp .scan
+.yes:
+    pop di
+    pop si
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    xor ax, ax
+    ret
+.no:
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+    or al, 1
+    ret
+
+tp_k_10pt:      db '10pt', 0
+tp_k_11pt:      db '11pt', 0
+tp_k_book:      db 'book', 0
+tp_k_document:  db 'document', 0
+tp_k_center:    db 'center', 0
+tp_k_quote:     db 'quote', 0
+tp_k_abstract:  db 'abstract', 0
+tp_k_itemize:   db 'itemize', 0
+tp_k_enumerate: db 'enumerate', 0
+tp_k_tabular:   db 'tabular', 0
+tp_k_table:     db 'table', 0
+tp_k_empty:     db 'empty', 0
+tp_k_letter:    db 'letterpaper', 0
+tp_k_legal:     db 'legalpaper', 0
+tp_k_a4:        db 'a4paper', 0
+tp_k_a5:        db 'a5paper', 0
+tp_k_twoside:   db 'twoside', 0
+tp_k_head:      db 'headings', 0
+tp_k_myhead:    db 'myheadings', 0
+
+tp_cmdtab:
+    dw tp_cn_dclass, tp_c_dclass
+    dw tp_cn_usep, tp_c_skipg
+    dw tp_cn_title, tp_c_title
+    dw tp_cn_author, tp_c_author
+    dw tp_cn_date, tp_c_date
+    dw tp_cn_make, tp_c_maketitle
+    dw tp_cn_begin, tp_c_begin
+    dw tp_cn_end, tp_c_end
+    dw tp_cn_sec, tp_c_section
+    dw tp_cn_sub, tp_c_subsec
+    dw tp_cn_ch, tp_c_chapter
+    dw tp_cn_parag, tp_c_para
+    dw tp_cn_bf, tp_c_textbf
+    dw tp_cn_emph, tp_c_emph
+    dw tp_cn_it, tp_c_emph
+    dw tp_cn_ul, tp_c_emph
+    dw tp_cn_tt, tp_c_texttt
+    dw tp_cn_bsl, tp_c_bslash
+    dw tp_cn_nl, tp_c_nl
+    dw tp_cn_par, tp_c_par
+    dw tp_cn_ni, tp_c_noindent
+    dw tp_cn_np, tp_c_newpage
+    dw tp_cn_cp, tp_c_newpage
+    dw tp_cn_pb, tp_c_newpage
+    dw tp_cn_vs, tp_c_vspace
+    dw tp_cn_big, tp_c_big
+    dw tp_cn_med, tp_c_med
+    dw tp_cn_sma, tp_c_sma
+    dw tp_cn_cen, tp_c_centering
+    dw tp_cn_item, tp_c_item
+    dw tp_cn_cap, tp_c_caption
+    dw tp_cn_lab, tp_c_skipg
+    dw tp_cn_cite, tp_c_cite
+    dw tp_cn_ps, tp_c_pstyle
+    dw tp_cn_od, tp_c_oddm
+    dw tp_cn_tm, tp_c_topm
+    dw tp_cn_tw, tp_c_tw
+    dw tp_cn_th, tp_c_th
+    dw tp_cn_pi, tp_c_pind
+    dw tp_cn_psk, tp_c_pskip
+    dw tp_cn_bs, tp_c_base
+    dw tp_cn_tcs, tp_c_tsep
+    dw tp_cn_hl, tp_c_nop
+    dw tp_cn_lg, tp_c_large
+    dw tp_cn_Lg, tp_c_Large
+    dw tp_cn_sm, tp_c_small
+    dw tp_cn_ns, tp_c_norm
+    dw tp_cn_tex, tp_c_tex
+    dw tp_cn_ltx, tp_c_latex
+    dw tp_cn_td, tp_c_today
+    dw 0
+
+tp_cn_dclass:   db 'documentclass', 0
+tp_cn_usep:     db 'usepackage', 0
+tp_cn_title:    db 'title', 0
+tp_cn_author:   db 'author', 0
+tp_cn_date:     db 'date', 0
+tp_cn_make:     db 'maketitle', 0
+tp_cn_begin:    db 'begin', 0
+tp_cn_end:      db 'end', 0
+tp_cn_sec:      db 'section', 0
+tp_cn_sub:      db 'subsection', 0
+tp_cn_ch:       db 'chapter', 0
+tp_cn_parag:    db 'paragraph', 0
+tp_cn_bf:       db 'textbf', 0
+tp_cn_emph:     db 'emph', 0
+tp_cn_it:       db 'textit', 0
+tp_cn_ul:       db 'underline', 0
+tp_cn_tt:       db 'texttt', 0
+tp_cn_bsl:      db 'textbackslash', 0
+tp_cn_nl:       db 'newline', 0
+tp_cn_par:      db 'par', 0
+tp_cn_ni:       db 'noindent', 0
+tp_cn_np:       db 'newpage', 0
+tp_cn_cp:       db 'clearpage', 0
+tp_cn_pb:       db 'pagebreak', 0
+tp_cn_vs:       db 'vspace', 0
+tp_cn_big:      db 'bigskip', 0
+tp_cn_med:      db 'medskip', 0
+tp_cn_sma:      db 'smallskip', 0
+tp_cn_cen:      db 'centering', 0
+tp_cn_item:     db 'item', 0
+tp_cn_cap:      db 'caption', 0
+tp_cn_lab:      db 'label', 0
+tp_cn_cite:     db 'cite', 0
+tp_cn_ps:       db 'pagestyle', 0
+tp_cn_od:       db 'oddsidemargin', 0
+tp_cn_tm:       db 'topmargin', 0
+tp_cn_tw:       db 'textwidth', 0
+tp_cn_th:       db 'textheight', 0
+tp_cn_pi:       db 'parindent', 0
+tp_cn_psk:      db 'parskip', 0
+tp_cn_bs:       db 'baselineskip', 0
+tp_cn_tcs:      db 'tabcolsep', 0
+tp_cn_hl:       db 'hline', 0
+tp_cn_lg:       db 'large', 0
+tp_cn_Lg:       db 'Large', 0
+tp_cn_sm:       db 'small', 0
+tp_cn_ns:       db 'normalsize', 0
+tp_cn_tex:      db 'TeX', 0
+tp_cn_ltx:      db 'LaTeX', 0
+tp_cn_td:       db 'today', 0
+
+; ---- emit / wrap ------------------------------------------------------------
+; One em = body point size. Preview maps 8px per em, so 12pt is
+; one 8x8 cell. The old 0.6em width collapsed to ~5px and words overlapped.
+tp_charw:
+    mov al, [tp_csize]
+    xor ah, ah
+    or ax, ax
+    jnz .s
+    mov al, 12
+.s:
+    ret
+
+tp_strlen:
+    push si
+    xor ax, ax
+.lp:
+    cmp byte [si], 0
+    je .o
+    inc ax
+    inc si
+    jmp .lp
+.o:
+    pop si
+    ret
+
+tp_emit_csi:
+    ; SI = DS NUL string, current style
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    call tp_strlen
+    mov cx, ax
+    jcxz .o
+    call tp_ensure
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mul cl                      ; AX = width  (CL * charw) - only if CX<256
+    ; use BX * CX more carefully
+    mov al, [tp_csize]
+    ; recompute width = len * charw
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mov ax, cx
+    mul bx                      ; DX:AX width
+    mov dx, ax                  ; width
+    cmp byte [tp_align], 0
+    je .left
+    call tp_c_append
+    jmp .o
+.left:
+    mov ax, [tp_x]
+    cmp ax, [tp_left]
+    jbe .fit
+    add ax, dx
+    cmp ax, [tp_right]
+    jbe .fit
+    call tp_nl
+.fit:
+    call tp_put_run
+    add [tp_x], dx
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_emit_str:
+    ; SI DS string CX len (not necessarily NUL)
+    push ax
+    push si
+    mov di, tp_wbuf
+    cmp cx, 70
+    jbe .c
+    mov cx, 70
+.c:
+    push cx
+    jcxz .z
+    rep movsb
+.z:
+    pop cx
+    mov bx, cx
+    mov byte [tp_wbuf+bx], 0
+    mov si, tp_wbuf
+    call tp_emit_csi
+    pop si
+    pop ax
+    ret
+
+tp_emit_line:
+    ; SI whole line, honor align
+    push ax
+    push bx
+    call tp_flush_c
+    call tp_ensure
+    cmp byte [tp_align], 0
+    je .l
+    call tp_strlen
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mul bl                      ; wait AX was len, then charw overwrote
+    ; redo
+    call tp_strlen
+    mov cx, ax
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mov ax, cx
+    mul bx
+    mov cx, [tp_right]
+    sub cx, [tp_left]
+    sub cx, ax
+    jns .p
+    xor cx, cx
+.p:
+    shr cx, 1
+    mov ax, [tp_left]
+    add ax, cx
+    mov [tp_x], ax
+    call tp_put_run
+    jmp .o
+.l:
+    mov ax, [tp_left]
+    mov [tp_x], ax
+    call tp_put_run
+.o:
+    pop bx
+    pop ax
+    ret
+
+tp_c_append:
+    ; append SI to cline
+    push ax
+    push si
+    push di
+    mov di, tp_cline
+    xor ah, ah
+    mov al, [tp_clen]
+    add di, ax
+.lp:
+    lodsb
+    or al, al
+    jz .z
+    cmp byte [tp_clen], TP_CLINE_MAX - 1
+    jae .z
+    mov [di], al
+    inc di
+    inc byte [tp_clen]
+    jmp .lp
+.z:
+    mov byte [di], 0
+    pop di
+    pop si
+    pop ax
+    ret
+
+tp_flush_c:
+    cmp byte [tp_clen], 0
+    je .o
+    push ax
+    push bx
+    push cx
+    push si
+    mov byte [tp_cline + TP_CLINE_MAX], 0
+    xor ah, ah
+    mov al, [tp_clen]
+    mov bx, ax
+    mov byte [tp_cline+bx], 0
+    mov si, tp_cline
+    mov byte [tp_align], 0      ; emit_line uses align; we center here
+    call tp_strlen
+    mov cx, ax
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mov ax, cx
+    mul bx
+    mov cx, [tp_right]
+    sub cx, [tp_left]
+    sub cx, ax
+    jns .p
+    xor cx, cx
+.p:
+    shr cx, 1
+    mov ax, [tp_left]
+    add ax, cx
+    mov [tp_x], ax
+    mov si, tp_cline
+    call tp_put_run
+    mov byte [tp_clen], 0
+    pop si
+    pop cx
+    pop bx
+    pop ax
+.o:
+    ret
+
+tp_ensure:
+    cmp byte [tp_inpara], 0
+    jne .o
+    mov byte [tp_inpara], 1
+    cmp byte [tp_needind], 0
+    je .ni
+    cmp byte [tp_align], 0
+    jne .ni
+    mov ax, [tp_left]
+    add ax, [tp_parind]
+    mov [tp_x], ax
+    jmp .d
+.ni:
+    mov ax, [tp_left]
+    mov [tp_x], ax
+.d:
+    mov byte [tp_needind], 0
+.o:
+    ret
+
+tp_space:
+    cmp byte [tp_inpara], 0
+    je .o
+    cmp byte [tp_align], 0
+    je .l
+    mov si, tp_s_spch
+    call tp_c_append
+    jmp .o
+.l:
+    mov cx, [tp_left]
+    cmp [tp_x], cx
+    jbe .o
+    mov si, tp_s_spch
+    call tp_emit_csi
+.o:
+    ret
+
+tp_nl:
+    call tp_flush_c
+    push ax
+    mov ax, [tp_tlead]
+    cmp al, [tp_csize]
+    jae .s
+    mov al, [tp_csize]
+    add al, 4
+    xor ah, ah
+.s:
+    sub [tp_y], ax
+    mov ax, [tp_y]
+    cmp ax, [tp_tbot]
+    jae .x
+    call tp_newpage
+    jmp .d
+.x:
+    mov ax, [tp_left]
+    add ax, [tp_indent]
+    mov [tp_x], ax
+.d:
+    mov word [tp_indent], 0
+    pop ax
+    ret
+
+tp_endpara:
+    call tp_flush_c
+    cmp byte [tp_inpara], 0
+    je .o
+    push ax
+    call tp_nl
+    mov ax, [tp_parskip]
+    sub [tp_y], ax
+    mov byte [tp_inpara], 0
+    mov byte [tp_needind], 1
+    mov ax, [tp_left]
+    mov [tp_x], ax
+    pop ax
+.o:
+    ret
+
+tp_newpage:
+    call tp_flush_c
+    cmp byte [tp_onpage], 0
+    je .o
+    call tp_footer
+    inc word [tp_page]
+    inc word [tp_npages]
+    cmp word [tp_npages], TP_MAX_PAGES
+    jbe .ok
+    mov word [tp_npages], TP_MAX_PAGES
+    dec word [tp_page]
+.ok:
+    call tp_geom
+    mov ax, [tp_ttop]
+    mov [tp_y], ax
+    mov ax, [tp_left]
+    mov [tp_x], ax
+    mov word [tp_indent], 0
+    mov byte [tp_onpage], 0
+.o:
+    ret
+
+tp_footer:
+    cmp byte [tp_pstyle], 0
+    je .o
+    push ax
+    push bx
+    push cx
+    push si
+    push di
+    mov di, tp_nbuf
+    mov ax, [tp_page]
+    inc ax
+    call tp_u16_di
+    mov byte [di], 0
+    mov si, tp_nbuf
+    call tp_strlen
+    mov cx, ax
+    mov al, 10
+    push word [tp_csize]
+    mov [tp_csize], al
+    call tp_charw
+    mov bl, al
+    xor bh, bh
+    mov ax, cx
+    mul bx
+    mov cx, ax                  ; text width
+    mov bx, 36
+    cmp byte [tp_pstyle], 2
+    jne .yok
+    mov bx, [tp_ph]
+    sub bx, 28
+.yok:
+    cmp byte [tp_pstyle], 3
+    je .outer
+    mov ax, [tp_pw]
+    sub ax, cx
+    shr ax, 1
+    jmp .put
+.outer:
+    mov ax, [tp_page]
+    and ax, 1
+    jnz .ol
+    mov ax, [tp_pw]
+    sub ax, cx
+    sub ax, 36
+    jmp .put
+.ol:
+    mov ax, 36
+.put:
+    mov si, tp_nbuf
+    call tp_put_run_at
+    pop word [tp_csize]
+    pop di
+    pop si
+    pop cx
+    pop bx
+    pop ax
+.o:
+    ret
+
+; SI string at current x,y
+tp_put_run:
+    mov ax, [tp_x]
+    mov bx, [tp_y]
+    sub bx, 2
+    call tp_put_run_at
+    ret
+
+; AX=x BX=y SI=NUL
+tp_put_run_at:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov [tp_rx], ax
+    mov [tp_ry], bx
+    mov cx, [tp_nruns]
+    cmp cx, TP_MAX_RUNS
+    jae .o
+    call tp_strlen
+    or ax, ax
+    jz .o
+    cmp ax, 255
+    jbe .ln
+    mov ax, 255
+.ln:
+    mov cx, ax
+    mov ax, [tp_tused]
+    add ax, cx
+    cmp ax, TP_TEXT_MAX
+    jae .o
+    mov di, [tp_tused]
+    add di, tp_text
+    push cx
+    push si
+    push ds
+    pop es
+    rep movsb
+    pop si
+    pop cx
+    mov ax, [tp_nruns]
+    mov dx, TP_RUN_SZ
+    mul dx
+    mov di, ax
+    add di, tp_runs
+    mov al, [tp_page]
+    mov [di], al
+    mov al, [tp_bold]
+    and al, 1
+    mov ah, [tp_under]
+    and ah, 1
+    shl ah, 1
+    or al, ah
+    mov [di+1], al
+    mov ax, [tp_rx]
+    mov [di+2], ax
+    mov ax, [tp_ry]
+    mov [di+4], ax
+    mov al, [tp_csize]
+    mov [di+6], al
+    mov [di+7], cl
+    mov ax, [tp_tused]
+    mov [di+8], ax
+    add [tp_tused], cx
+    inc word [tp_nruns]
+    mov byte [tp_onpage], 1
+.o:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_emit_box:
+    ; AX=x BX=y CX=w DX=h
+    push ax
+    push bx
+    push cx
+    push dx
+    push di
+    mov si, [tp_nboxes]
+    cmp si, TP_MAX_BOXES
+    jae .o
+    push ax
+    mov ax, si
+    mov si, TP_BOX_SZ
+    mul si
+    mov di, ax
+    add di, tp_boxes
+    pop ax
+    push ax
+    mov al, [tp_page]
+    mov [di], al
+    mov byte [di+1], 0
+    pop ax
+    or cx, cx
+    jnz .w
+    inc cx
+.w:
+    or dx, dx
+    jnz .h
+    inc dx
+.h:
+    mov [di+2], ax
+    mov [di+4], bx
+    mov [di+6], cx
+    mov [di+8], dx
+    inc word [tp_nboxes]
+    mov byte [tp_onpage], 1
+.o:
+    pop di
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_sty_push:
+    push ax
+    push bx
+    mov al, [tp_sty_n]
+    cmp al, TP_STY_MAX
+    jae .o
+    xor ah, ah
+    mov bl, 4
+    mul bl
+    mov bx, ax
+    add bx, tp_sty
+    mov al, [tp_bold]
+    mov [bx], al
+    mov al, [tp_under]
+    mov [bx+1], al
+    mov al, [tp_csize]
+    mov [bx+2], al
+    mov al, [tp_align]
+    mov [bx+3], al
+    inc byte [tp_sty_n]
+.o:
+    pop bx
+    pop ax
+    ret
+
+tp_sty_pop:
+    push ax
+    push bx
+    cmp byte [tp_sty_n], 0
+    je .o
+    dec byte [tp_sty_n]
+    mov al, [tp_sty_n]
+    xor ah, ah
+    mov bl, 4
+    mul bl
+    mov bx, ax
+    add bx, tp_sty
+    mov al, [bx]
+    mov [tp_bold], al
+    mov al, [bx+1]
+    mov [tp_under], al
+    mov al, [bx+2]
+    mov [tp_csize], al
+    mov al, [bx+3]
+    mov [tp_align], al
+.o:
+    pop bx
+    pop ax
+    ret
+
+tp_env_push:
+    ; AL = type
+    push bx
+    mov bl, [tp_env_n]
+    cmp bl, TP_ENV_MAX
+    jae .o
+    xor bh, bh
+    mov [tp_env+bx], al
+    inc byte [tp_env_n]
+.o:
+    pop bx
+    ret
+
+tp_env_pop:
+    cmp byte [tp_env_n], 0
+    je .o
+    dec byte [tp_env_n]
+.o:
+    ret
+
+; feed tp_arg as text (simple)
+tp_feed_arg:
+    push ax
+    push si
+    push di
+    mov si, tp_arg
+.lp:
+    mov al, [si]
+    or al, al
+    jz .o
+    cmp al, '\'
+    je .cmd
+    cmp al, ' '
+    je .sp
+    cmp al, 9
+    je .sp
+    cmp al, 10
+    je .sp
+    cmp al, 13
+    je .sp
+    cmp al, '$'
+    je .sk1
+    cmp al, '{'
+    je .sk1
+    cmp al, '}'
+    je .sk1
+    ; word
+    mov di, tp_wbuf
+.w:
+    mov al, [si]
+    or al, al
+    jz .ew
+    cmp al, ' '
+    je .ew
+    cmp al, 9
+    je .ew
+    cmp al, '\'
+    je .ew
+    cmp al, '{'
+    je .ew
+    cmp al, '}'
+    je .ew
+    cmp al, '$'
+    je .ew
+    mov [di], al
+    inc di
+    inc si
+    jmp .w
+.ew:
+    mov byte [di], 0
+    push si
+    mov si, tp_wbuf
+    cmp byte [si], 0
+    je .n
+    call tp_emit_csi
+.n:
+    pop si
+    jmp .lp
+.sp:
+    inc si
+    call tp_space
+    jmp .lp
+.sk1:
+    inc si
+    jmp .lp
+.cmd:
+    inc si
+    mov al, [si]
+    or al, al
+    jz .o
+    call tp_isalpha
+    jc .escch
+    ; named: textbackslash -> '\'; other names are dropped
+    mov di, tp_cmd
+    xor cx, cx
+.en:
+    mov al, [si]
+    or al, al
+    jz .ed
+    call tp_isalpha
+    jc .ed
+    cmp cx, 24
+    jae .ed
+    mov [di], al
+    inc di
+    inc si
+    inc cx
+    jmp .en
+.ed:
+    mov byte [di], 0
+    push si
+    mov si, tp_cmd
+    mov di, tp_cn_bsl
+    call tp_streq
+    pop si
+    jne .lp
+    ; \textbackslash + letters -> one run ("\documentclass")
+    mov di, tp_wbuf
+    mov al, '\'
+    stosb
+    xor cx, cx
+.gl:
+    mov al, [si]
+    or al, al
+    jz .ge
+    cmp al, 'A'
+    jb .ge
+    cmp al, 'Z'
+    jbe .glet
+    cmp al, 'a'
+    jb .ge
+    cmp al, 'z'
+    ja .ge
+.glet:
+    cmp cx, 24
+    jae .ge
+    stosb
+    inc si
+    inc cx
+    jmp .gl
+.ge:
+    mov byte [di], 0
+    push si
+    mov si, tp_wbuf
+    call tp_emit_csi
+    pop si
+    jmp .lp
+.escch:
+    ; \% \{ \} \\ \& \$ \# \_
+    mov [tp_wbuf], al
+    mov byte [tp_wbuf+1], 0
+    inc si
+    push si
+    mov si, tp_wbuf
+    call tp_emit_csi
+    pop si
+    jmp .lp
+.o:
+    pop di
+    pop si
+    pop ax
+    ret
+
+; ---- tabular ----------------------------------------------------------------
+tp_do_tabular:
+    ; tp_arg holds column spec
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    call tp_endpara
+    call tp_tab_spec
+    call tp_tab_body
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_tab_spec:
+    push ax
+    push si
+    push di
+    mov si, tp_arg
+    xor di, di                  ; col count
+    xor ah, ah                  ; pending bar
+    mov byte [tp_colbar], 0
+.lp:
+    lodsb
+    or al, al
+    jz .d
+    cmp al, '|'
+    jne .col
+    mov ah, 1
+    jmp .lp
+.col:
+    cmp al, 'l'
+    je .ok
+    cmp al, 'c'
+    je .ok
+    cmp al, 'r'
+    je .ok
+    cmp al, 'p'
+    jne .lp
+    mov al, 'l'
+    ; skip {..}
+    cmp byte [si], '{'
+    jne .ok
+    inc si
+    mov cl, 1
+.sk:
+    lodsb
+    or al, al
+    jz .ok
+    cmp al, '{'
+    jne .rc
+    inc cl
+    jmp .sk
+.rc:
+    cmp al, '}'
+    jne .sk
+    dec cl
+    jnz .sk
+    mov al, 'l'
+.ok:
+    cmp di, TP_COL_MAX
+    jae .lp
+    mov [tp_colk+di], al
+    mov [tp_colbar+di], ah
+    xor ah, ah
+    inc di
+    jmp .lp
+.d:
+    mov [tp_colbar+di], ah       ; trailing
+    or di, di
+    jnz .n
+    inc di
+    mov byte [tp_colk], 'l'
+    mov byte [tp_colbar], 0
+.n:
+    mov [tp_tmp4], di           ; ncols
+    pop di
+    pop si
+    pop ax
+    ret
+
+tp_tab_body:
+    ; gather rows from source until \end{tabular}
+    ; We measure and emit in one walk using a simple row buffer in linebuf.
+    ; First pass: measure col widths. Second: emit.
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov es, [tp_srcseg]
+    mov ax, [tp_si]
+    mov [tp_tmp], ax            ; body start
+    ; measure
+    xor ax, ax
+    mov cx, TP_COL_MAX
+    mov di, tp_colw
+    xor ax, ax
+    push cx
+    push di
+    xor ax, ax
+    mov cx, TP_COL_MAX
+    rep stosw
+    pop di
+    pop cx
+    mov word [tp_tmp2], 0       ; nrows
+    mov word [tp_tmp3], 0       ; hline flags packed? skip, always rule if seen
+    call tp_tab_measure
+    ; emit
+    mov ax, [tp_tmp]
+    mov [tp_si], ax
+    call tp_tab_emit
+    ; skip \end{tabular}
+    call tp_tab_skip_end
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_tab_skip_end:
+    push ax
+    push cx
+    push si
+    push es
+    mov es, [tp_srcseg]
+    mov si, [tp_si]
+    mov cx, 20
+.lp:
+    cmp si, [tp_se]
+    jae .o
+    cmp byte [es:si], '\'
+    je .try
+    inc si
+    loop .lp
+    jmp .o
+.try:
+    ; match end{tabular}
+    push si
+    inc si
+    push di
+    mov di, tp_s_endtab
+    ; compare
+.m:
+    mov al, [di]
+    or al, al
+    jz .hit
+    cmp al, [es:si]
+    jne .no
+    inc si
+    inc di
+    jmp .m
+.hit:
+    pop di
+    pop ax
+    mov [tp_si], si
+    jmp .o
+.no:
+    pop di
+    pop si
+    inc si
+    jmp .lp
+.o:
+    pop es
+    pop si
+    pop cx
+    pop ax
+    ret
+
+tp_tab_measure:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov es, [tp_srcseg]
+    xor bx, bx                  ; col
+    xor cx, cx                  ; cell len
+    mov word [tp_tmp2], 0
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .d
+    ; \end{tabular}?
+    cmp byte [es:si], '\'
+    jne .ch
+    call tp_tab_at_end
+    jc .cmd
+    jmp .d
+.cmd:
+    inc si
+    ; hline or double-backslash
+    cmp byte [es:si], '\'
+    jne .hl
+    add si, 1
+    mov [tp_si], si
+    call tp_tab_note
+    xor bx, bx
+    xor cx, cx
+    inc word [tp_tmp2]
+    jmp .lp
+.hl:
+    ; skip command name
+    mov [tp_si], si
+    inc word [tp_si]
+    jmp .skc
+.ch:
+    mov al, [es:si]
+    inc si
+    mov [tp_si], si
+    cmp al, '&'
+    je .amp
+    cmp al, '%'
+    je .com
+    cmp al, 10
+    je .lp
+    cmp al, 13
+    je .lp
+    inc cx
+    jmp .lp
+.amp:
+    call tp_tab_note
+    inc bx
+    xor cx, cx
+    jmp .lp
+.com:
+    ; skip to nl
+.cs:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .lp
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, 10
+    je .lp
+    jmp .cs
+.skc:
+    ; skip letters
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .lp
+    mov al, [es:si]
+    call tp_isalpha
+    jc .lp
+    inc word [tp_si]
+    jmp .skc
+.d:
+    ; last row if any
+    or cx, cx
+    jnz .last
+    or bx, bx
+    jz .o
+.last:
+    call tp_tab_note
+    inc word [tp_tmp2]
+.o:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; CX = cell char count, BX = col. update colw
+tp_tab_note:
+    push ax
+    push bx
+    push dx
+    cmp bx, TP_COL_MAX
+    jae .o
+    call tp_charw
+    xor ah, ah
+    mul cx                      ; width
+    add ax, [tp_tabsep]
+    add ax, [tp_tabsep]
+    shl bx, 1
+    cmp [tp_colw+bx], ax
+    jae .o
+    mov [tp_colw+bx], ax
+.o:
+    pop dx
+    pop bx
+    pop ax
+    ret
+
+; CF=0 if at \end{tabular}
+tp_tab_at_end:
+    push ax
+    push si
+    push di
+    mov si, [tp_si]
+    cmp byte [es:si], '\'
+    jne .no
+    inc si
+    mov di, tp_s_endtab
+.m:
+    mov al, [di]
+    or al, al
+    jz .yes
+    cmp al, [es:si]
+    jne .no
+    inc si
+    inc di
+    jmp .m
+.yes:
+    pop di
+    pop si
+    pop ax
+    clc
+    ret
+.no:
+    pop di
+    pop si
+    pop ax
+    stc
+    ret
+
+tp_tab_emit:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    ; total width
+    xor ax, ax
+    mov cx, [tp_tmp4]
+    or cx, cx
+    jnz .tw0
+    inc cx
+.tw0:
+    xor si, si
+.tw:
+    add ax, [tp_colw+si]
+    add si, 2
+    loop .tw
+    mov [tp_tmp5], ax           ; table width
+    mov [tp_tabw], ax
+    mov ax, [tp_tmp4]
+    mov [tp_tabn], ax
+    ; Row must clear an em of type plus the rules. 16pt was too
+    ; short: 12pt glyphs sat on the bottom rule.
+    mov al, [tp_csize]
+    xor ah, ah
+    add ax, 10
+    cmp ax, 20
+    jae .rh
+    mov ax, 20
+.rh:
+    mov [tp_rowh], ax
+    mov ax, [tp_rowh]
+    mov bx, [tp_tmp2]
+    or bx, bx
+    jnz .nr
+    inc bx
+.nr:
+    mul bx
+    mov cx, ax                  ; table h
+    mov ax, [tp_y]
+    sub ax, cx
+    cmp ax, [tp_tbot]
+    jae .fit
+    call tp_newpage
+.fit:
+    mov ax, [tp_y]
+    mov [tp_tabtop], ax
+    mov [tp_tabbot], ax
+    mov [tp_tmp3], ax
+    ; walk rows again
+    mov es, [tp_srcseg]
+    xor bx, bx                  ; col
+    mov di, tp_linebuf          ; cell
+    mov byte [tp_linebuf], 0
+    mov word [tp_clen], 0       ; used as cell len here - careful
+    mov byte [tp_clen], 0
+    mov ax, [tp_y]
+    mov [tp_tmp2], ax           ; current row top
+.lp:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .fin
+    call tp_tab_at_end
+    jnc .fin
+    mov al, [es:si]
+    cmp al, '\'
+    je .bs
+    inc word [tp_si]
+    cmp al, '&'
+    je .amp
+    cmp al, '%'
+    je .com
+    cmp al, 10
+    je .lp
+    cmp al, 13
+    je .lp
+    ; append char
+    push bx
+    xor bh, bh
+    mov bl, [tp_clen]
+    cmp bl, 70
+    jae .skc2
+    mov [tp_linebuf+bx], al
+    inc byte [tp_clen]
+    inc bx
+    mov byte [tp_linebuf+bx], 0
+.skc2:
+    pop bx
+    jmp .lp
+.amp:
+    call tp_tab_cell
+    inc bx
+    mov byte [tp_clen], 0
+    mov byte [tp_linebuf], 0
+    jmp .lp
+.bs:
+    inc si
+    cmp byte [es:si], '\'
+    jne .cmd
+    inc si
+    mov [tp_si], si
+    call tp_tab_cell
+    ; next row
+    mov ax, [tp_tmp2]
+    sub ax, [tp_rowh]
+    mov [tp_tmp2], ax
+    mov [tp_tabbot], ax
+    mov [tp_y], ax
+    xor bx, bx
+    mov byte [tp_clen], 0
+    mov byte [tp_linebuf], 0
+    jmp .lp
+.cmd:
+    inc word [tp_si]            ; past backslash
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .lp
+    mov al, [es:si]
+    call tp_isalpha
+    jc .tesc
+    ; named: textbackslash -> '\'; hline skipped
+    mov di, tp_cmd
+    xor cx, cx
+.tn:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .td
+    mov al, [es:si]
+    call tp_isalpha
+    jc .td
+    cmp cx, 24
+    jae .td
+    mov [di], al
+    inc di
+    inc word [tp_si]
+    inc cx
+    jmp .tn
+.td:
+    mov byte [di], 0
+    mov si, tp_cmd
+    mov di, tp_cn_bsl
+    call tp_streq
+    jne .lp
+    mov al, '\'
+    jmp .tadd
+.tesc:
+    inc word [tp_si]
+    ; fall through, AL is the escaped char
+.tadd:
+    push bx
+    xor bh, bh
+    mov bl, [tp_clen]
+    cmp bl, 70
+    jae .tad2
+    mov [tp_linebuf+bx], al
+    inc byte [tp_clen]
+    inc bx
+    mov byte [tp_linebuf+bx], 0
+.tad2:
+    pop bx
+    jmp .lp
+.com:
+.cs:
+    mov si, [tp_si]
+    cmp si, [tp_se]
+    jae .lp
+    mov al, [es:si]
+    inc word [tp_si]
+    cmp al, 10
+    je .lp
+    jmp .cs
+.fin:
+    cmp byte [tp_clen], 0
+    je .grid
+    call tp_tab_cell
+.grid:
+    ; restore y to bottom
+    mov ax, [tp_tmp2]
+    sub ax, 8
+    mov [tp_y], ax
+    call tp_tab_grid
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; emit current cell at col BX, row top tmp2
+tp_tab_cell:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    ; BX counts the & separators in the ROW, and nothing in a .TEX file makes a
+    ; row agree with the \begin{tabular}{...} preamble - so a row with more
+    ; cells than there are columns arrives here with BX past the end of both
+    ; tp_colw (TP_COL_MAX words) and tp_colk. tp_tab_note already refuses to
+    ; WRITE past them; this is the reading side, and unclamped it walks off both
+    ; and lays the cell out from whatever follows in the bss. Extra cells stack
+    ; up in the last column, which is what the eye expects from a ragged row.
+    cmp bx, TP_COL_MAX
+    jb .col
+    mov bx, TP_COL_MAX - 1
+.col:
+    ; x = left + sum of prior colw
+    mov ax, [tp_left]
+    xor si, si
+    mov cx, bx
+    jcxz .x
+.add:
+    add ax, [tp_colw+si]
+    add si, 2
+    loop .add
+.x:
+    add ax, [tp_tabsep]
+    ; alignment
+    mov cl, [tp_colk+bx]
+    push ax
+    mov si, tp_linebuf
+    call tp_strlen
+    mov cx, ax
+    call tp_charw
+    mov dl, al
+    xor dh, dh
+    mov ax, cx
+    mul dx
+    mov dx, ax                  ; text w
+    pop ax
+    mov ch, [tp_colk+bx]
+    cmp ch, 'c'
+    je .c
+    cmp ch, 'r'
+    je .r
+    jmp .put
+.c:
+    push ax
+    mov ax, bx
+    shl ax, 1
+    mov si, ax
+    mov ax, [tp_colw+si]
+    sub ax, [tp_tabsep]
+    sub ax, [tp_tabsep]
+    sub ax, dx
+    jns .c2
+    xor ax, ax
+.c2:
+    shr ax, 1
+    pop si
+    add ax, si
+    jmp .put
+.r:
+    push ax
+    mov ax, bx
+    shl ax, 1
+    mov si, ax
+    mov ax, [tp_colw+si]
+    sub ax, [tp_tabsep]
+    sub ax, [tp_tabsep]
+    sub ax, dx
+    jns .r2
+    xor ax, ax
+.r2:
+    pop si
+    add ax, si
+.put:
+    mov si, tp_linebuf
+    cmp byte [si], 0
+    je .o
+    ; PDF y is the top of the 8px run. Hang it a few points
+    ; under the top rule, not on the bottom rule.
+    mov bx, [tp_tmp2]
+    sub bx, 5
+    call tp_put_run_at
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+tp_tab_grid:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov ax, [tp_tabtop]
+    sub ax, [tp_tabbot]
+    cmp ax, 8
+    jae .hh
+    mov ax, 8
+.hh:
+    mov dx, ax
+    mov ax, [tp_left]
+    mov bx, [tp_tabbot]
+    mov cx, [tp_tabw]
+    or cx, cx
+    jnz .ww
+    mov cx, 120
+.ww:
+    call tp_emit_box
+    mov ax, [tp_left]
+    xor si, si
+.v:
+    cmp si, [tp_tabn]
+    jae .hs
+    push ax
+    push si
+    shl si, 1
+    add ax, [tp_colw+si]
+    mov bx, [tp_tabbot]
+    mov cx, 1
+    mov dx, [tp_tabtop]
+    sub dx, [tp_tabbot]
+    call tp_emit_box
+    pop si
+    pop ax
+    push si
+    shl si, 1
+    add ax, [tp_colw+si]
+    pop si
+    inc si
+    jmp .v
+.hs:
+    mov ax, [tp_rowh]
+    or ax, ax
+    jnz .hr0
+    mov ax, 16
+    mov [tp_rowh], ax
+.hr0:
+    mov ax, [tp_tabtop]
+    sub ax, [tp_rowh]
+.hr:
+    cmp ax, [tp_tabbot]
+    jle .o
+    push ax
+    mov bx, ax
+    mov ax, [tp_left]
+    mov cx, [tp_tabw]
+    mov dx, 1
+    call tp_emit_box
+    pop ax
+    sub ax, [tp_rowh]
+    jmp .hr
+.o:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; ---- strings used by parser -------------------------------------------------
+tp_s_spch:      db ' ', 0
+tp_s_amp:       db '&', 0
+tp_s_dash:      db '--', 0
+tp_s_abs:       db 'Abstract', 0
+tp_s_chap:      db 'Chapter ', 0
+tp_s_bullet:    db '*', 0
+tp_s_lbr:       db '[', 0
+tp_s_rbr:       db ']', 0
+tp_s_bsl:       db '\', 0
+tp_s_tex:       db 'TeX', 0
+tp_s_latex:     db 'LaTeX', 0
+tp_s_today:     db 'August 2026', 0
+tp_s_endtab:    db 'end{tabular}', 0


### PR DESCRIPTION
Brings in the contributed **TeXPad** as a shipped package. Source on the left, the typeset page on the right, F5 sets it, and **File > Export** writes a PDF 1.4 or a PostScript Level 1 file that a reader on another machine opens. No kernel change of any kind — it builds against the current SDK as-is, which is the claim §20 exists to make good.

`SPEC.md` §66 is the contract. `apps/texpad/GUIDE.TEX` is the markup written up as a document TeXPad sets, so the manual for the dialect is a worked example of it.

## Where it ships

The ordinary apps disk, not one of its own. Word and Frotz each got a disk (§65.5, §61.9) because each needs *documents* beside it and Word alone is 43KB; TeXPad plus its two `.TEX` files is 23KB, so the 360KB floppy still has **62 free clusters** with it aboard. The documents ride `MEDIA/` for §38.10's reason — that is where a File > Open starts — and both are associated, so a double-click on either opens TeXPad on it.

## Review findings, fixed

**Memory safety.** Five, of which the first two escape the app's own bss:

- **`tp_open_gap` could walk ~64KB backwards over the claim heap.** It derives the tail to move as `srclen - cur`, which underflows when the caret is past the end, and the `std`/`rep movsb` under it then crosses the whole segment the 8KB source claim sits in. Reachable: `tp_crlf_fix` collapses CR LF across the buffer and knows nothing about the caret, so pasting CRLF text at the end of a document left the caret past `srclen` and the next keystroke did it. Fixed at both ends.
- **`tp_pdf_patch5` wrote five bytes past the 24KB export claim.** It is the one write into that buffer that doesn't go through `tp_xw_al`'s bound, and `tp_xw_al` saturates rather than growing — so on a document that fills the buffer, the digits it came back to patch were never there. Bounded; and the export now *refuses* a saturated buffer (`Export too large` — a string already in the binary and never wired up) instead of writing a PDF whose xref offsets point at bytes that were never written.
- `tp_plain_arg` copied up to 180 bytes of `\title{...}` into an 82-byte buffer; the `\section` / `\subsection` builders copied a document title into a 48-byte one with an unbounded copy. All now carry a ceiling **at the copy**, as a named constant beside it — the bss here is a hand-laid map of offsets that nothing cross-checks.
- `tp_tab_cell` indexed the column arrays by the cell count of the *row*, which no `.TEX` file makes agree with the `tabular` preamble.
- A paste advanced by what `CLIP_SIZE` promised rather than what `CLIP_GET` copied — the clipboard is the desktop's, and this app is pre-empted between the two calls.

**Found by running it.** The status strip read `0/8190` under a document plainly not empty (the deferred load repainted the source pane only); fixing that exposed `tp_paint` taking the window in SI while the caret routines *return* a source offset in SI, which painted a second set of chrome over the menu bar. PostScript export of `PAPER.TEX` didn't fit 24KB and was silently truncated — the writer re-selected the face in front of every run instead of on change, 38 bytes each; it's 13,939 bytes now against a 15,095-byte PDF. And every `%%Page:` carried its ordinal as `32`, because `mov al, ' '` leaves `AX = 0x0020`.

**Also:** ~900 lines of unreachable code removed (the `tp_flow_*` live-preview family the typesetter superseded, plus four orphans) — 21,913 → 19,930 bytes, and a second TeX parser gone from the tree. About card trimmed to the app and its contributor, in the shape `apps/paint` and `apps/modplug` use it.

## Testing

All three adapters (§39): VGA 640×480, Hercules 720×348 via docs/HERCULES-TESTING.md's framebuffer read-back, and CGA 640×200 where the window template is taller than the screen. Launch by `.TEX` association, deferred load, typeset, edit, copy/paste, both exports, and the 360KB disk. The exported PDF renders through CoreGraphics and is structurally sound — 10 objects for 3 pages, xref consistent, `%%EOF`. `make` is clean, `checkdocs` passes, all three apps disks verify.

Left out of scope deliberately: the upstream tree's host-side Python twin of the dialect (`tex2pdf.py` + `pdfv1.py`, ~2,400 lines), which would be a second implementation to keep in sync by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)