### PR TITLE
Word: proportional metrics, and the fast path that drew in Pica anyway (§65.13, §65.13.1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -44869,6 +44869,20 @@ width is rounded up to a multiple of 8. And `ty_flush` may answer CF=1 (a
 back to lettering the row in the 8×8 face; because the *measuring* side goes
 through face 0 either way, that fallback needs no second layout.
 
+**What the metrics cost, said plainly.** Three things got more expensive and
+none of them is free. The walk now asks `ty_advof` once a character instead of
+adding a literal 8 — a table lookup and a `call`/`ret`, against a pen that used
+to move in one instruction. `wd_wordfit` sums those advances instead of counting
+down a register, so the wrap lookahead pays the same per character of the word
+it measures. And `[wd_rcols]` is sized from `TY_MINADV`, which roughly **doubles
+it** on a fullscreen window — so `wd_rstart`'s two `rep stosb` and the delta
+diff's cell-by-cell compare each walk twice as many cells as they did in the
+kernel's cell, whether or not the row is that long. All of it is per-character
+work on a path that already costs a `gfx` call per row, and none of it changes
+the number of DRAWING calls a row makes, which is what PERFORMANCE.md prices a
+redraw by — but it is real, it is paid on the target machine, and it is paid
+only while a face is chosen.
+
 **A keystroke costs more in a proportional face and the reason is inherent.**
 Changing one character in a fixed cell moves that cell's pixels; changing one in
 a proportional face **re-flows every cell after it**, so the damage runs from the
@@ -44906,17 +44920,88 @@ because the failure looks nothing like its cause — the last painted frame is
 intact and correct, including the caption the handler had just changed, so the
 screen shows a working program and the clock is what says otherwise.
 
-**What has landed, and what has not.** The library, the face file, `wd_cx`,
-`wd_xc`, `wd_px[]`, the raised `WD_MAXCOL`, the discovery and the Font combo are
-in, and **`[wd_prop]` is 0**: bss arrives zeroed, so a build with no face file, a machine
-whose kernel refuses the band blit, and today's tree all behave exactly as they
-did. **`WD_PROPDRAW` is 1: a chosen face is what the document is SET in.** The
+**What has landed.** All of it. The library, the face file, `wd_cx`, `wd_xc`,
+`wd_px[]`, the raised `WD_MAXCOL`, the discovery, the Font combo, the band draw
+and the metrics. **`[wd_prop]` is 0 until a face is picked** — bss arrives
+zeroed, so a build with no face file, a machine whose kernel refuses the band
+blit, and a document nobody has set all behave exactly as they always did.
+**`WD_PROPDRAW` is 1: a chosen face is what the document is SET in.** The
 dropdown re-letters the whole note — every row, every run — and switching back
 to Pica re-letters it in the kernel's cell. What each face costs the layout is
-its own `rows` and `leading`: an 8-row face changes **nothing** (same pitch,
-same caret, same clicks, only the glyph shapes move), and a taller one moves the
-row advance through `[wd_ghb]` and raises `[wd_hasfmt]` so the non-uniform-row
-paths that line spacing already needed do the work.
+its own `rows` and `leading`: a taller face moves the row advance through
+`[wd_ghb]` and raises `[wd_hasfmt]` so the non-uniform-row paths that line
+spacing already needed do the work.
+
+**`[wd_pxon]` is `[wd_prop]`, and it is set in `wd_facemetrics` beside the
+glyph band.** One flag says "`wd_px[]` is the truth", every cell-to-pixel
+question goes through `wd_cx`/`wd_xc`, and the two faces differ in those two
+routines rather than in thirty. Five things follow it, and each is where a
+pitch used to be assumed:
+
+- **the pen advances by `ty_advof`**, not by 8, and by the advance of the
+  character that is DRAWN — so the small-caps case map (§65.1) happens before
+  the advance is taken and not inside the drawing gate below it. That single
+  choice is what makes `ty_putn`'s pen inside a band agree with `wd_px[]`
+  outside it: the band composes from the run's first cell, so if the walk
+  advanced by anything else the two would disagree by a pixel a glyph
+- **the wrap rule measures pixels.** `wd_wordfit`'s two thresholds — what is
+  left of this row, and what a fresh row of this paragraph would hold — are
+  pixel sums over `ty_advof` rather than cell counts, and `wd_rowmeasure`
+  answers the centre/right dry run in pixels for the same reason. `wd_tabw` is
+  pixel arithmetic in both faces (a tab stop is every `WD_TABSTOP`×8 pixels
+  from the row's own start pen), which is bit-identical to the cell version it
+  replaces whenever the pen is a multiple of 8
+- **a TAB is ONE cell** in a proportional face, wearing the tab's dress and
+  carrying the whole gap as its advance — against the fixed face's run of
+  space cells. That is the consequence named above, and it is why the row
+  buffer holds characters rather than screen columns
+- **the click's half-cell is a half-ADVANCE.** `wd_ask` splits the character at
+  `DI + adv/2`, so click-to-caret lands on the nearer edge of a 4-pixel `i` and
+  of an 8-pixel `m` alike
+- **`[wd_rcols]` is sized from `TY_MINADV`**, not from 8: a row of narrow
+  glyphs holds more cells than it holds byte columns, and the row buffer, its
+  padding and the delta diff are all bounded by it
+
+**The tail of a row is erased in pixels, once.** A fixed row erases itself: the
+buffer is space-padded to `[wd_rcols]` and one opaque run covers the band. A
+proportional row cannot pad, because a cell past the row's content has no pen —
+so `wd_rflush` clamps the span to the cells the walk actually stored, and where
+the row's glyphs used to reach further than they now do, ONE white fill covers
+the difference. `[wd_prowrx]` banks that right edge beside `wd_prow`, and a row
+whose cache describes some other row erases to the paragraph's right edge
+instead. It costs one `gfx_fill` on a row that SHRANK and nothing at all on a
+row that grew, which is the common case: typing. The band-level right-margin
+fill in `wd_redraw` is skipped outright for the same reason — `[wd_rcols]` is a
+count sized from `TY_MINADV` there and `8 ×` it is not a pixel coordinate.
+
+**And the SPAN GROWS OUTWARDS TO BYTE COLUMNS before it is drawn.** This is
+§5.4.2's back-up rule read the other way round. The band is blitted by whole
+byte columns and is paper where nothing was composed, so a run whose first cell
+starts mid-byte whitens up to 7 pixels of the glyph to its LEFT, and one whose
+last cell ends mid-byte does the same on its right. At the *row's* own edges
+that is exactly what `FONT_RUN`'s background would have done; between two
+neighbouring cells it rubs out ink that nothing is going to put back. In the
+kernel's cell the question never arose — every cell edge is a multiple of 8 —
+and the first proportional build showed it as a keystroke eating the tail of the
+character before it, one pixel column at a time. `wd_rflush` walks `[wd_flo]`
+down and `[wd_fhi]` up until both edges land on a multiple of 8; it costs a
+neighbouring cell or two redrawn and erases none.
+
+That leaves ONE case unhandled and it is written down rather than fixed: a row
+carrying **several different CHPs** is several runs, each with its own band, and
+the interior boundaries between them are not byte-aligned. Run *n* can therefore
+whiten up to 7 pixels of run *n−1*'s last glyph. The obvious repair — one band
+for the whole row, composed run by run and blitted once — was written and
+reverted: it hangs, and the cause is not yet understood, so what ships is the
+per-run band that has always shipped. Plain text, which is every run of a
+document nobody has styled, is one run and is unaffected.
+
+**Two fast paths refuse a chosen face outright.** `wd_append` (§27.14.1) patches
+one glyph and one caret onto the glass without walking, and `wd_brktry`
+(§27.12) scrolls a row band by whole cells; both do column arithmetic in
+multiples of 8 and both drew through the kernel's cell. They now test
+`[wd_pxon]` and fall back to the walk. This is the third bug below and the one
+that was actually reported.
 
 **Bold is a second compose, not a second call.** The cell arm strikes the run
 again one pixel right with an `OSAPI_FONT_STR`; the band arm composes it again
@@ -44928,14 +45013,7 @@ different typeface from the words either side of it — which reads as a bug rat
 than as italic. Upright in the right face is the better wrong answer until a face
 carries a drawn italic (§6.4's style 2).
 
-**The metrics are still the 8-pixel grid.** `[wd_pxon]` is 0: the wrap rule, the
-accumulate walk's cell index and `wd_px[]` are unconverted, so a proportional
-face is set at fixed pitch — its shapes, its height, its leading, but eight
-pixels a character. That is the remaining half of this section, and it is
-separable precisely because `wd_cx`/`wd_xc` already stand between every call site
-and the answer.
-
-#### 65.13.1 Two bugs this cost, both worth writing down
+#### 65.13.1 Four bugs this cost — three fixed, one open — all worth writing down
 
 **A literal that becomes a variable must be initialised before anything reads
 it.** `[wd_gh1]` — the glyph band's height less one, which replaced a hard `7` at
@@ -44954,6 +45032,73 @@ looking: the bands landed at exactly the right x, width, y and height on every
 row, which proved the whole rendering path correct and left the caller as the
 only suspect. **When a change touches a drawing path, make the path
 unconditional and look at it before theorising about who calls it.**
+
+**A FAST PATH IS A SECOND DRAWING PATH, and a face has to reach it too.** The
+half-converted state above shipped, and what it was reported as is neither of
+the things it was known to be: *"I can change the font used by the document, but
+when I start typing, the font used is not the one from the selected list."*
+`wd_append` (§27.14.1) is the reason. It is the whole point of §27.14.1 that a
+printable typed at the end of a line does not walk the note — it stamps the one
+glyph and moves the one caret — and it stamped it with `OSAPI_FONT_RUN`, which
+is the kernel's 8×8 cell and nothing else. Its guards were all about
+*geometry* (`[wd_hasfmt]`, hidden characters, tabs), and a face changes the
+GLYPHS without necessarily changing the geometry: `tallx` is 8 rows with an
+advance of 8, so it raises no flag any of those guards test, and every
+character typed at the end of a line in it came out in Pica while every
+character the walk redrew came out in tallx. A 12-row face hid it — `[wd_ghb]`
+≠ 8 raises `[wd_hasfmt]`, which refused the fast path for an unrelated reason —
+so the defect was invisible in nine of the ten faces on the disk and total in
+the tenth.
+
+Three lessons, and the last generalises past this program. A guard list that
+enumerates *what makes the geometry unusual* does not answer *what makes the
+pixels unusual*. A flag tested as a proxy — `[wd_hasfmt]` standing in for "this
+is not the plain 8×8 engine" — is a guard that holds only while the proxy
+happens to be exact, and nothing tells you the day it stops being. And **a
+screendump of the common case proves nothing**: nine faces looked right.
+
+**FINDING EVERY SITE OF A LITERAL IS THE OTHER HALF OF THE FIRST BUG ABOVE —
+and this one is NOT FIXED.** `[wd_gh1]` was found because the note vanished. Its
+siblings were not: `wd_walk` sets the y of the row a walk STARTS on, and it is
+`wd_advy`'s three arms written out longhand — `.yzero` (`ty + h − 8`), `.ynegs`
+(`ty − 8`) and `.yhave`'s `[wd_rbandt]` (`bp − h + 8`) — each carrying a literal
+8 where `wd_advy` had already learned to read `[wd_gh]`. `wd_advblank` steps a
+blank row 8 pixels where a real one steps `[wd_ghb]`; `wd_seecaret`, `wd_redraw`,
+`wd_shiftrows`, `wd_mclose` and `wd_scrollpaint` each derive a band top or a band
+bottom from `wd_ryb` with a literal `8` or `7`.
+
+**The symptom is §65.6's leading-gap fill eating the row above.** `wd_rflush`
+whitens `[wd_rbandt] .. rby−1` to clear a spaced row's gap; a band top `gh − 8`
+pixels too high puts that fill *inside the row above*, so **every keystroke
+shaves the bottom off the line before it** — reported, exactly, as the new line
+overlapping the old one. It is worst where the face has no leading: `jetbrain`
+and `courier` are 14 rows with `leading 0`, so the band IS the advance and
+nothing absorbs the 6-pixel error; `times` and `helv` (12 rows, `leading 2`)
+lose 4 pixels and merely look tight; the kernel's 8×8 cell has `gh = 8` and
+loses nothing, which is why it shipped and why §65.13's own testing missed it.
+
+**What was tried.** Converting the sites — `.yzero`, `.ynegs`, `.yhave`,
+`wd_advblank` and five of the `wd_ryb` derivations — DOES fix the shaving:
+verified in `jetbrain`, `courier` and `times`, typing and Enter, on VGA and CGA,
+with the kernel's cell staying pixel-identical. It also moves **every row's y**,
+which is exactly the input to §65.6's rows-MOVED repaint, and in that state some
+sequences leave earlier rows erased and never redrawn. No variant tried both
+fixed the shaving and kept the incremental repaint honest: the band top alone
+leaves the origin disagreeing with it, and the origin too puts the banked
+`wd_ryb` a face-height away from what the last pass drew. **A half-converted
+height model is worse than an unconverted one**, which is §65.13's own rule
+about `[wd_prop]` applied to y instead of x, so none of it is in the tree.
+
+Whoever takes it next: the conversion is right and the fix is those sites, but
+it has to arrive with `[wd_vrows]` (which counts 8-pixel rows into a band that
+holds 14-pixel ones), `wd_advblank` and `wd_scrollpaint`'s scroll delta in the
+same change, and it has to be tested by *switching faces on a note that already
+has rows* — not by typing into an empty one. And **the lesson is not "use the
+variable"**: it is that a variable replacing a literal has to be hunted by
+VALUE, not by meaning. `8` in this file is a glyph height, a row advance, a cell
+width, a tab stop and a byte column, and only a handful of the dozens of them
+are the height. Nothing but reading each one tells them apart, and a face whose
+height differs from its advance is the only test that separates them.
 
 ## 66. TeXPad — the TeX pad (`apps/texpad/texpad.asm`)
 

--- a/apps/word/word.asm
+++ b/apps/word/word.asm
@@ -290,24 +290,17 @@ WD_CHROME_TOP equ WD_MENU_H + WD_RIBBON_H + WD_RULER_H   ; 48, all strips ON.
 WD_M_N       equ 9              ; menus on the bar
 ; WD_PROPDRAW - is a chosen face DRAWN, or only opened and named?
 ;
-; 0 while SPEC.md 65.13's conversion is unfinished, and this is the switch it
-; finishes at. What works: the face opens, the ribbon names it, wd_bandrun
-; composes and emits a run through SPEC.md 6.3's band, and the row advance and
-; glyph band follow the face's own rows via [wd_gh]/[wd_ghb]. What does NOT,
-; measured by turning this on and looking:
+; 1, and SPEC.md 65.13's conversion is finished behind it: the face opens, the
+; ribbon names it, wd_bandrun composes and emits a run through SPEC.md 6.3's
+; band, the row advance and glyph band follow the face's own rows via
+; [wd_gh]/[wd_ghb], and [wd_pxon] makes wd_px[] the truth about where a cell
+; sits - so the pen advances by ty_advof, the wrap rule measures pixels and a
+; click splits a character at half its own advance.
 ;
-;   1. the chrome doubles - the content geometry moves under the bar and the
-;      strips, and repainting them the way a View toggle does is not enough;
-;      wd_ctcalc/wd_bounds have to be understood first
-;   2. the rows redraw but the glyphs stay the 8x8 cell's, so ty_flush is
-;      refusing or the band is arriving empty - unproven either way
-;   3. the metrics are still the 8-pixel grid ([wd_pxon] is 0): the wrap rule,
-;      the accumulate walk's cell index and wd_px[] are not converted
-;
-; A half-converted Word is worse than an unconverted one - it draws in one
-; face and measures in another - so this stays 0 until all three are done, and
-; the code above it stays in the tree because it assembles and is most of the
-; way there.
+; The switch stays because it is the one place to stand a whole face's worth of
+; drawing down from, and because a half-converted Word is worse than an
+; unconverted one: it draws in one face and measures in another. That state
+; DID ship once and SPEC.md 65.13.1 records what it was reported as.
 ;
 ; %assign AND NOT equ, and that distinction cost a whole debugging round: `%if`
 ; is a PREPROCESSOR directive and an `equ` is an ASSEMBLER symbol, so `%if
@@ -1803,13 +1796,22 @@ wd_bounds:
                                     ; it stays right under WF_FULL, where the
                                     ; frame IS the content (SPEC.md 11.2)
 
-    mov ax, [wd_rgt]                ; whole 8px CELLS between the pen and the
-    sub ax, [wd_tx]                 ; right edge: the width of one opaque run,
-    inc ax                          ; and what the row buffer is padded to
+    mov ax, [wd_rgt]                ; whole CELLS between the pen and the right
+    sub ax, [wd_tx]                 ; edge: the width of one opaque run, and
+    inc ax                          ; what the row buffer is padded to
     jns .cok
     xor ax, ax
 .cok:
     mov cl, 3
+    cmp byte [wd_pxon], 0           ; ...and a CELL is 8 pixels in the kernel's
+    je .cshr                        ; cell and as little as TY_MINADV in a
+    mov cl, 2                       ; chosen face (SPEC.md 6.4), so a row of
+                                    ; narrow glyphs holds more cells than it
+                                    ; holds byte columns. WD_MAXCOL was sized
+                                    ; from that floor and not from the face -
+                                    ; the face comes off a floppy while the
+                                    ; constant is in the tree (SPEC.md 65.13)
+.cshr:
     shr ax, cl
     cmp ax, WD_MAXCOL - 1
     jbe .csave
@@ -2061,6 +2063,19 @@ wd_papload:
     mov dx, [wd_rcols]
 .cok:
     mov [wd_wcols], dx
+    cmp byte [wd_pxon], 0           ; ...and the same capacity in PIXELS, which
+    jne .wpx                        ; is what wd_wordfit's second threshold
+    shl dx, cl                      ; measures now (SPEC.md 65.13). The fixed
+    jmp short .wpxs                 ; face takes exactly 8 x the cells, so its
+.wpx:                               ; wrap is the one it always had
+    mov dx, [wd_wrgt]
+    inc dx
+    sub dx, [wd_tx]
+    sub dx, [wd_wleftpx]
+    jns .wpxs
+    xor dx, dx
+.wpxs:
+    mov [wd_wcpx], dx
     mov al, [es:bx+2]               ; first-line, SIGNED, clamped so the pen
     cbw                             ; lands in [tx .. wrgt-7]
     shl ax, cl
@@ -2106,6 +2121,21 @@ wd_papload0:
     mov [wd_wrgt], ax
     mov ax, [wd_rcols]
     mov [wd_wcols], ax
+    cmp byte [wd_pxon], 0           ; the fresh-row capacity in pixels, exactly
+    jne .wpx                        ; as wd_papload derives it
+    push cx
+    mov cl, 3
+    shl ax, cl
+    pop cx
+    jmp short .wpxs
+.wpx:
+    mov ax, [wd_rgt]
+    inc ax
+    sub ax, [wd_tx]
+    jns .wpxs
+    xor ax, ax
+.wpxs:
+    mov [wd_wcpx], ax
     pop ax
     ret
 
@@ -2212,21 +2242,15 @@ wd_tabw:
     push cx
     push dx
     mov ax, di
-    sub ax, [wd_rowx0]
-    mov cl, 3
-    shr ax, cl                      ; cells consumed on this row
-    mov cx, ax
-    xor dx, dx
-    mov ax, cx
-    push cx
-    mov cx, WD_TABSTOP
-    div cx
-    inc ax
-    mul cx                          ; the next stop, cells
-    pop cx
-    sub ax, cx
-    mov cl, 3
-    shl ax, cl
+    sub ax, [wd_rowx0]              ; PIXELS consumed on this row, not cells:
+    xor dx, dx                      ; a proportional row's pen is not a
+                                    ; multiple of 8 and flooring it to one
+    mov cx, WD_TABSTOP * 8          ; loses the remainder - the tab then lands
+    div cx                          ; short of its stop by up to 7px and the
+    inc ax                          ; column walks. Identical to the cell
+    mul cx                          ; arithmetic this replaces whenever the pen
+    sub ax, di                      ; IS a multiple of 8, which is every row of
+    add ax, [wd_rowx0]              ; the fixed face
     pop dx
     pop cx
     ret
@@ -2333,8 +2357,15 @@ wd_facemetrics:
     dec ax
     mov [wd_gh1], ax
     mov word [wd_ghb], 8
-    cmp byte [wd_prop], 0
-    je .out
+    mov word [wd_spadv], 8          ; ...and a space is 8 wide in it
+    mov al, [wd_prop]               ; ...and the METRICS follow the face too
+    mov [wd_pxon], al               ; (SPEC.md 65.13): one flag, read by wd_cx
+    cmp byte [wd_prop], 0           ; and wd_xc, and by the two fast paths that
+    je .out                         ; cannot be expressed without an 8px column
+    mov al, ' '                     ; the padding cell's own width, banked: the
+    call ty_advof                   ; row buffer pads with spaces and wd_pxcell
+    xor ah, ah                      ; extrapolates the caret's parking cell by
+    mov [wd_spadv], ax              ; exactly this
     call ty_getrows
     xor ah, ah
     mov [wd_gh], ax
@@ -2346,11 +2377,13 @@ wd_facemetrics:
     call ty_getlead
     xor ah, ah
     add [wd_ghb], ax
-    cmp word [wd_ghb], 8            ; ...and ONLY a face whose row advance is
-    je .out                         ; not 8 needs the non-uniform paths. An
-    mov byte [wd_hasfmt], 1         ; 8-row face changes no geometry at all -
-.out:                               ; same pitch, same caret, same clicks, and
-                                    ; only the glyph shapes move
+    cmp word [wd_ghb], 8            ; ...and only a face whose row advance is
+    je .out                         ; not 8 needs the non-uniform-ROW paths. An
+    mov byte [wd_hasfmt], 1         ; 8-row face still lands every row where it
+.out:                               ; always did - what its glyphs no longer do
+                                    ; is land on the 8-pixel COLUMN, and that
+                                    ; is [wd_pxon]'s business above and not
+                                    ; this flag's (SPEC.md 65.13)
     pop ax
     ret
 
@@ -2536,10 +2569,10 @@ wd_xc:
 .prop:
     xor bx, bx
 .w:
-    cmp bx, [wd_rcols]
-    jae .have
-    push bx
-    shl bx, 1
+    cmp bx, [wd_rcn]                ; ...the cells the WALK stored, not the
+    jae .have                       ; buffer's capacity: wd_px past the row's
+    push bx                         ; own content is the last row's pens and
+    shl bx, 1                       ; describes nothing on this one
     mov cx, [wd_px + bx + 2]        ; ...the NEXT cell's pen: x belongs to
     pop bx                          ; cell k while it is short of cell k+1
     cmp ax, cx
@@ -2551,6 +2584,133 @@ wd_xc:
 .out:
     pop cx
     pop bx
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_advof - the advance of one character, in pixels (SPEC.md 65.13)
+; in:  AL = the character AS DRAWN (small caps already mapped)
+; out: AX = its advance; preserves every other register
+;
+; 8 in the kernel's cell, the face's own otherwise - and the face's own is the
+; number ty_putn will step by when the band composes this very character, which
+; is the whole of why wd_px[] and the drawn glyphs agree.
+; -----------------------------------------------------------------------------
+wd_advof:
+    cmp byte [wd_pxon], 0
+    jne .prop
+    mov ax, 8
+    ret
+.prop:
+    call ty_advof                   ; AL = the advance, AH untouched
+    xor ah, ah
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_scapof - small caps: the character as it is DRAWN (SPEC.md 65.1)
+; in:  AL = the character, AH = its CHP byte; out: AL mapped; preserves the rest
+;
+; The map used to live inside wd_walk's drawing gate, because the only thing it
+; changed was which glyph went into the row buffer. It changed the WIDTH too the
+; moment a face arrived, and a width the gate can skip is a pen that disagrees
+; with the pixels - so it is a helper now, called before the advance is taken
+; and by the dry run as well.
+; -----------------------------------------------------------------------------
+wd_scapof:
+    test ah, WDAT_SCAP
+    jz .out
+    cmp al, 'a'
+    jb .out
+    cmp al, 'z'
+    ja .out
+    sub al, 32
+.out:
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_penadv - the advance of the character the walk is ABOUT to take
+; in:  ES:SI -> it, BX = characters left; out: AX = pixels; preserves the rest
+;
+; The wrap rule and the click's half-cell both need the width of the cell this
+; index WILL occupy, before it has been consumed. A newline or a tab answers 8:
+; neither is measured here (a tab goes to wd_tabw and a newline ends the row),
+; and 8 is what the fixed face asked for both.
+; -----------------------------------------------------------------------------
+wd_penadv:
+    cmp byte [wd_pxon], 0
+    jne .prop
+.eight:
+    mov ax, 8
+    ret
+.prop:
+    or bx, bx
+    jz .eight
+    mov al, [es:si]                 ; THE DOCUMENT IS ES:SI (SPEC.md 27.6)
+    cmp al, 13
+    je .eight
+    cmp al, 9
+    je .eight
+    call ty_advof                   ; preserves BX, and AH with it
+    xor ah, ah
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_cellat - the cell index the pen is standing on (SPEC.md 65.13)
+; out: BX = it; preserves every other register
+;
+; COUNTED in a proportional face and DERIVED in the fixed one, which is the one
+; place the accumulate walk had to change: (DI - [wd_tx]) >> 3 needs a divisor
+; the face does not have. The count is [wd_rcn], kept by wd_pxcell below.
+; -----------------------------------------------------------------------------
+wd_cellat:
+    cmp byte [wd_pxon], 0
+    jne .prop
+    push cx
+    mov bx, di
+    sub bx, [wd_tx]
+    mov cl, 3
+    shr bx, cl
+    pop cx
+    ret
+.prop:
+    mov bx, [wd_rcn]
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_pxcell - record the cell at the pen and count it (SPEC.md 65.13)
+; in:  BX = the cell (wd_cellat), DI = the pen, AX = the cell's advance
+; out: wd_px[BX..BX+2] written, [wd_rcn] = BX+1; preserves every register
+;
+; THREE slots for one cell, and the third is not spare. The slot past the cell
+; makes a span's right edge a lookup rather than a special case, and the next
+; cell overwrites it with the same value, so the two can never disagree. The
+; slot past THAT is the caret's parking cell - the one index past the row's
+; last character, which wd_rflush letters a space into when a caret leaves it -
+; and it is a space's own advance wide, which is what the band will step by
+; when it composes that very space.
+; -----------------------------------------------------------------------------
+wd_pxcell:
+    cmp byte [wd_pxon], 0
+    je .out
+    cmp bx, WD_MAXCOL               ; the map is WD_MAXCOL + 3 slots, so a cell
+    ja .out                         ; at WD_MAXCOL still has two past it
+    push ax
+    push bx
+    push dx
+    mov dx, di
+    sub dx, [wd_tx]                 ; the pen, RELATIVE to the content left -
+    shl bx, 1                       ; a window that MOVES does not reflow
+    mov [wd_px + bx], dx
+    add dx, ax
+    mov [wd_px + bx + 2], dx
+    add dx, [wd_spadv]
+    mov [wd_px + bx + 4], dx
+    shr bx, 1
+    inc bx
+    mov [wd_rcn], bx
+    pop dx
+    pop bx
+    pop ax
+.out:
     ret
 
 wd_rowmeasure:
@@ -2569,8 +2729,10 @@ wd_rowmeasure:
     mov al, [es:si]
     cmp al, 13
     je .done
-    mov cx, di
-    add cx, 7
+    call wd_penadv                  ; the cell this index will occupy, which is
+    mov cx, di                      ; 8 wide in the kernel's cell and the
+    add cx, ax                      ; face's own otherwise (SPEC.md 65.13)
+    dec cx
     cmp cx, [wd_wrgt]
     ja .over
     call wd_wordfit
@@ -2582,8 +2744,12 @@ wd_rowmeasure:
 .take:
     cmp al, 9
     je .tab
-    cmp byte [wd_hashid], 0         ; hidden occupies no cell (SPEC.md 65.1)
-    je .vis
+    xor ah, ah                      ; the cell's dress. Fetched when the note
+    cmp byte [wd_hashid], 0         ; carries hidden text - which is what this
+    jne .chp                        ; dry run always needed it for - and in a
+    cmp byte [wd_pxon], 0           ; chosen face as well, because small caps
+    je .vis                         ; measures as the CAPITAL there and the
+.chp:                               ; live walk draws it as one
     push es
     push bx
     mov bx, si
@@ -2591,11 +2757,14 @@ wd_rowmeasure:
     mov ah, [es:bx]
     pop bx
     pop es
-    test ah, WDAT_HID
+    test ah, WDAT_HID               ; hidden occupies no cell (SPEC.md 65.1)
     jnz .adv0
 .vis:
-    add di, 8
-.adv0:
+    call wd_scapof
+    call wd_advof
+    add di, ax
+    mov al, [es:si]                 ; ...and the word state below reads the
+.adv0:                              ; character as TYPED, not as drawn
     mov byte [wd_wstart], 0
     cmp al, ' '
     jne .ws
@@ -2613,10 +2782,8 @@ wd_rowmeasure:
     dec bx
     jmp short .loop
 .done:
-    mov ax, di
-    sub ax, bp
-    mov cl, 3
-    shr ax, cl
+    mov ax, di                      ; PIXELS (SPEC.md 65.13), which is what the
+    sub ax, bp                      ; centre/right offset wants in either face
     pop cx                          ; the saved word state
     mov [wd_wstart], cl
     pop bp
@@ -2655,23 +2822,40 @@ wd_rowsetup:
     cmp al, 2                       ; justified renders as left (65.1)
     jne .anchor
 .meas:
-    call wd_rowmeasure              ; AX = the row's cells
+    call wd_rowmeasure              ; AX = the row's width in PIXELS
     mov dx, [wd_wrgt]
     inc dx
-    sub dx, di
-    mov cl, 3
-    shr dx, cl                      ; cells available from this pen
+    sub dx, di                      ; pixels available from this pen
     sub dx, ax
     jle .anchor                     ; full (or hanging): no offset
-    cmp byte [wd_walign], 2
-    je .roff
-    shr dx, 1                       ; centred: half the free cells
-.roff:
-    mov cl, 3
+    cmp byte [wd_pxon], 0
+    jne .poff
+    mov cl, 3                       ; the kernel's cell: whole cells, exactly
+    shr dx, cl                      ; the rounding this always did (SPEC.md
+    cmp byte [wd_walign], 2         ; 65.1) - the row is 8k wide and the offset
+    je .croff                       ; is 8k too, so the pen stays on the grid
+    shr dx, 1
+.croff:
     shl dx, cl
+    jmp short .roff
+.poff:
+    cmp byte [wd_walign], 2         ; a chosen face: PIXELS, because there is no
+    je .roff                        ; grid left to round to
+    shr dx, 1
+.roff:
     add di, dx
 .anchor:
     mov [wd_rowx0], di
+    cmp byte [wd_pxon], 0           ; cell 0's pen, before a character has been
+    je .nopx0                       ; stored: an EMPTY row still carries a
+    push ax                         ; caret, and wd_cx(0) has to answer where
+    mov ax, di                      ; it stands (SPEC.md 65.13)
+    sub ax, [wd_tx]
+    mov [wd_px], ax
+    add ax, [wd_spadv]              ; ...and cell 0 IS the parking cell there,
+    mov [wd_px+2], ax               ; so it is a space wide, as wd_pxcell has it
+    pop ax
+.nopx0:
     cmp byte [wd_hasfmt], 0
     je .nofold
     push ax                         ; fold the pen and the height into the
@@ -2883,8 +3067,10 @@ wd_walk:
 
 .loop:
     ; --- the wrap rule, applied to the cell this index will occupy ---------
-    mov cx, di
-    add cx, 7
+    call wd_penadv                  ; ...and the cell is as wide as the FACE
+    mov cx, di                      ; says, which is 8 in the kernel's cell and
+    add cx, ax                      ; the character's own otherwise (SPEC.md
+    dec cx                          ; 65.13)
     cmp cx, [wd_wrgt]               ; the paragraph's own right edge (its
     ja .over                        ; right indent; [wd_rgt] when Normal)
     call wd_wordfit                 ; ...or the WORD that begins here would run
@@ -2945,21 +3131,24 @@ wd_walk:
     mov ax, WDAT_PIL
     call wd_fold
     pop ax
-    cmp byte [wd_draw], 0
-    je .nlplain
     push ax
     push bx
     push cx
+    call wd_cellat                  ; the mark's own cell, and its pen - taken
+    mov ax, 8                       ; OUTSIDE the drawing gates below, because
+    call wd_pxcell                  ; [wd_rcn] is the cell INDEX in a chosen
+                                    ; face and a count a pass may skip is a
+                                    ; count that describes no row. 8 wide: the
+                                    ; pilcrow is a stamp, not a glyph of the
+                                    ; face (SPEC.md 65.1)
+    cmp byte [wd_draw], 0
+    je .nlpop
     mov cx, bp                      ; the same three gates the glyph store has:
-    add cx, [wd_gh1]                       ; the row fits, this pass redraws it, and
+    add cx, [wd_gh1]                ; the row fits, this pass redraws it, and
     cmp cx, [wd_bot]                ; the cell is inside the band
     ja .nlpop
     call wd_rowdirty
     jc .nlpop
-    mov bx, di
-    sub bx, [wd_tx]
-    mov cl, 3
-    shr bx, cl
     cmp bx, [wd_rcols]
     jae .nlpop
     mov byte [wd_rbuf+bx], ' '
@@ -3020,38 +3209,41 @@ wd_walk:
     jmp .loop                       ; fold above still saw it, so toggling
                                     ; hidden dirties the row
 .visible:
+    ; The character AS DRAWN and its ADVANCE, both taken before the drawing
+    ; gates below (SPEC.md 65.13). The small-caps map used to live inside them,
+    ; because the only thing it changed was which glyph reached the row buffer;
+    ; it changes the WIDTH too the moment a face arrives, and a pen that moves
+    ; by one character while the band composes another is a row that drifts a
+    ; pixel a glyph. The pen record is outside them for the same reason: in a
+    ; chosen face [wd_rcn] IS the cell index, and a count a pass may skip is a
+    ; count that describes no row.
+    push dx
+    mov ah, [wd_cattr]
+    call wd_scapof
+    mov dl, al                      ; DL = the character as drawn...
+    call wd_advof
+    mov dh, al                      ; ...DH = its advance (a byte: SPEC.md 6.4)
+    push bx
+    call wd_cellat                  ; BX = the cell this pen occupies
+    mov al, dh
+    xor ah, ah
+    call wd_pxcell
     cmp byte [wd_draw], 0
-    je .advance
+    je .nocell
     mov cx, bp                      ; vertical clip: drop rows that overflow,
-    add cx, [wd_gh1]                       ; but keep advancing the pen so every
+    add cx, [wd_gh1]                ; but keep advancing the pen so every
     cmp cx, [wd_bot]                ; position below stays true
-    ja .advance
+    ja .nocell
     call wd_rowdirty                ; ...and drop the rows whose pixels this
-    jc .advance                     ; redraw already knows are right
-    push bx                         ; into the row buffer at this pen's CELL -
-    mov bx, di                      ; wd_rflush draws the whole row at once
-    sub bx, [wd_tx]
-    push cx
-    mov cl, 3
-    shr bx, cl
-    pop cx
+    jc .nocell                      ; redraw already knows are right
     cmp bx, [wd_rcols]
     jae .nocell                     ; past the band: the wrap rule above means
-    push ax                         ; this cannot normally happen, and a
+                                    ; this cannot normally happen, and a
                                     ; clamped wd_rcols is the case where it can
-    mov ah, [wd_cattr]              ; small caps case-map at accumulate time
-    test ah, WDAT_SCAP              ; (SPEC.md 65.1): the row buffer holds the
-    jz .nomap                       ; capital, so the delta diff and the run
-    cmp al, 'a'                     ; draw both see what the screen shows
-    jb .nomap
-    cmp al, 'z'
-    ja .nomap
-    sub al, 32
-.nomap:
-    mov [wd_rbuf+bx], al
-    mov al, ah                      ; ...and the cell's attribute beside it,
+    mov al, dl                      ; into the row buffer at this pen's CELL -
+    mov [wd_rbuf+bx], al            ; wd_rflush draws the whole row at once
+    mov al, [wd_cattr]              ; ...and the cell's attribute beside it,
     mov [wd_abuf+bx], al            ; which is what wd_rflush splits into runs
-    pop ax
     push ax
     push dx
     mov ax, [wd_i]
@@ -3080,8 +3272,10 @@ wd_walk:
     pop ax
 .nocell:
     pop bx
-.advance:
-    add di, 8
+    mov al, dh                      ; the pen moves by the advance the band
+    xor ah, ah                      ; will step by, and by nothing else
+    add di, ax
+    pop dx
     jmp .loop                       ; near: the cell-buffer store above pushed
                                     ; the loop body past a short jump's reach
 
@@ -3137,24 +3331,28 @@ wd_walk:
     mov ax, 8
 .twok:
     mov cx, ax                      ; CX = the width, held to the advance
-    cmp byte [wd_draw], 0
-    je .tadv
-    mov ax, bp                      ; the glyph-store gates, cell test aside
-    add ax, [wd_gh1]
-    cmp ax, [wd_bot]
-    ja .tadv
-    call wd_rowdirty
-    jc .tadv
     push ax
     push bx
     push dx
-    mov dx, cx                      ; DX = px still to write
-    mov bx, di
-    sub bx, [wd_tx]
-    push cx
-    mov cl, 3
-    shr bx, cl
-    pop cx                          ; BX = the first cell
+    call wd_cellat                  ; BX = the tab's first cell, taken outside
+    mov dx, cx                      ; the gates for .visible's reason. DX = the
+    cmp byte [wd_pxon], 0           ; px the store loop still owes cells
+    je .tgate
+    mov ax, cx                      ; A CHOSEN FACE GIVES A TAB ONE CELL, as
+    call wd_pxcell                  ; wide as the whole gap (SPEC.md 65.13) -
+    mov dx, 8                       ; against the kernel's cell, where it is a
+.tgate:                             ; run of space cells one per 8 pixels. That
+                                    ; is the row buffer holding characters
+                                    ; rather than screen columns, which is what
+                                    ; the delta diff wanted all along
+    cmp byte [wd_draw], 0
+    je .tcdone
+    mov ax, bp                      ; the glyph-store gates, cell test aside
+    add ax, [wd_gh1]
+    cmp ax, [wd_bot]
+    ja .tcdone
+    call wd_rowdirty
+    jc .tcdone
 .tcell:
     cmp bx, [wd_rcols]
     jae .tcdone
@@ -3391,34 +3589,41 @@ wd_wordfit:
     push dx
     push si
 
-    mov ax, [wd_wrgt]
-    inc ax
-    sub ax, di                      ; pixels left on this row, this cell first
-    jle .pop_no                     ; the caller has already tested the cell,
-    mov cl, 3                       ; so this cannot fire - but a shift of a
-    shr ax, cl                      ; negative width would answer nonsense
-    mov dx, ax                      ; DX = R, whole cells left on this row
-
+    mov ax, [wd_wrgt]               ; PIXELS throughout, in both faces (SPEC.md
+    inc ax                          ; 65.13). The fixed face's every advance is
+    sub ax, di                      ; 8 and its R was these pixels divided by
+    jle .pop_no                     ; it, so the arithmetic below is the same
+    mov dx, ax                      ; question scaled - and a chosen face has no
+    cmp byte [wd_pxon], 0           ; divisor to ask it any other way.
+    jne .rok                        ; DX = R, the pixels left on this row -
+    and dx, 0xFFF8                  ; floored to whole cells in the fixed face,
+.rok:                               ; where R WAS a cell count and [wd_wcpx] is
+                                    ; 8 x [wd_wcols]: without that the ragged
+                                    ; remainder of a window whose width is not
+                                    ; a multiple of 8 would move a break that
+                                    ; has never moved
     mov cx, dx                      ; --- does the word END inside them? -----
-.p1:                                ; THE BREAK TEST COMES FIRST, and the cell
-    or bx, bx                       ; count second: a word that exactly fills
-    jz .pop_no                      ; the space left ends on the cell after the
-    mov al, [es:si]                 ; last one it occupies, and testing the
-    cmp al, ' '                     ; count first calls that an overflow. It
-    je .pop_no                      ; is invisible at 29 columns and constant
-    cmp al, 13                      ; at 9, which is what a narrow window
-    je .pop_no                      ; showed
+.p1:                                ; THE BREAK TEST COMES FIRST, and the width
+    or bx, bx                       ; second: a word that exactly fills the
+    jz .pop_no                      ; space left ends on the cell after the last
+    mov al, [es:si]                 ; one it occupies, and testing the width
+    cmp al, ' '                     ; first calls that an overflow. It is
+    je .pop_no                      ; invisible at 29 columns and constant at 9,
+    cmp al, 13                      ; which is what a narrow window showed
+    je .pop_no
     cmp al, 9                       ; a tab ends a word too (SPEC.md 65.3)
     je .pop_no
-    jcxz .p2
-    inc si
+    call wd_penadv                  ; measured as TYPED: small caps would make
+    cmp cx, ax                      ; this word WIDER, so a word it lets by is
+    jb .p2                          ; split by the cell rule instead of broken
+    sub cx, ax                      ; in front of - the degrade, not a wrong
+    inc si                          ; break
     dec bx
-    dec cx
     jmp short .p1
 
 .p2:                                ; --- no. Would a whole row hold it? -----
-    mov cx, [wd_wcols]              ; a fresh row of THIS paragraph
-    sub cx, dx                      ; the cells a FRESH row would add
+    mov cx, [wd_wcpx]               ; a fresh row of THIS paragraph, in pixels
+    sub cx, dx                      ; the pixels a FRESH row would add
     jbe .pop_no                     ; the pen is at the left margin already
 .p2l:
     or bx, bx                       ; same order, for the same reason
@@ -3430,10 +3635,12 @@ wd_wordfit:
     je .pop_yes
     cmp al, 9
     je .pop_yes
-    jcxz .pop_no                    ; longer than a row: the cell rule owns it
+    call wd_penadv
+    cmp cx, ax
+    jb .pop_no                      ; longer than a row: the cell rule owns it
+    sub cx, ax
     inc si
     dec bx
-    dec cx
     jmp short .p2l
 
 .pop_yes:
@@ -3508,10 +3715,10 @@ wd_ask:
     mov [wd_hiti], ax               ; the first index on the row, until a
     mov byte [wd_hitset], 1         ; later cell claims it
 .hit2:
-    mov cx, di
-    add cx, 4
-    cmp [wd_hitx], cx
-    jb .want                        ; the left half: the caret goes before it
+    call wd_halfadv                 ; CX = the middle of THIS character, which
+    cmp [wd_hitx], cx               ; in a chosen face is half its own advance
+    jb .want                        ; and not half a cell: the left half puts
+                                    ; the caret before it
     call wd_isnl
     jc .want                        ; a newline has no right half
     inc ax
@@ -3529,8 +3736,7 @@ wd_ask:
     mov [wd_wanti], ax
     mov byte [wd_wantset], 1
 .want2:
-    mov cx, di
-    add cx, 4
+    call wd_halfadv
     cmp [wd_wantx], cx
     jb .out
     call wd_isnl
@@ -3539,6 +3745,26 @@ wd_ask:
     mov [wd_wanti], ax
 .out:
     pop cx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; wd_halfadv - the pixel that splits the character at the pen down the middle
+; in:  DI = the pen, ES:SI -> the character, BX = characters left
+; out: CX = it; preserves every other register
+;
+; The half-cell rule of SPEC.md 27.6, made a half-ADVANCE: a click in the left
+; half of a character puts the caret before it and one in the right half after.
+; In the kernel's cell that is DI + 4 and always was; in a chosen face it is
+; half of what THIS character is worth, so a 4px `i` and an 8px `m` each split
+; where the reader sees their middle.
+; -----------------------------------------------------------------------------
+wd_halfadv:
+    push ax
+    call wd_penadv
+    shr ax, 1
+    mov cx, di
+    add cx, ax
     pop ax
     ret
 
@@ -3655,6 +3881,9 @@ wd_rstart:
     cld
     mov [wd_rby], bp
     mov word [wd_rcx], 0xFFFF
+    mov word [wd_rcn], 0            ; no cells stored: in a chosen face this IS
+                                    ; the next cell's index, and wd_rowsetup
+                                    ; writes cell 0's pen a moment from now
     mov word [wd_rs0], 0xFFFF       ; ...and no inverted cells yet either
     mov word [wd_rs1], 0xFFFF
     mov word [wd_xs0], 0xFFFF       ; ...nor any whose inversion must change
@@ -3815,20 +4044,12 @@ wd_rflush:
     cmp ax, 0xFFFF
     je .cache                       ; this row's inversion is already right
     mov cx, [wd_xs1]
-    push cx
-    mov cl, 3
-    shl ax, cl
-    pop cx
-    add ax, [wd_tx]                 ; x1
-    push ax
-    mov ax, cx
-    inc ax
-    push cx
-    mov cl, 3
-    shl ax, cl
-    pop cx
-    add ax, [wd_tx]
-    dec ax
+    call wd_cx                      ; x1 - through wd_cx, which is the same
+    push ax                         ; three shifts in the kernel's cell and a
+    mov ax, cx                      ; wd_px[] lookup in a chosen face
+    inc ax                          ; (SPEC.md 65.13)
+    call wd_cx                      ; ...and the slot PAST the span's last cell
+    dec ax                          ; is why wd_px[] carries one
     mov cx, ax                      ; x2
     pop ax
     mov bx, [wd_rby]
@@ -3844,14 +4065,16 @@ wd_rflush:
     mov ax, [wd_rcx]
     cmp ax, 0xFFFF
     je .span
-    sub ax, [wd_tx]
-    mov cl, 3
-    shr ax, cl
+    call wd_xc
     mov [wd_fcc], ax
 .span:
-    mov word [wd_flo], 0            ; the default span is the whole row
-    mov ax, [wd_rcols]
-    dec ax
+    mov word [wd_flo], 0            ; the default span is the whole row - which
+    mov ax, [wd_rcols]              ; in a chosen face is the cells the WALK
+    dec ax                          ; stored plus the one the caret parks in,
+    cmp byte [wd_pxon], 0           ; because a cell past those has no pen and
+    je .spanhi                      ; nothing to draw at (SPEC.md 65.13). The
+    mov ax, [wd_rcn]                ; tail past it is erased in pixels below
+.spanhi:
     mov [wd_fhi], ax
     mov ax, [wd_row]
     cmp ax, [wd_prowi]
@@ -3976,6 +4199,98 @@ wd_rflush:
 .tdone:
     mov [wd_fhi], bx
 .draw2:
+    cmp byte [wd_pxon], 0           ; --- the TAIL, in pixels (SPEC.md 65.13) -
+    je .runs                        ; A fixed row erases itself: the buffer is
+                                    ; space-padded to [wd_rcols] and one opaque
+                                    ; run covers the band. A proportional row
+                                    ; cannot pad, because a cell past its
+                                    ; content has no pen - so the span stops at
+                                    ; the cells the walk stored and ONE white
+                                    ; fill covers the ground the row's glyphs
+                                    ; used to reach and no longer do.
+    mov ax, [wd_rcn]
+    cmp ax, [wd_fhi]
+    ja .tailhi
+    mov [wd_fhi], ax                ; ...the caret's parking cell included: a
+.tailhi:                            ; caret that moved off the end has to be
+                                    ; lettered over, and the cell it stood in
+                                    ; is the one past the last character - so
+                                    ; wd_px[] carries a slot past THAT one too
+
+    ; --- and GROWN to byte columns at both ends (SPEC.md 5.4.2) -------------
+    ; The band is blitted by whole byte columns and is paper where nothing was
+    ; composed, so a span whose first cell starts mid-byte whitens up to 7
+    ; pixels of the glyph to its LEFT, and one whose last cell ends mid-byte
+    ; does the same on its right. Growing the span outwards until both edges
+    ; land on a multiple of 8 redraws a neighbour or two and rubs out none.
+    ; In the kernel's cell every cell edge IS a multiple of 8 and neither loop
+    ; runs past its first test.
+    mov ax, [wd_flo]
+.blo:
+    or ax, ax
+    jz .blodone                     ; the row's own first cell: what is left of
+    push ax                         ; it is the margin, and blank
+    call wd_cx
+    test ax, 7
+    pop ax
+    jz .blodone
+    dec ax
+    jmp short .blo
+.blodone:
+    mov [wd_flo], ax
+    mov ax, [wd_fhi]
+.bhi:
+    cmp ax, [wd_rcn]
+    jae .bhidone                    ; past the row's content: blank ground
+    push ax
+    inc ax
+    call wd_cx
+    test ax, 7
+    pop ax
+    jz .bhidone
+    inc ax
+    jmp short .bhi
+.bhidone:
+    mov [wd_fhi], ax
+
+    mov ax, [wd_fhi]
+    inc ax
+    call wd_cx
+    mov cx, ax                      ; CX = where this row's ink now ends
+    mov ax, [wd_prowrx]             ; ...against where it ended when last drawn
+    cmp byte [wd_clean], 0
+    jne .tailno                     ; a blank band owes nothing
+    push bx
+    mov bx, [wd_row]
+    cmp bx, [wd_prowi]
+    pop bx                          ; POP touches no flags
+    je .tailcmp
+    mov ax, [wd_rgt]                ; the cache is some other row's: erase to
+    inc ax                          ; the margin, which is what the padding
+.tailcmp:                           ; run did for the fixed face
+    cmp ax, cx
+    jbe .tailno
+    push ax
+    push bx
+    push cx
+    push dx
+    xchg ax, cx                     ; AX = x1, the new right edge; CX = x2, the
+    dec cx                          ; last column the old row still owns
+    mov bx, [wd_rby]
+    mov dx, bx
+    add dx, [wd_gh1]
+    push ax
+    mov al, CWHITE
+    call OSAPI_SET_COLOR
+    pop ax
+    call OSAPI_GFX_FILL
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+.tailno:
+    mov [wd_prowrx], cx             ; ...and this is the edge the next pass
+.runs:                              ; measures against
     ; --- the span, split into runs of equal CHP (SPEC.md 65.1) --------------
     ; Adjacent plain cells are one run by construction, so unstyled text is
     ; exactly the one opaque font_run it always was; each styled run draws by
@@ -4371,21 +4686,27 @@ wd_itrun:
 ; out: nothing; preserves all registers
 ; -----------------------------------------------------------------------------
 ; -----------------------------------------------------------------------------
-; wd_bandrun - one styled run, composed into the band and put down in ONE call
-; in:  [wd_r0]/[wd_r1] = the run's cells, [wd_rby] = its glyph y, wd_rbuf holds
-;      the characters; gfx lock held
-; out: nothing; preserves all registers
+; The band, opened once a ROW and not once a run (SPEC.md 6.3/65.13)
 ;
 ; SPEC.md 6.3's method, and the whole of what a proportional face costs at draw
-; time: ty_band, ty_putn, ty_flush. It replaces ONE OSAPI_FONT_RUN with one
-; OSAPI_GFX_BLIT1, so the call count a row costs does not move - what moves is
-; that the glyphs are the face's instead of the cell's.
+; time: ty_band, a ty_putn a run, ty_flush. It replaces the row's OSAPI_FONT_RUN
+; with one OSAPI_GFX_BLIT1, so the call count a row costs does not move - what
+; moves is that the glyphs are the face's instead of the cell's.
 ;
-; THE BACK-UP RULE (SPEC.md 5.4.2). The blit wants an x on a multiple of 8, and
-; a run does not start on one - so the band starts at the byte column to its
-; LEFT, the 0..7 remainder becomes the pen inside the band, and the width is
-; rounded up to the next byte column. The band is paper where the run is not,
-; so this erases exactly what FONT_RUN's background would have.
+; THE BACK-UP RULE (SPEC.md 5.4.2) is why the band belongs to the ROW. The blit
+; wants an x on a multiple of 8, and a run does not start on one - so the band
+; starts at the byte column to its LEFT, the 0..7 remainder becomes the pen
+; inside the band, and the width is rounded up to the next byte column. The band
+; is PAPER where nothing was composed, so those few pixels are whitened: at the
+; span's outer edges that is exactly what FONT_RUN's background would have done,
+; and in its MIDDLE it would rub out the tail of the run before. One band a row
+; has no middle. (wd_rflush grows the span outwards to byte columns for the two
+; outer edges, so no neighbour is rubbed out either.)
+;
+; wd_bandopen  - paper, and the byte column the band starts at
+; wd_bandrun   - compose one equal-CHP run into it; NOTHING is drawn
+; wd_bandclose - one blit, and the row is on the glass
+; All three preserve every register.
 ; -----------------------------------------------------------------------------
 wd_bandrun:
     push ax
@@ -4483,9 +4804,7 @@ wd_drawrun:
     cmp bx, [wd_r1]
     ja .done
     mov ax, bx
-    mov cl, 3
-    shl ax, cl
-    add ax, [wd_tx]
+    call wd_cx
     push bx
     push bp
     push es
@@ -4530,9 +4849,7 @@ wd_drawrun:
     push bx
     mov si, [wd_r0]
     mov ax, si
-    mov cl, 3
-    shl ax, cl
-    add ax, [wd_tx]
+    call wd_cx
     mov cx, ax                      ; CX = x of the run's first cell
     add si, wd_rbuf
     mov dx, [wd_rby]
@@ -4560,14 +4877,14 @@ wd_drawrun:
     call OSAPI_SET_COLOR
     pop ax
     mov ax, [wd_r0]
-    mov cl, 3
-    shl ax, cl
-    add ax, [wd_tx]                 ; AX = x1
-    mov bx, [wd_r1]
-    inc bx
-    shl bx, cl
-    add bx, [wd_tx]
-    dec bx                          ; BX = x2
+    call wd_cx                      ; AX = x1
+    push ax
+    mov ax, [wd_r1]
+    inc ax
+    call wd_cx
+    dec ax
+    mov bx, ax                      ; BX = x2
+    pop ax
     mov dx, [wd_rby]
     add dx, [wd_gh1]                       ; the cell's last row
     test byte [wd_runa], WDAT_UL
@@ -4597,16 +4914,12 @@ wd_drawrun:
     cmp byte [wd_rbuf+si], ' '
     jne .wx
 .wdraw:
+    mov ax, si
+    call wd_cx
+    dec ax
+    mov bx, ax                      ; BX = x2, the span's last column
     mov ax, di
-    push cx
-    mov cl, 3
-    shl ax, cl
-    add ax, [wd_tx]
-    mov bx, si
-    shl bx, cl
-    add bx, [wd_tx]
-    dec bx
-    pop cx
+    call wd_cx                      ; AX = x1
     call OSAPI_GFX_HLINE
 .wnext:
     inc si
@@ -4801,6 +5114,10 @@ wd_brktry:
     jne .no                         ; formatted rows are not 8px and do not
                                     ; start at [wd_tx]: the break's scroll
                                     ; and column arithmetic both die (65.6)
+    cmp byte [wd_pxon], 0
+    jne .no                         ; ...and a chosen face has no COLUMN for
+                                    ; the arithmetic below to count in
+                                    ; (SPEC.md 65.13)
     mov di, [wd_currow]             ; DI = the caret's row (banked by the
                                     ; pass-1 walk that just stood on it)
     mov ax, [wd_dr1]
@@ -8118,6 +8435,19 @@ wd_append:
     jne .no                         ; formatted rows have indents, offsets and
                                     ; heights this path's x/y arithmetic does
                                     ; not model - walk properly (SPEC.md 65.6)
+    cmp byte [wd_pxon], 0
+    jne .no                         ; ...AND A CHOSEN FACE (SPEC.md 65.13.1).
+                                    ; This path does not walk, so it does not
+                                    ; compose a band: it stamps the glyph with
+                                    ; OSAPI_FONT_RUN, which is the KERNEL's 8x8
+                                    ; cell and nothing else. Every guard above
+                                    ; is about geometry, and a face changes the
+                                    ; GLYPHS - tallx is 8 rows at an advance of
+                                    ; 8 and raises none of them, so a character
+                                    ; typed at the end of a line came out in
+                                    ; Pica while every character the walk
+                                    ; redrew came out in the face. That is the
+                                    ; bug this section was reported as
 
     ; NOTHING AFTER THE CARET ON THIS ROW, which is the whole precondition and
     ; has exactly two shapes (SPEC.md 27.14.1). The end of the NOTE, where
@@ -8576,7 +8906,16 @@ wd_redraw:
     jg .mr
     call OSAPI_GFX_FILL
 .mr:
-    mov ax, [wd_rcols]              ; right: the <8px tail past the last cell
+    cmp byte [wd_pxon], 0           ; right: the <8px tail past the last cell.
+    jne .mdone                      ; A CHOSEN FACE HAS NO SUCH TAIL - its rows
+                                    ; end where their glyphs do and each one
+                                    ; erases its own in wd_rflush (SPEC.md
+                                    ; 65.13), and [wd_rcols] there is sized from
+                                    ; TY_MINADV, so 8 x it is not a pixel count
+                                    ; at all. It happened to fall past [wd_rgt]
+                                    ; and be skipped, which is not a thing to
+                                    ; leave standing on
+    mov ax, [wd_rcols]
     push cx
     mov cl, 3
     shl ax, cl
@@ -9190,19 +9529,11 @@ wd_selxor:
 .l1:
     cmp ax, cx
     ja .out
-    push cx
-    mov cl, 3
-    shl ax, cl
-    pop cx
-    add ax, [wd_tx]             ; AX = x1
-    push ax
-    mov ax, cx
+    call wd_cx                  ; AX = x1 (SPEC.md 65.13: the same three shifts
+    push ax                     ; in the kernel's cell, a wd_px[] lookup in a
+    mov ax, cx                  ; chosen face)
     inc ax
-    push cx
-    mov cl, 3
-    shl ax, cl
-    pop cx
-    add ax, [wd_tx]
+    call wd_cx
     dec ax
     mov cx, ax                  ; CX = x2, the last column of the last cell
     pop ax
@@ -19346,15 +19677,18 @@ section .text
                             ; can never inherit an Up's bound
 
 ; --- the proportional face, SPEC.md 65.13 ------------------------------------
-    WDVAR wd_px, (WD_MAXCOL + 2) * 2  ; word per cell: the pen the k-th cell
-                                  ; starts at, RELATIVE to [wd_tx], plus one
-                                  ; past the end so a span's right edge is a
-                                  ; lookup rather than a special case. This is
-                                  ; the whole of what a proportional row costs
-                                  ; over a fixed one - in a fixed face the
-                                  ; k-th cell is at 8k and nothing needs
-                                  ; storing, which is why wd_cx branches
-                                  ; rather than always reading this
+    WDVAR wd_px, (WD_MAXCOL + 3) * 2  ; word per cell: the pen the k-th cell
+                                  ; starts at, RELATIVE to [wd_tx], plus TWO
+                                  ; past the end - one so a span's right edge
+                                  ; is a lookup rather than a special case, and
+                                  ; one for the caret's parking cell, which is
+                                  ; a cell the walk never stored and wd_rflush
+                                  ; still letters a space into. This is the
+                                  ; whole of what a proportional row costs over
+                                  ; a fixed one - in a fixed face the k-th cell
+                                  ; is at 8k and nothing needs storing, which
+                                  ; is why wd_cx branches rather than always
+                                  ; reading this
     WDVAR wd_rcn, 2               ; word: cells stored in the row so far. In a
                                   ; fixed face the cell index comes from the
                                   ; PEN - (di - tx) >> 3 - and a tab therefore
@@ -19380,8 +19714,22 @@ section .text
                                   ; taken on the way out as a tail jump
     WDVAR wd_pxon, 1              ; byte: wd_px[] is the truth about where a
                                   ; cell sits. 0 = the 8-pixel grid, which is
-                                  ; what wd_cx computes without reading it
-    WDVAR wd_bx0,  2              ; word: wd_bandrun's aligned band origin
+                                  ; what wd_cx computes without reading it.
+                                  ; wd_facemetrics sets it from [wd_prop], so
+                                  ; the metrics and the glyphs can never be two
+                                  ; different faces (SPEC.md 65.13.1)
+    WDVAR wd_spadv, 2             ; word: what a SPACE is worth in the current
+                                  ; face. The row buffer pads with spaces and
+                                  ; wd_pxcell extrapolates the parking cell by
+                                  ; exactly this, so the pen it predicts is the
+                                  ; one ty_putn will take
+    WDVAR wd_prowrx, 2            ; word: the absolute x the cached row's ink
+                                  ; ended at when it was drawn. A row that
+                                  ; SHRANK is erased from its new right edge to
+                                  ; this, in one fill - a proportional row
+                                  ; cannot pad itself blank the way a fixed one
+                                  ; does (SPEC.md 65.13)
+    WDVAR wd_bx0,  2              ; word: the band's aligned origin
     WDVAR wd_gh,   2              ; word: the GLYPH BAND's height in pixels -
                                   ; 8 for the kernel's cell, the face's `rows`
                                   ; for a chosen one. Every site that used to
@@ -19511,6 +19859,11 @@ section .text
     WDVAR wd_wfirstpx, 2    ; word } and the effective right edge and fresh-
     WDVAR wd_wrgt,  2       ; word } row cell capacity the wrap rule reads
     WDVAR wd_wcols, 2       ; word } instead of [wd_rgt]/[wd_rcols]
+    WDVAR wd_wcpx,  2       ; word: ...and that capacity in PIXELS, which is
+                            ; what wd_wordfit's second threshold measures now.
+                            ; Exactly 8 x [wd_wcols] in the kernel's cell, so
+                            ; the wrap it computes there is the one it always
+                            ; computed (SPEC.md 65.13)
     WDVAR wd_rowhv, 2       ; word: the entered row's height in px
     WDVAR wd_rowx0, 2       ; word: the row's start pen x (indent + alignment
                             ; offset) - the tab stops' anchor


### PR DESCRIPTION
## What was reported

> I can change the font used by the document, but when I start typing, the font used is not the one from the selected list.

That is exactly what it was, and it is `wd_append` (§27.14.1). A printable typed at the end of a line does not walk the note — it stamps the one glyph — and it stamped it with `OSAPI_FONT_RUN`, the kernel's 8×8 cell. Every guard on that path was about **geometry** (`[wd_hasfmt]`, hidden text, tabs), and a face changes the **glyphs** without necessarily changing the geometry: `tallx` is 8 rows at an advance of 8 and raises none of them.

Nine of the ten faces on the disk are 12 or 14 rows and hid the bug behind `[wd_hasfmt]`; in the tenth it was total. `wd_brktry` (§27.12) had the same hole. Both test `[wd_pxon]` now.

## What else was under it

The half-converted state §65.13 already recorded: `ty_putn` advanced the pen by each glyph's real advance while every metric in Word was still `8k`. A whole-row redraw packed the text; a per-keystroke redraw put each new glyph on the 8-pixel grid, with the caret floating well right of the line.

§65.13's second half is in, so the two agree — the pen advances by `ty_advof` (by the *drawn* character, so the small-caps map moved out of the drawing gate), `wd_px[]`/`[wd_rcn]` are recorded outside the drawing gates, the wrap rule and `wd_rowmeasure`/`wd_tabw` measure pixels, a tab is one wide cell, a click splits a character at half its own advance, and `[wd_rcols]` is sized from `TY_MINADV`.

Two things a proportional row needs that a fixed one does not: its **tail** is erased in pixels (`[wd_prowrx]`) because a cell past the content has no pen to pad at, and its **span grows outwards to byte columns** before drawing, because the band blits by whole byte columns and would otherwise whiten 7 pixels of the neighbouring glyph.

## Verified

| | |
|---|---|
| the reported bug | typed vs walk-redrawn glyphs **byte-identical** in `tallx` and `Times` |
| click-to-caret | exact against real pen positions — Col 2 / 7 / 15 for clicks at x = 26 / 46 / 100 on `iiiii mmmmm iiiii` |
| the rest | drag-select, bold, underline, tabs, wrap, backspace |
| adapters | CGA (1bpp) as well as VGA |
| **no regression** | the kernel's 8×8 cell is **pixel-identical** to the pre-change build across five frames of an identical scripted session (only the menu-bar clock differs) |

`make` and the doc gate are clean. Word is 46,776 → 47,230 bytes.

## Two things this does NOT fix — §65.13.1 has both

**1. Interior run boundaries.** A row of different CHPs is several bands and their interior edges are not byte-aligned, so a styled run can still whiten 7 pixels of the run before it. Plain text is one run and is unaffected. One band a row is the repair; it was written, it hangs, and the cause is not understood — so what ships is the per-run band that always shipped.

**2. The row-height model — this is the "newline overlaps the previous line" report.** `wd_walk` still carries literal `8`s where it means `[wd_gh]`, so `wd_rflush`'s leading-gap fill lands *inside the row above* and shaves the bottom off it on every keystroke. Worst in a face with no leading (`jetbrain`, `courier`: 14 rows, `leading 0` — the band **is** the advance).

It is **pre-existing** — it reproduces identically on the build before this change. Converting the sites does fix the shaving (verified in `jetbrain`, `courier` and `Times`, on both adapters, with Pica still pixel-identical), but it also moves every row's y, which is the input to §65.6's rows-MOVED repaint, and in that state some sequences leave earlier rows erased and never redrawn. It needs `[wd_vrows]` (which counts 8-pixel rows into a band holding 14-pixel ones), `wd_advblank` and `wd_scrollpaint`'s scroll delta in the same change — so none of it is here. A half-converted height model is worse than an unconverted one, which is §65.13's own rule about `[wd_prop]` applied to y instead of x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
