### PR TITLE
gfx_blit1: restore DS before the nest count, not after (§5.4.2.1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1241,7 +1241,9 @@ rule 2 intact.
 
 **No `rep` carries a segment override**, deliberately: an 8086 loses the prefix
 if an interrupt lands mid-`rep`, and this is an interrupt-heavy kernel. DS is
-pointed at the caller's band and restored.
+pointed at the caller's band and restored — and **between those two moments
+this routine has no kernel variables**, which is a rule about the exit as much
+as the emit (§5.4.2.1).
 
 **WHAT IT COSTS, MEASURED (PERFORMANCE.md Set 62).** `tests/bandbench` under
 `-icount`, converted at Part 2's 0.359 ms a count. The emit is **2.42 ms a row**
@@ -1265,6 +1267,67 @@ neither package this serves can load on the machine that build is for — Word i
 46.5 KB and TeXPad 31.5 KB against a 128 KB machine's 28 KB heap. A package
 therefore **must test CF**, and the documented degrade is that it letters in the
 kernel's 8×8 face instead, with `font_run` (§6.1).
+
+#### 5.4.2.1 The two bytes that decremented the CALLER'S IMAGE
+
+These two lines sat at `.done`, **above `pop ds`**:
+
+```
+    cmp byte [vid_ndisp], 1         ; both DS-relative, and DS at this point
+    jbe .noleave                    ; is still the CALLER's band segment
+    dec byte [gfx_dnest]
+```
+
+The emit moves DS to the caller (the rule above), and the exit read and wrote
+two kernel variables before putting it back. So both addressed **the package**,
+at `vid_ndisp`'s and `gfx_dnest`'s kernel offsets. Three things follow, and each
+one is worse than the last.
+
+**The read decides the write, so the guard is not a guard.** `[vid_ndisp]` is
+"how many displays" and is 1 on every ordinary machine, which is what makes this
+look untestable — a single-monitor build should never take the branch. But the
+byte actually read is whatever the *package* holds at offset 0x11FD. The
+multi-monitor path was not being exercised; a package's code was being read as a
+monitor count.
+
+**The write is a silent one-byte-per-blit rot of the caller's own image.**
+`dec byte [gfx_dnest]` decrements the package at offset 0x1698, once per band it
+puts down. Nothing detects it: there is no checksum over a loaded package, the
+loader is long finished, and the damaged byte is in a region nobody reads back.
+
+**WHETHER IT FIRES AT ALL IS DECIDED BY ONE ARBITRARY BYTE OF THE CALLER**, and
+that is the part worth keeping. At the build this was found in, Word held `0x01`
+at 0x11FD — so `1 ≤ 1`, the branch skipped, and the bug did nothing whatsoever.
+An unrelated edit to `apps/word/word.asm` (§65.13's proportional metrics) moved
+that offset onto a byte of `wd_walk`'s code holding `0x53`, 83 > 1, and the same
+kernel armed itself: every blit rotted a byte, and inside twenty keystrokes the
+machine wedged. **A latent write that is gated on a byte of an unrelated file is
+not a dormant bug, it is a scheduled one** — nothing about the edit that arms it
+is anywhere near this code, and nothing warns.
+
+The freeze it eventually produces is two steps past the corruption: the mangled
+instruction derails the package, and by then the rot has also changed the
+segment immediate of one of its `call KERNEL_SEG:...` instructions, so a far
+call goes to an unmapped window, reads `0xFF`, takes an invalid-opcode fault,
+and returns to it forever. **A frozen guest whose timer still runs is a fault
+loop, not a hang** — and the registers being *identical* sample after sample,
+rather than merely similar, is what says so.
+
+And on a machine that really does have two displays it was broken the other way
+round. `gfx_disp_enter`'s `inc byte [gfx_dnest]` (vga12.inc:249) runs *above*
+the emit, with DS still KERNEL_SEG, so it was always correct; only the matching
+`dec` addressed the package. The kernel's nest count therefore **ratcheted up by
+one per band blit and never came down**, and §39.14.4's `cmp byte [gfx_dnest],
+0` and this section's `cmp byte [gfx_dnest], 1` both read it — so every
+primitive after the first band on `xt-multimon` would take the nested path and
+translate against the wrong origin. One `pop ds` in the wrong place is two
+different bugs on two different machines.
+
+**A `push ds`/`pop ds` pair does not mean DS is safe in between — it means it is
+NOT**, and the window ends at the `pop`, not at the last instruction that looked
+like work. The emit loop here was scrupulous about exactly that
+(`[cs:gfx_sub_rs]` at vga12.inc:3118 carries the comment "CS: IS MANDATORY"),
+and the exit four lines below it was not.
 
 ### 5.5 `gfx_scroll` — move a rect instead of redrawing it
 

--- a/kernel/vga12.inc
+++ b/kernel/vga12.inc
@@ -3662,6 +3662,17 @@ section .cold                   ; gfx_blit1's body, and its far entry below it
 ; CALLER's band. This body's CS is COLD_SEG, so sw_xfer's [cs:vid_rowadd] idiom
 ; does not transfer either - the frame is the way to reach a geometry word once
 ; DS has moved.
+;
+; THAT RULE COVERS THE EXIT TOO, and it did not: the nest count came down at
+; `.done`, which is ABOVE `pop ds`, so `cmp byte [vid_ndisp]` and `dec byte
+; [gfx_dnest]` both addressed the CALLER's segment. The read decided the write
+; - a package whose image happens to hold anything above 1 at vid_ndisp's
+; offset fell through the guard - and the write then decremented one byte of
+; that package's own IMAGE, once per blit. Nothing in the kernel or the package
+; is checking, so it is silent until the rotted byte is CODE the package
+; executes: Word (SPEC.md 65.13) hit it at 0x1698, the head of wd_rflush's
+; leading-gap fill, which only a face taller than the 8x8 cell ever runs.
+; SPEC.md 5.4.2.1 is the account.
 ; =============================================================================
 gfx_blit1_x:
     test ax, 7                  ; the two argument refusals, and they are the
@@ -3842,10 +3853,6 @@ gfx_blit1_x:
     mov sp, bp
     add sp, 12
 .done:
-    cmp byte [vid_ndisp], 1
-    jbe .noleave
-    dec byte [gfx_dnest]        ; ...and NOTHING restores the display
-.noleave:                       ; (SPEC.md 39.14.3)
     pop ax
     pop bx
     pop cx
@@ -3853,8 +3860,15 @@ gfx_blit1_x:
     pop di
     pop si
     pop bp
-    pop ds
-    pop es
+    pop ds                      ; DS IS KERNEL_SEG AGAIN, AND NOT ONE BYTE
+    pop es                      ; SOONER: the emit above spends it on the
+                                ; CALLER's band, so the two bytes below have to
+                                ; wait for this pop. They did not, and both of
+                                ; them landed in the CALLER'S IMAGE - see below.
+    cmp byte [vid_ndisp], 1
+    jbe .noleave
+    dec byte [gfx_dnest]        ; ...and NOTHING restores the display
+.noleave:                       ; (SPEC.md 39.14.3)
     clc
     ret
 .none:                          ; clipped away entirely: drawn, and nothing


### PR DESCRIPTION
Reported as *"inserting a newline with a different font in Word froze the computer"*. It is not a Word bug.

## What it is

`gfx_blit1` points **DS at the caller's band** for its `rep movsb` — that is the routine's whole method, and its header says so. Its exit read and wrote two kernel variables *before* putting DS back:

```asm
.done:
    cmp byte [vid_ndisp], 1      ; both DS-relative, and DS here is still
    jbe .noleave                 ; the CALLER's segment
    dec byte [gfx_dnest]
    ...
    pop ds                       ; only restored here
```

Both therefore addressed **the package**, at those two variables' kernel offsets.

**The read is what makes it fire.** `[vid_ndisp]` is "how many displays" and is 1 on any ordinary machine, so that branch should never be taken — but the byte actually read is whatever the *caller* holds at 0x11FD. **The write then decrements one byte of the caller's own image, once per band it puts down** — silently: nothing checksums a loaded package, and nothing reads that region back.

## Why it has been invisible

Whether it fires at all is decided by one arbitrary byte of the caller. On `main` today Word holds `0x01` at 0x11FD — `1 <= 1`, the branch skips, and the bug does nothing whatsoever. It has been sitting here since the band shipped (#88).

On #90's branch (§65.13's proportional metrics) an unrelated edit moved that offset onto a byte of `wd_walk` holding `0x53`. 83 > 1, and the identical kernel arms itself: every keystroke that blits rots a byte, and about twenty in, the machine wedges.

**Ordering matters: #90 is what arms this. This should land before it, or with it.**

What the rot reaches there is `wd_rflush`'s leading-gap fill — code only a face *taller* than the 8×8 cell ever runs — which is why the symptom sorts by typeface and looks like a font bug:

| face | band blit? | rotted byte executed? | user sees |
|---|---|---|---|
| Pica (kernel 8×8) | no — `font_run` | — | nothing; correct |
| `tallx` (8 rows, advance 8) | yes | no — no leading gap | nothing, and the image is rotting |
| `courier`/`jetbrain` (14), `times`/`helv` (12) | yes | yes | derails, then freezes |

The freeze is two steps past the corruption: the mangled instruction derails the package, and by then the rot has also turned a `call KERNEL_SEG:...` segment immediate into an unmapped window, which reads `0xFF`, faults on an invalid opcode, and returns to it forever. **A frozen guest whose timer still runs is a fault loop, not a hang** — the registers being *identical* rather than merely similar, sample after sample, is what says so.

## And the other machine

On a real two-display machine it was broken the other way round. `gfx_disp_enter`'s `inc byte [gfx_dnest]` runs *above* the emit with DS still `KERNEL_SEG` and was always correct; only the matching `dec` went into the package. The nest count therefore ratcheted up per blit and never came down, and both §39.14.4's `cmp byte [gfx_dnest], 0` and §5.4.2's `cmp byte [gfx_dnest], 1` read it — so every primitive after the first band on `xt-multimon` would take the nested path and translate against the wrong origin.

One `pop ds` in the wrong place is two different bugs on two different machines.

## The fix

The two lines moved below `pop ds`. No size change (94,476 bytes), no pixel changes: `clc` still sets the answer, and `.none` reaches `.done` with DS already `KERNEL_SEG` either way.

SPEC.md gains §5.4.2.1 for the account, and §5.4.2's "DS is pointed at the caller's band and restored" now says that the rule covers the exit.

## Verified

Fixed kernel run against the **arming** Word (built from #90's branch):

- image byte 0x1698 stays `0x89` across 24 keystrokes — it previously lost one per keystroke
- total bytes differing from the on-disk package stays flat at the font-scan table's own writes
- `courier`, `times`, `jetbrain` each survive four lines and three newlines; each died on the 7th keystroke before
- CGA as well as VGA; doc gate passes

Root cause was located by single-stepping the guest under QEMU's gdb stub to the instruction that stored (`Z2` write watchpoints are accepted but never fire in this build — worth knowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)