### PR TITLE
port-to-os8088: a skill that ports an existing program to a C package the way CWORD was made

### DIFF
--- a/.claude/skills/port-to-os8088/LESSONS.md
+++ b/.claude/skills/port-to-os8088/LESSONS.md
@@ -1,0 +1,488 @@
+# What the CWORD port learned
+
+`apps/cword` is Microsoft Word 1.1a, ported to os8088 as a C package across
+four working sessions: the one that built the C toolchain and a demonstrator,
+the one that built the overlay mechanism and did the port proper, the one that
+added Page view and typefaces off the system disk, and the one that polished
+the product name, the About box and the disk images. This file is what those
+sessions hit, **in the order the next port will hit it**, each with what it
+cost and what fixed it. Every agent the `port-to-os8088` skill spawns reads it
+first, and the point of reading it is not to be interesting — it is that
+every item below assembled cleanly, booted, and was wrong, and most of them
+were found by counting or by a screendump on the wrong adapter rather than by
+a crash.
+
+Where a section of `SPEC.md` owns the reasoning it is cited; `docs/C-TOOLCHAIN.md`
+has the mechanics of the compiler and the gate and is not repeated here.
+
+---
+
+## 1. What "port" meant, and what it did not
+
+- **The user interface is the original's, taken from its source and not
+  from memory.** CWORD's nine menus, every string and mnemonic, the shortcut
+  captions, the ribbon's six buttons, the ruler's controls, the status line's
+  field order and the dialogs' contents each came from ONE named file in the
+  reference tree (`Opus/resource/menus.cmd`, `keys.cmd`, `ibdefs.h`,
+  `status.h`, `dlg/*.des`) — and that table of surface → file is the first
+  thing in SPEC.md §70.12. Build that table before writing a line. When you
+  find yourself typing a menu string you did not just read, stop.
+- **The code did not port and was never expected to.** Word was pcode built
+  by a proprietary compiler against the Windows 2.x API. What carried was
+  *tables, formats and behaviour*: the RTF keyword table was transcribed whole
+  (~70 keywords, everything else through an ignore path); bit-field records
+  became byte-offset records with build-time self-checks; every 32→16-bit
+  narrowing was written down. Expect the same of any reference: survey what
+  would compile in this C (K&R, `long`, bit-fields, anonymous unions, heap
+  handles → almost nothing) and plan a **reimplementation of behaviour**, not
+  a compile.
+- **What cannot be carried is present and greyed with the FACT that greys
+  it** (SPEC.md §47) — "no printing path in this OS", "no Undo in this build"
+  — never silently missing and never faked. CWORD greys the Print family,
+  Spelling, Thesaurus, the Macro menu, Outline, footnotes, fields, tables,
+  Paste Link, Summary Info, Glossary and Undo, and each greying names why.
+  View > Page was greyed as a fact until the session that built it.
+- **A shipped sample document may not claim what the reader cannot render.**
+  The Word disk's `WELCOME.DOC` demonstrates centring and double spacing;
+  cword's RTF reader carries character formatting only, so a verbatim copy
+  would have rendered *"This paragraph is centered"* flush left. `WELCOME.RTF`
+  says those formats can be set *in the program* (true) and names the three
+  narrowed spans in prose instead of wearing them (§70.12.3).
+- **The licence question is the user's.** The reference had no LICENSE and
+  every file said "Copyright (C) Microsoft". Four options were put to the
+  user (clean-room; lift tables, keep unreleased; lift and ship; pause) with a
+  recommendation; the user chose to lift the tables and ship. The attribution
+  went into every file header carrying derived material, into the About box,
+  and into the PR body. Ask this once, early, and record the answer.
+- **Two programs may share an ambition; they may not share a name.**
+  `apps/word` (assembly, `WORD`, `.DOC`, `vm/xt-word`) and `apps/cword` (C,
+  `CWORD`, `.RTF`, `vm/386-c-word`) share no file, target, image, vm dir or
+  extension, by rule, "because the next person to touch either will silently
+  get the other" (§70.12). Check every name against `apps/`, `vm/`, the
+  Makefile and `build/` before wave 1.
+
+## 2. Measure before scoping
+
+- **Build the ceiling before you plan against it.** The port opened by
+  building both existing packages and quoting `os88pkg`'s line: `apps/word`
+  at 54,952 of 61,440; the C demonstrator at 47,136 for a fraction of the
+  function. That one measurement produced the conclusion — C costs 2–3× the
+  image of hand assembly, so the port does not fit in one segment — and the
+  user's decision that followed. Never estimate what one `make` will tell you.
+- **When memory is the constraint, measure per function.** For the typeface
+  work (2,350 bytes spare, a 2,850-byte library to add) a nasm `-l` listing
+  of the shim plus a small Python pass attributing bytes to each `_cw_*` label
+  turned every move into a decision instead of a guess. It cost one build.
+- **Reproduce a documented blocker before designing around it.** SPEC.md's
+  note that the assembly overlay froze on UI callbacks was stale — three
+  variants and seven round trips disproved it in minutes, and the note was
+  fixed. A plan that routes around a defect nobody has re-checked is paying
+  for a ghost.
+- **A capability gate that puts numbers on the glass beats reasoning.**
+  `tests/covl` prints `Loaded: yes`, a counter only the module can bump,
+  `ovl_mix(1,2,3,4) = 1234` (a wrong argument fixup reads the saved CS, "a
+  large and obviously wrong number rather than a plausible one"), and a
+  callback that reports what it was told — which found the shim bug static
+  review missed ("told 10 saw 49"). Press the key ten times: a two-byte stack
+  leak works for a while. Build the gate before the feature that needs the
+  mechanism.
+- **Prove a lowering, don't argue it.** The instruction lowerings in
+  `cc8086.py` were checked by a boot floppy running the 386 form and the 8086
+  replacement from identical state and diffing registers and FLAGS — 428
+  cases, with a **negative control** injecting broken lowerings so a clean run
+  means something. Any new tool in the chain gets the same treatment.
+
+## 3. The compiler, in practice (what `C-TOOLCHAIN.md` does not say)
+
+- `smlrcc` needs `smlrc` on `PATH` (`sh: smlrc: command not found`);
+  `apps/cc/Makefile.inc` sets it. Never pass `-nopp`.
+- **`Identifier table exhausted` is a build flag, not a patch.** SmallerC's
+  tables are `#ifndef`-guarded constants; `tools/setup-cc.sh` builds it with
+  `CFLAGS="... -DMAX_IDENT_TABLE_LEN=32768 -DMAX_MACRO_TABLE_LEN=16384
+  -DSYNTAX_STACK_MAX=16384 -DMAX_CASES=512"` — via `CFLAGS`, not `CPPFLAGS`
+  (which carries `-DPATH_PREFIX`/`-DHOST_MACOS` and would be replaced, giving a
+  compiler that cannot find its includes). Changing them does not retrigger
+  the freshness check: `make clean-cc && tools/setup-cc.sh`.
+- SmallerC will not parse `-32768` (`Constant too big`): write `-32767 - 1`.
+- **`char` is signed and `int` is 16 bits.** `char c; if (c == 200)` is never
+  true; use `unsigned char` for a byte.
+- **One translation unit is one namespace.** `Invalid or unsupported
+  redeclaration of 'cw_pap'` — the RTF reader already owned the name in an
+  `#include`d file. Grep every included file for a name before declaring it,
+  and rename with a word-boundary regex (`\bcw_pap\b(?!_)`), because a plain
+  sed also hits `cw_pap_*`.
+- **`imul` refusals are shape problems.** `imul ax, ax, 54 … needs a scratch
+  register … none is provably dead` → `(at<<5)+(at<<4)+(at<<2)+(at<<1)`;
+  `imul ax, ax, 8 … FLAGS is live` → split the expression so the multiply is
+  not the last thing before a test. Make strides powers of two
+  (`CW_SH_STRIDE 128`) so `row*stride` is a shift and never an `imul`.
+- **`binary output format does not support external references` names a
+  symbol you called and never defined** — it surfaces at nasm, not at the
+  compiler, and for an `ovl_*` shim table it surfaces from a line in
+  `build/*.gen.asm` you did not write. The name in the message is the answer.
+- The shim's `%include` path is relative to the nasm `-I apps/ -I build/`
+  line: `%include "cword/cwmove.inc"`, not `"cwmove.inc"`.
+- `%error` inside an `%include`d file was silently dropped on nasm 3.02;
+  guards in the runtime use `%fatal`.
+- **The host harness compiles the same C with clang**, which is stricter about
+  prototypes: `call to undeclared function`, `static declaration follows
+  non-static declaration`. Put prototypes at the top of the main `.c`.
+
+## 4. The four rules, as they were actually met
+
+- **Every out-parameter is a static.** `struct os88_pt org; os88_wm_content(w,
+  &org)` is refused; `static struct os88_pt org;` is the idiom. Half the API
+  is out-parameters. A `static` inside a function is fine and is not
+  re-entrant — a worker and a callback sharing it will pre-empt each other.
+- **A struct table may be INDEXED; only copying is forbidden.** The first
+  menu table was five parallel arrays "so nothing could be copied by
+  accident" and was wrong on day one — four items dropped, every attribute
+  below out of step. `static const struct cw_item cw_it[]` indexed by row
+  copies nothing. Parallel arrays are the error-prone option.
+- **A refused `rep movsb` under a bare `L<n>:` label with no function above
+  it means a struct went by value somewhere** — an argument, an assignment or
+  a `return`. Grep for `struct` on the right of `=` and in argument lists.
+- **Frames were never the problem** — 26 bytes maximum in 158 functions
+  against the 96 cap — because every buffer is static. Keep it that way; the
+  worker task has 256 bytes of stack in total.
+- **The one hand-written byte mover is the only place ES is loaded**, and it
+  is tested on a real x86 with `SS != DS` by a boot-sector harness
+  (`hosttest/cwmovetest.asm`) with negative controls, including "ES not
+  restored → the machine never returns". `os88_memcpy` is ascending-only and
+  smears an insertion; if you need overlap-safe moves you need the same
+  routine and the same test.
+- **A new assembly shim is a new host stub, in the same edit.** Three times
+  the harness failed to link (`Undefined symbols … "_cw_ty_fit"`) because a
+  shim went into `cwtype.inc` and no stub into `hosttest/cwuitest.c`. The build
+  tells you three steps late.
+- **A shim that answers in AL must `xor ah, ah`**, and a shim that passes text
+  to a kernel routine that reads `ES:` must load ES = DS and put it back —
+  ES is `KERNEL_SEG` on every callback and stays so.
+- **`OSAPI_GFX_PEN` is a setter whose argument is CF, and the cell preserves
+  every flag.** A routine that read the carry back as if it were a query
+  greyed a whole band whenever the caller happened to arrive with CF set — a
+  bold+underlined run drawn as a 50% checkerboard, seen once. `clc` before
+  the call. Read a slot's contract for FLAGS as well as registers.
+
+## 5. The budget, and the overlay
+
+The numbers, so the next port can do the arithmetic before it starts:
+
+| | resident image | bss | overlay | spare of 61,440 |
+|---|---|---|---|---|
+| the C demonstrator (3 kernel menus, 4,000-char doc, RTF tables) | 20,086 | 27,050 | — | 14,304 |
+| after the port proper (nine menus, dialogs, search, utilities) | 37,062 | 22,028 | 9,430 | 2,350 |
+| after Page view (+772) and the check mark | 37,886 | 22,032 | 9,430 | 1,522 |
+| RTF engine moved out | 32,874 | 22,032 | 14,646 | 6,534 |
+| + type library + proportional row model | 38,938 | 24,507 | 14,646 | **−2,005 (refused)** |
+| clipboard + paragraph commands moved out | 36,752 | 24,507 | 17,097 | 181 |
+| Font panel moved out | 35,808 | 24,507 | 18,310 | 1,125 |
+| shipping | 35,886 | 24,511 | 18,564 | 1,043 |
+
+- **~9,800 lines of C = ~36KB resident + 18.5KB overlay + 24.5KB bss.** Use
+  that ratio for the estimate in the plan, and expect the first full build to
+  overshoot: the first one here was `image 36236 + bss 27718 = 63954 exceeds
+  budget`, fixed by halving a staging buffer (`CW_RTF_MAX 12000 → 6000`).
+- **bss is the cheap half** — it costs no file bytes and the loader zeroes
+  it. An *initialised* array in `.data` is paid for twice (floppy and
+  region); a 6-byte three-field menu-set struct was chosen over the 36-byte
+  library one for exactly that reason. The next byte to save in CWORD is a
+  buffer moving from bss to a heap claim, not code.
+- **Track the size line from the first commit** and treat 55,000 resident as
+  the trigger: at that point the next wave's first job is the split. CWORD hit
+  the ceiling mid-feature twice, and both times the fix was moving code out,
+  which is cheap only if the code is already the kind that can move.
+- **Split by FREQUENCY, never by size** (§70.14). What a keystroke touches —
+  layout, wrap, the shadow, the chrome, the keyboard, the type library — stays
+  resident; what runs once per command — dialogs, file in/out, search, Sort,
+  Renumber, TOC, the clipboard, the paragraph dictionary, the Font list —
+  goes out. Done that way the resident image got *smaller* while the program
+  grew a view and a text engine.
+- **Renaming a function to `ovl_*` is the entire mechanism.** A regex rename
+  across every `.c` file *and the host harness* is the operation; the counters
+  `cc8086.py` prints (`N functions moved to .modc`, `M resident shims`, `K
+  loading call sites`) are how you know it took.
+- **Only code moves.** Every global, literal and bss byte the moved code
+  names stays resident and DS-relative; that is what makes it possible in C
+  at all. Nothing in an `#include`d shared assembly file (`apps/os88type.inc`,
+  which `apps/word` and `tests/facetest` also include) may be `%ifdef`'d into
+  a section — leave shared code resident and move the UI around it. The
+  useful side effect: the Font list works on a disk with no `.OVL`.
+- **An overlay function answers a status and 0 means it did not happen.** A
+  refused load (no heap, no file, stale module, a worker task asking) toasts
+  the reason and returns 0 without running (§47). Design the callers so 0 is
+  a normal path.
+- **Never call an `ovl_*` from a worker task, and never take one's
+  address.** The worker gate is decided from SP, not from a flag a task that
+  never exits raised once ("works until the app spawns a worker and never
+  again"). `cc8086.py` refuses the address by name.
+- **The `.OVL` is resolved in the launching instance's current directory**
+  (§19.2.1), and a double-click on a document leaves that directory on the
+  *document's* (§54.9). So package, overlay and welcome document are **three
+  files in one folder** on every disk they share — which is why each Word has
+  a folder of its own on `apps-all.img` and never a place in `APPS/`
+  (§19.9). A disk with the package and no `.OVL` is a program whose every menu
+  refuses, politely.
+- **Two calling conventions meet at the overlay boundary and the shim is
+  where copying an assembly idiom into C breaks.** A `call`/`retf` shim is
+  right when arguments travel in registers and fatal when they are on the
+  stack (a far call pushes four bytes of return, so every `[bp+N]` for N ≥ 4
+  is off by two). It is solved once, in `crt0.asm` and `cc8086.py`; do not
+  write your own.
+
+## 6. The redraw path is the design, not the polish
+
+PERFORMANCE.md's prices — 756 µs a `gfx_*` call, ~900 µs a glyph cell, 46.7 µs
+an API call — do not change because the source is C, and C makes the wasteful
+structure the natural one to write. What CWORD does, and what it costs:
+
+- **The glass is shadowed.** `cw_sh[]/cw_sha[]` hold the character and
+  attribute of every cell on the screen; a repaint lays out the rows that
+  *could* have changed, compares each against the shadow, and draws only the
+  columns that differ. A keystroke is **5 calls and 8 cells**; the one that
+  scrolls is 8 and 9; a full repaint of the 69×24 view is 132 calls and 1,899
+  cells — **1.8 seconds** on the target, which is what a screen of text costs
+  whoever draws it. Design this in wave 1. A full repaint per keystroke is a
+  defect, not a first draft.
+- **The layout stops early.** After an insertion the rows below hold the same
+  text one byte along; the moment a row's new start equals its old start plus
+  the delta, `cw_relayout` stops.
+- **A row's break is decided by the character one PAST its end**, so an edit
+  in row N can move row N−1's break: relayout starts one row *above* the edit
+  (`cw_from--`). Found by the harness; the glass had kept "...three times" for
+  "...three times acr" through a whole session.
+- **The row pitch is 11, not 10, and it is a variable.** The italic
+  overstrike sits one pixel above the glyph band and the double underline two
+  below; at pitch 10 the rule landed exactly where the next row's italic goes
+  and rubbed it out on every repaint. Model every pixel row outside the band
+  separately, and let a face off `FONTS/` bring its own height.
+- **One decision per cell, one call per RUN.** Bold is a second strike one
+  pixel right, italic a strike up-and-right, the underlines are drawn rules,
+  small caps a case map — each ONE extra call per run, never one per glyph.
+  A row of proportional type composes into a 1bpp band in the package's RAM
+  and goes down with **one `gfx_blit1`**; the three per-character walks
+  (`ty_fit`, `ty_pen`, `ty_hit`) are assembly called once a row.
+- **The ruler scale was ~70 `gfx_pixel`/`vline` calls** — "54 ms and a third
+  of everything a full repaint did" — until it became one `gfx_blit1` band
+  (203 → 132 calls). Anything drawn from a loop of primitives is a band
+  waiting to happen.
+- **The status line delta-draws** (was 44 cells a keystroke to change `Col
+  n`); **a scroll's vacated row is one white fill plus its text** (79 → 9
+  cells), and that test must be first in the shadow-compare chain.
+- **Paste opened the hole once.** One `memmove` per pasted character on a
+  4,000-char document is 16MB moved — about four minutes on the target.
+- **After any panel owns the glass, invalidate the shadow.** A dialog, a
+  menu, the About box, the Standard File dialog: `ovl_dlg_paint` clears
+  `cw_sh_ok` and the caret flag; `os88_onfile` always redraws, because after a
+  Save the row read `iH#there bold` — the shadow still described what the
+  dialog had covered. The harness's shadow-vs-glass audit is what names the
+  step at which the shadow starts lying.
+- **`os88_wm_destroy` without the gfx lock does not take** — the window
+  hides, the dock tile stays, the program is unreachable and resident. Bracket
+  it with `os88_gfx_lock/unlock`, then `os88_task_alive(win)` *outside* the
+  lock. (There is no self-close slot; File > Close is a worker that sleeps 4
+  ticks and does that.)
+- **No C between `gfx_lock` and `gfx_unlock` that is not bounded by a count
+  you can state.**
+- **Cache on the pick, not on the row.** The pre-shifted glyph table costs
+  ~160 ms once when a face is chosen (a third of one `int 13h`) for 2× off
+  every line after; its one refusal is the carry deliberately dropped,
+  because there is nothing the caller could do about it.
+- **The three emulator-invisible defects** — a visible redraw, a double-draw
+  flash, input overrun — never show in a screendump. The harness's cost table
+  is how you see the first two.
+
+## 7. The host harness: where the real bugs were
+
+`apps/cword/build.sh` runs four host checks before anything is built for the
+8086, and every one stops the build: the RTF tables check themselves; the RTF
+reader and writer round-trip documents; **`hosttest/cwuitest.c` includes the
+whole program against a stub `os88.h`, drives it like a user, rebuilds what the
+screen ought to show from an independently written wrap after every keystroke,
+audits the shadow against the modelled glass, and prints the cost table**;
+`cwmovetest` runs the byte mover on a real x86. Three real defects came out of
+the UI harness that no screendump would have shown (the row-above break, the
+pitch collision, the modal panel and the shadow). Build the skeleton of it in
+wave 1 and grow it with the program.
+
+Traps in the harness itself:
+
+- **A stub that always refuses measures the fallback path.** The stub
+  `os88_gfx_blit1` refused, so the cost table priced the 71-call fallback
+  until the stub modelled the real thing. Verify the stubs model what the
+  machine does.
+- **A cost fixture filled to the cap measures the refusal path** (0 calls per
+  "keystroke"). Use 30 lines, not `CW_DOC_MAX`.
+- **The scripts change with the product.** File > New started asking Word's
+  save-changes prompt (`Tab, Enter`), About became modal (Esc, not a click),
+  Copy needed a selection first, and a step left the caret at 0 so a
+  selection copied nothing. Print the whole row — glass, model, shadow,
+  document — on any failure.
+- The stub `os88.h` grew with every API the program touched
+  (`struct os88_mouse`, `os88_onmouseup`, `os88_worker`, `os88_font_char`,
+  `os88_gfx_line/vline/pixel`, `os88_task_yield/sleep`, `os88_gfx_lock/unlock`
+  …). Budget for that.
+
+## 8. Fidelity: what the original does that this platform bends
+
+- **More menus than `MENU_APPMAX` (5) means the bar is drawn in the window**
+  (§12.2) — CWORD's nine titles are its own, with both period gestures
+  (press-drag-release and click-open), Esc/arrows/Enter/mnemonics and
+  Alt+mnemonic.
+- **The kernel bar shows the instance name unless a menu set says
+  otherwise.** The header's 15-char name is also the `.OVL` stem and the
+  association, so it could not just say "Microsoft Word". The fix is the one
+  `apps/word` uses: register an EMPTY menu set (count 0) whose `AM_NAME` is
+  the product; its command handler is a stub that can never be called, but
+  `CC_HAS_MENUS` declares it and the shim and the C may not drift.
+- **The About box carries the product, the version, what this port is and
+  the attribution — and nothing about how the build renders.** Draft-only
+  notes were removed from it; what is synthesised or unimplemented is a fact
+  about the build and belongs in the SPEC and in the greyed items.
+- **The BIOS folds Ctrl-H/I/M into BkSp/Tab/Enter, so italic, hidden text
+  and one indent have no Ctrl key here; Ctrl+Space arrives as ASCII 32 with
+  the space bar's scan code**, and the "reset character formatting" binding
+  ate every space the user typed ("The quick" arrived as "Thequick", seen in
+  a zoomed crop). Route those four through the ribbon and a dialog.
+- **The kernel face is characters 32..126.** `os88_font_char(0xFB)` for the
+  IBM check mark drew NOTHING, and no checkable item had ever shown a check
+  — it hid because every earlier checkable had its state visible somewhere
+  else. Draft/Page was the first pair where the check *is* the answer. The
+  check is two `gfx_line` strokes; the pilcrow is three drawing calls and
+  rides through the row buffer as a marker byte. Anything outside ASCII is
+  drawn, not lettered.
+- **A dialog is TWELVE rows, which is a 640×200 number** (§39). The panel
+  clamps to the content box but a control's y is `6 + row*10` and nothing
+  clamps that: a 19-row About box put its OK button on the DESKTOP on CGA and
+  Hercules. `6 + 10*10 + 11 = 117` against ~122. Adding a row to a dialog
+  table looks right on VGA and is wrong on two adapters of three; the row
+  count is a compatibility constant and carries a comment saying so.
+- **A list wraps into columns sized from the live window height**, not from
+  its length — the Font list ran off the bottom of a 200-line screen.
+- **Grey rounds to black on 1bpp**, so a disabled item is a checkerboard and
+  a ring is dotted; look at a greyed item and a dialog on `VIDEO=cga` before
+  calling a drawing change done.
+- **Mouse-up is delivered wherever it happens.** Choosing a menu item whose
+  row lay over the text band selected from the caret to the release point;
+  `os88_onmouseup` acts only if a press in the text set the drag flag.
+- **A modal dialog's controls that overlapped its labels** (OK/Cancel at
+  column 26 over text) and a **ruler whose numbers landed inside its
+  buttons** were both found by cropping and zooming a screendump; the strip
+  grew, the buttons moved. Look at every strip at zoom before believing it.
+- **Ambiguity in the ask is enumerated, not guessed.** "Images with all the
+  apps on 1.44MB disks, but keep the two Words separate" had a reading that
+  rebuilt the shipped apps disks and one that added a fifth image; saying so
+  in a sentence got the precise answer.
+
+## 9. Files, make, disks
+
+- **One translation unit, split by concern into `#include`d `.c` files**
+  (`cwmenu.c` tables, `cword.c` model + engine, `cwchrome.c`, `cwdrop.c`,
+  `cwcmd.c`, `cwovl.c`, `cwrtfio.c`, `cwrtftbl.c/h`), and **make cannot see
+  through `#include`**: `$(BUILD)/<name>.raw.asm: <every included file>` and
+  `$(BUILD)/<name>.bin: <every %included .inc>` — or an edit leaves a stale
+  `.o88` and reads exactly like a change that did nothing. `touch` the main
+  `.c` or `rm build/<name>.o88` when in doubt.
+- `$(eval $(call CC_PACKAGE,<name>,<dir>,<NAME>.OVL))` — the third argument
+  turns the overlay cut on (`tools/os88ovl.py --trim`); without it the build
+  fails at `os88pkg: image size field != actual file size` once any `ovl_*`
+  exists.
+- **Every image in three geometries, each `os88disk.py --verify`ed** in the
+  recipe (`--verify` is a standalone invocation and takes no other
+  arguments). The 360KB build is where a port most needs re-checking: with
+  CWORD on it the XT apps disk would sit at 347/354 clusters.
+- **Nothing in `all` may need the compiler.** The C targets are on demand
+  (`cword`, `cworddisk`, `allapps`), reach the compiler only through the
+  `cc-toolchain` guard, and `cc-note` prints one paragraph when `build/cc` is
+  absent. `make clean` spares `build/cc`.
+- **A generated sample document shares the parser with the existing one**
+  (`tools/os88rtf.py` imports `parse_line` from `tools/os88doc.py`) — a second
+  parser is a second dialect. It is deterministic so the shipped file
+  rebuilds byte for byte.
+- **Verify a saved file from the host by walking the FAT12 directory entry
+  to its cluster**, not by grepping the image for its magic — the first grep
+  found the package's own string literals.
+- **The C SDK has no build-time association block**, so `assoc=0` in the
+  header and `.RTF` is not double-clickable on a cold boot until the program
+  has run once (`os88_assoc_set()` is runtime). Known, ~15 lines in
+  `crt0.asm` (§54.6), left as an SDK change. Say so in the plan if the port
+  has a document type.
+- **The 86Box machine is a copy of one that has booted**, with the B: image
+  and the uuid changed and *nothing else*: 86Box does not reject an unknown
+  `cpu_family`, it substitutes a default speed and rewrites the config on
+  exit. It also rewrites the uuid on every launch — `git checkout` the cfg
+  before committing, and never commit the `nvr/`. `RESET=1|cmos|flash|both`
+  clears CMOS on the way in. One machine, not two: an XT target before
+  anyone has *measured* the port there is a claim, not a machine.
+
+## 10. Testing: the traps, in the order they bit
+
+- **A stale QEMU answers on `build/qmp.sock` with the OLD image.** Every
+  screendump succeeds and shows the previous kernel. `tools/qmp.py
+  build/qmp.sock quit; rm -f build/qmp.sock` before every boot. When more than
+  one checkout is in use, identify a QEMU by `lsof -p <pid> | grep cwd`, not by
+  name — an agent once killed two QEMUs belonging to another checkout. Use a
+  private socket path when the tree is shared (and keep it short: a
+  scratchpad path over ~104 bytes is refused by QEMU).
+- **A double-click is one process.** Two `mouse.py click`s decode as two
+  single clicks; the launch needs two presses inside the 9-tick window. Every
+  session wrote the same tiny driver — `to X Y`, then two `mouse_button
+  1/0` pairs at 80/100 ms — plus `key:`/`shot:`/`sleep:` verbs. `mouse.py`
+  with no arguments tracebacks (`IndexError`); read its source for usage.
+- **`--screen` must match the adapter.** On `VIDEO=cga` clicks scaled for
+  640×480 land nowhere; `mouse.py --screen 640x200`. Hercules is
+  `VIDEO=herc HERCSEG=0x7000` and `tools/hercshot.py build/qmp.sock 0x70000`
+  — `screendump` shows a black image there (docs/HERCULES-TESTING.md).
+- **`VIDEO=` restamps `build/kernel.bin`.** Building a CGA kernel while
+  another agent boots the shared `build/` changes what *they* boot; use a
+  copy of the tree or serialise.
+- **Save into a scratch copy** (`cp build/cword.img /tmp/scratch.img`) so a
+  test's writes do not dirty the build image.
+- **Crop and zoom before concluding a click was lost** — the check mark, the
+  page ticks, the ruler and the eaten space were all `--crop … --zoom 8`
+  findings.
+- **The Bash tool resets cwd between calls**; `cd apps/x && …` heredocs fail
+  with `no such file or directory`. Use repo-root-relative paths.
+- **Patch with `assert s.count(old) == 1`** before every replace; one such
+  assertion stopped a bad edit.
+
+## 11. Working with agents on this
+
+- **SPEC before code, and reconcile after.** The SPEC section was written
+  first every time — `checkdocs.py` runs in `make` and rejects a citation to
+  a heading that does not exist — and it drifted every time (reversed file
+  names, phantom constants, numbers three builds stale). A closing pass that
+  re-measures every number in SPEC, the source header and the README against
+  the last build is part of the work: 37,078 → 37,084 → 37,062 was re-edited
+  three times in one session.
+- **Check for tree movement before a long run.** A `git fetch` mid-flight
+  found main four commits ahead including a 9,000-line SPEC change; the
+  workflow was stopped, the branch fast-forwarded, the brief edited, and the
+  run resumed from cache.
+- **Give every agent exclusive file ownership and a "do not re-derive"
+  block of established facts.** Several honest "not mine to fix" reports
+  followed; schedule an owner for the cross-cutting one-liners (an
+  unterminated comment that ate `OS88_FDLG_SAVE` was reported by three agents
+  and fixed by the fourth).
+- **The adversarial audit found what boot tests could not**: a bss byte the
+  loader never zeroed (odd `.data` length, `.bss` aligned one past the image
+  end) and an `imul` lowering that refused ordinary `return i*10` because the
+  liveness scan stopped at a label. Neither showed on the glass. Review with
+  a lens that is trying to break it.
+- **Only one hand in the translation unit at a time.** Reviewers read; the
+  implementer and the fixer write, in sequence.
+- **Commit and push only when asked**, one commit per coherent step, with the
+  numbers in the message. Leave `vm/*/86box.cfg` unstaged when only its uuid
+  moved.
+
+## 12. What was the user's to decide, and what was not
+
+Asked, with a recommendation each time: the licence posture; overlay-first
+versus a maximal one-segment subset (the user chose overlay-first — the
+mechanism, then everything); whether to trim the RTF tables (kept whole);
+what "images with all the apps" meant. Everything else — the file split, the
+resident/overlay line, buffer sizes, the four-number layout, drawing the menu
+bar in-window, the empty menu set, greying Undo and Page as facts, the pitch,
+the 12 rows, not touching a shared include, not fixing a pre-existing defect
+outside scope (F8 extend, the dialog-dismiss sliver — reported instead) — was
+decided, done, and written down. That is the ratio to keep.

--- a/.claude/skills/port-to-os8088/SKILL.md
+++ b/.claude/skills/port-to-os8088/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: port-to-os8088
+description: Port an existing program - written in C or in any other language - to os8088 as a C package (SPEC.md §70), the way apps/cword ported Microsoft Word 1.1a. Interactive intake of the reference source (scan nearby repos or clone a list), then a multi-agent scouting workflow that drafts the port plan, then one multi-agent implementation workflow per wave, asking the user only at real decisions, and a PR at the end. Runs on Opus 5 or Fable 5 only. Use when the user asks to port, bring over, reimplement or "do a CWORD-style port of" an application.
+---
+
+# Port a program to os8088, in C
+
+This skill turns a reference codebase — the original program, in whatever
+language — into a **native os8088 package written in C**, the way
+`apps/cword/` is Microsoft Word 1.1a. "Port" here means what it meant there:
+**the user interface is the original's, taken from its source and not from
+memory; the behaviour is reimplemented in the strict C subset this toolchain
+compiles; what cannot be carried is present and greyed with the fact that
+greys it, never silently missing.** The code of the original almost never
+compiles here and is not expected to. Its resources, tables, formats and
+behaviour do.
+
+Invoking this skill **authorises the multi-agent orchestration below** (the
+`Workflow` tool — what the user calls "ultracode"). Every phase that reads a
+lot or writes a lot fans out; every decision that is the user's comes back to
+them through `AskUserQuestion`; everything else you decide and record.
+
+Three files travel with this skill and are read by every agent it spawns:
+
+| file | what |
+|---|---|
+| [`LESSONS.md`](LESSONS.md) | everything the CWORD port learned the hard way — the obstacles, in the order a port meets them, each with the fix. **Read it in full before step 1.** |
+| [`workflows/scout.js`](workflows/scout.js) | the scouting workflow: reference source + this tree → a draft port plan and the user's questions |
+| [`workflows/implement.js`](workflows/implement.js) | one implementation wave: implement → three review lenses → fix → independent verify on QEMU |
+
+Also binding, and already in the tree: `docs/C-TOOLCHAIN.md` (what to type
+and what each refusal means), `SPEC.md §70` (the contract), `apps/cc/os88.h`
+(the API), `CLAUDE.md` (the hard rules and the performance table).
+
+---
+
+## 0. The model gate — do this first
+
+This skill is supported on **Opus 5** and **Fable 5** only. Look at the
+`# Environment` block of your own system prompt: it says which model is
+running. If it is not `claude-opus-5` or `claude-fable-5`, say so in one line,
+tell the user to switch with `/model` and re-run `/port-to-os8088`, and
+**stop**. Do not run the workflows on another model: they were sized and
+worded for these two, and a smaller model reading twenty thousand lines of
+someone else's source and a 50,000-line SPEC does not scout, it guesses.
+
+Never pass a `model` override to an agent inside the workflows — they inherit
+the session model, which is the one the gate just checked.
+
+## 1. Read before asking
+
+1. `LESSONS.md` beside this file — all of it.
+2. `docs/C-TOOLCHAIN.md` — the four rules, the ceiling, the overlay.
+3. `apps/cc/os88.h`'s header comment, and skim the prototypes.
+4. `SPEC.md §70.12` (the CWORD account) and `§70.14` (the overlay).
+5. `apps/cword/cword.c`'s header comment — the redraw model and the cost table.
+
+That is ~1,500 lines and it is the difference between a plan that fits and one
+that discovers the 60KB ceiling in wave 4.
+
+## 2. Intake — where is the reference source?
+
+Ask, with `AskUserQuestion`, in one call — three questions:
+
+1. **Where is the reference source?** (single select)
+   - *Scan for repositories here* `(Recommended)` — you list every git
+     checkout in the current directory and its parent (`ls -d ./*/ ../*/`,
+     keep the ones with a `.git`), and the user picks from them.
+   - *I will give you a list to clone* — the user supplies URLs (or paths)
+     in "Other"; you `git clone --depth 1` each into the session scratchpad
+     directory (never into this repo, never into `build/`).
+2. **What is the program?** (single select)
+   - *Infer it from the repository — its name, README and about text*
+     `(Recommended)`
+   - *I will type the name and version* — "Microsoft Word 1.1a",
+     "Lotus 1-2-3 2.01"; the answer arrives as "Other".
+3. **Anything about scope you already know?** (single select)
+   - *No — port it whole and grey what cannot carry* `(Recommended)`
+   - *Yes, I will describe it* — a subsystem to leave out, a file format to
+     prefer, a feature that matters most; arrives as "Other".
+
+If they chose *scan*, run the scan and ask a second `AskUserQuestion`
+(multiSelect) listing what you found — path, top-level language guess from
+file extensions, and one line from its README if it has one — and let them
+pick one or more. If nothing plausible is found, fall through to *clone*.
+
+Then confirm the set back in one line and record it: **write a memory** (a
+`reference` type, like the existing `word-opus-source` memory) naming where the
+reference source lives, because the repo will never say — SPEC.md names the
+release, not a path — and the next session that touches the port will need
+it.
+
+Two things to say to the user here, once, plainly:
+
+- The reference source stays outside this repo. **Nothing is vendored**
+  (CONTRIBUTING.md §6): the port quotes strings, tables and formats and cites
+  the file; it does not copy code. If the reference is under a licence that
+  needs attribution, that attribution goes into every file header that
+  carries derived material and into the About box — CWORD carries the
+  Computer History Museum credit exactly so.
+- The port will be **written in the C this toolchain accepts**, which is
+  smaller than C: no `long`, `float`, `double`, no `&local`, no struct by
+  value, no `printf`, no `malloc` as they know it, one translation unit,
+  60KB. A program that needs 32-bit arithmetic on its hot path is a
+  candidate for a *rewrite of its behaviour*, and the plan will say so.
+
+## 3. Preflight — the machine and the branch
+
+```
+tools/setup-cc.sh && make cc-smoke        # the compiler, at the pinned commit; the smoke test builds
+make covl                                 # the overlay gate builds (you will very likely need the overlay)
+pkill -f qemu-system-i386 || true         # a stale QEMU answers on build/qmp.sock with an OLD image
+git status --short                        # clean tree
+git checkout -b port/<name> main          # branch; never work on main
+```
+
+If `setup-cc.sh` fails, that is a blocker for the *user* (network, Xcode
+tools) — say what it printed and stop. Every later step needs the compiler.
+
+## 4. Scout — the multi-agent survey
+
+```
+Workflow({ scriptPath: "<abs repo>/.claude/skills/port-to-os8088/workflows/scout.js",
+           args: { repo: "<abs repo>", sources: ["<abs path>", ...],
+                   app: "<program name and version>", name: "<proposed package name or ''>",
+                   notes: "<the user's scope notes>" } })
+```
+
+It runs one scout per reference repo and three over this tree, one planner,
+three adversarial reviewers and a reconciler, and returns `{ plan, sources,
+tree, reviews }`. The plan is JSON in the shape `PLAN_SCHEMA` in `scout.js`:
+name, authority table (surface → defining source file), scope
+(ships / greyed-with-fact / absent), file split, byte budget with its basis,
+API gaps, **waves**, verification, risks, and **questions**.
+
+While it runs, do nothing that touches the tree. If it returns with a
+source report missing (a null in `sources`), say which repo failed and re-run
+scouting for that one alone before planning on three-quarters of the facts.
+
+## 5. Decide — the user's questions, and yours
+
+Take `plan.questions` to the user with `AskUserQuestion`, **at most four
+questions per call**, each with the plan's options and its recommendation
+first, labelled `(Recommended)`. Typical ones, and they are the only kind that
+belong here:
+
+- the package name, if the plan's is unsure or collides
+- a scope cut that changes what ships (which of two file formats; whether a
+  whole subsystem is greyed or built)
+- whether to spend an API slot / add a thunk versus greying a feature
+- which reference wins where two disagree
+
+Everything else — the file split, the wave order, the buffer sizes, which
+mode the program opens in — **you decide**, and you record the decision in the
+plan. Do not ask a question whose answer is in `LESSONS.md` or the SPEC.
+
+Then write the plan into the tree, in this order:
+
+1. **`SPEC.md`** — a new top-level section at the end (the next free number),
+   titled `<N>. <NAME> — <Product>, written in C`, in the shape of §70.12:
+   what it is, where the UI comes from (the authority table), the two segments
+   and the byte budget, what ships, what is greyed and the fact for each, the
+   names (package, dir, images, vm) and the sentence that it shares nothing
+   with any other package. SPEC is updated **before** the code, and this is
+   the section every wave amends. `make` runs `tools/checkdocs.py`, so every
+   `§` you cite must exist.
+2. **`docs/<NAME>-PORT-PLAN.md`** — the plan itself, with the user's answers
+   folded in and the questions section replaced by "Decisions". This is the
+   file the implementation workflow reads.
+3. Commit the two: `Plan the <NAME> port (SPEC.md §<N>)`.
+
+## 6. Names, once
+
+Before wave 1, check every name the plan uses collides with nothing:
+`ls apps/ vm/ | grep -i <name>`, `grep -in <name> Makefile | head`. A package,
+its directory, its disk images, its vm directory and its extension must not
+answer to an existing program's name — `apps/word` and `apps/cword` are two
+programs with one ambition and **share nothing**, by rule (SPEC.md §70.12).
+Package names are ≤ 15 characters, upper case in `CC_PKG_NAME`.
+
+## 7. Implement — one workflow per wave
+
+For each wave `n` in the plan, in order:
+
+```
+Workflow({ scriptPath: "<abs repo>/.claude/skills/port-to-os8088/workflows/implement.js",
+           args: { repo: "<abs repo>", plan: "<abs repo>/docs/<NAME>-PORT-PLAN.md",
+                   wave: n, name: "<NAME>", dir: "apps/<dir>",
+                   sources: ["<abs path>", ...],
+                   decisions: "<every user answer so far, verbatim>", rounds: 2 } })
+```
+
+One implementer builds the wave through the gate, runs the host harness,
+boots it and shoots it; three read-only reviewers (the four rules + budget,
+the redraw budget, fidelity to the source) find what is wrong; a fixer applies
+it; an independent verifier rebuilds, reboots and checks the wave's
+`done_when` with its own eyes. It returns `{ status, report, questions, size,
+shots, reviews }`.
+
+Then, **you**:
+
+- `status: done` — read `report` and `size`, **look at two of the `shots`
+  yourself** (Read the PNGs), run `make` once (the doc gate) and commit the
+  wave: subject `<NAME>: <what the wave added> (§<N>)`, body with the size
+  line and how it was verified. Amend the SPEC section if the wave changed a
+  fact in it. Go to the next wave.
+- `status: blocked` — take `questions` to the user (`AskUserQuestion`, ≤ 4 a
+  call, recommendation first), append the answers to `decisions`, and
+  **re-run the same wave** with the new `decisions`.
+- `status: failed` — read the workflow's `journal.jsonl` (the path is in the
+  tool result), find which agent failed and why, and either re-run the wave
+  or fix the specific thing by hand and re-run. Do not skip a wave; a later
+  wave builds on it.
+
+Watch the size line across waves. The moment resident image + bss passes
+**55,000 of 61,440**, the next wave's first job is the overlay split, not a
+feature — `LESSONS.md` "The overlay" says what moves and what may not.
+
+Between waves the tree always builds and boots. If it does not, that is the
+thing to fix before anything else.
+
+## 8. Finish
+
+When the last wave is done:
+
+1. **The disk and the machine.** The plan's disk target builds all three
+   geometries and `--verify`s each (copy the `cworddisk` rules). Ask the user
+   whether the port gets its own 86Box machine (`vm/<machine>/86box.cfg`,
+   copied from `vm/386-c-word/86box.cfg` with the B: image and the uuid
+   changed and **nothing else** — see LESSONS.md on 86Box rewriting configs)
+   and whether it goes onto `make allapps` (SPEC.md §19.9: a package with an
+   overlay gets a **folder of its own** on that disk, never `APPS/`).
+2. **The documents.** The SPEC section is final and its numbers are the
+   shipping ones (`os88pkg` line, overlay size, frame max, the harness's cost
+   table). `docs/<NAME>-PORT-PLAN.md` gets a closing "What shipped" section.
+   `README.md` gets a paragraph beside the CWORD one under *A package can also
+   be written in C*. `CLAUDE.md`'s command table gets the new targets if they
+   are on demand like `cword`'s.
+3. **The gates.** `make clean && make` (nothing in `all` may need the
+   compiler — your targets are on demand); `make <name>disk`; the host
+   harness; boot the 360KB image once (`make test TESTAPPS=build/<name>360.img`);
+   `VIDEO=cga` once and look at a dialog and a greyed item on it.
+4. **The PR.** Push the branch and open the PR against `main` with the body
+   CONTRIBUTING.md §7 asks for: what changed and why, which SPEC sections
+   moved, **how you verified it** with the exact commands and cropped
+   screendumps, and whether the 360KB build was booted. Attach the cost
+   table. Add `Co-Authored-By: Claude <model> <noreply@anthropic.com>`.
+5. Tell the user, in a paragraph they can paste into a release note, what the
+   port does, what it greys, and what it costs — numbers, not adjectives
+   (the `release-os8088` skill's "Writing the copy" section is the standard).
+
+## When to stop and ask, and when not to
+
+Ask (`AskUserQuestion`, with a recommendation) when:
+
+- a scope cut changes what ships, or a feature would need a new kernel
+  facility rather than a thunk;
+- two references disagree about the UI;
+- a name collides;
+- a wave comes back `blocked`;
+- the plan wants to raise `KERN_BUDGET`, `KERN_CODE_MAX` or `APP_MAX_SIZE` —
+  the answer is no unless the user says otherwise, and CLAUDE.md says why;
+- the reference's licence needs something you cannot give.
+
+Do not ask about: file layout, buffer sizes, wave order, which precedent to
+copy, whether to build the harness (always), whether to use the overlay (when
+the size line says so), whether to grey rather than fake (always grey a fact).
+Those are in `LESSONS.md` and were settled once.

--- a/.claude/skills/port-to-os8088/workflows/implement.js
+++ b/.claude/skills/port-to-os8088/workflows/implement.js
@@ -1,0 +1,168 @@
+// =============================================================================
+// port-to-os8088 / workflows/implement.js  --  ONE WAVE OF THE IMPLEMENTATION
+//
+// Invoked by the port-to-os8088 skill (SKILL.md, step 7) ONCE PER WAVE:
+//
+//   Workflow({ scriptPath: "<repo>/.claude/skills/port-to-os8088/workflows/implement.js",
+//              args: { repo: "<abs path of the os8088 checkout>",
+//                      plan: "<abs path of docs/<NAME>-PORT-PLAN.md>",
+//                      wave: <n>,
+//                      name: "<package name>", dir: "<apps/<dir>>",
+//                      sources: ["<abs path of reference repo>", ...],
+//                      decisions: "<the user's answers so far, verbatim>",
+//                      rounds: 2 } })
+//
+// One wave per run, on purpose: a blocker inside a wave comes back to the
+// skill as a QUESTION and the skill asks the user before the next wave; and a
+// run stays under 15 agents. Only ONE agent edits the tree at a time - the
+// implementer, then the fixer - and every reviewer is read-only, because a C
+// package is one translation unit and two hands in it do not merge.
+//
+// Returns { status: 'done' | 'blocked' | 'failed', report, questions[],
+//           size, shots[], reviews }.
+// =============================================================================
+export const meta = {
+  name: 'port-implement-wave',
+  description: 'Implement one wave of a port plan, review it through three lenses, fix, and verify on QEMU',
+  phases: [
+    { title: 'Implement', detail: 'one agent writes the wave, builds through the gate, runs the harness, boots it' },
+    { title: 'Review', detail: 'three read-only lenses: the four rules + budget, the redraw budget, fidelity to the source' },
+    { title: 'Fix', detail: 'the findings are applied and the build re-run; up to `rounds` times' },
+    { title: 'Verify', detail: 'a fresh agent boots the result and takes the screendumps the plan asked for' },
+  ],
+}
+
+const REPO = args.repo
+const SKILL = REPO + '/.claude/skills/port-to-os8088'
+const ROUNDS = args.rounds == null ? 2 : args.rounds
+const WAVE = args.wave
+
+const READ_FIRST = `Read, in this order, before touching anything:
+  ${SKILL}/LESSONS.md            (what the CWORD port learned - binding)
+  ${args.plan}                   (the port plan - wave ${WAVE} is yours)
+  ${REPO}/docs/C-TOOLCHAIN.md    (the four C rules, refusals and their fixes, the overlay)
+  ${REPO}/apps/cc/os88.h         (the API; its header comment is the short version of the rules)
+  ${REPO}/CLAUDE.md              (hard rules; the performance table; the two testing traps)
+Precedent to copy, not to admire: ${REPO}/apps/cword/ (the C port of Word - its files, shim, hosttest/, Makefile rules), ${REPO}/tests/covl/covl.c (the overlay gate), ${REPO}/apps/cc/ccsmoke.c (the template).
+Reference source(s) the UI is taken from, verbatim: ${(args.sources || []).join(', ')}
+Decisions the user has already made (binding): ${args.decisions || '(none yet)'}`
+
+const IMPL_SCHEMA = {
+  type: 'object', required: ['status', 'report', 'questions', 'size', 'shots', 'files_touched'],
+  properties: {
+    status: { type: 'string', enum: ['done', 'blocked', 'failed'] },
+    report: { type: 'string', description: 'what was built, how it was verified, the exact commands, and what a reviewer should look at' },
+    questions: { type: 'array', items: { type: 'object', required: ['q', 'options', 'recommend', 'why'], properties: {
+      q: { type: 'string' }, options: { type: 'array', items: { type: 'string' } }, recommend: { type: 'string' }, why: { type: 'string' } } },
+      description: 'ONLY decisions the user must make. Empty when status is done and nothing is open' },
+    size: { type: 'string', description: 'the os88pkg line verbatim (image=, bss=) and, if there is an overlay, the .OVL size; plus the frame-size max cc8086 printed' },
+    shots: { type: 'array', items: { type: 'string' }, description: 'paths of screendumps taken, under build/port-shots/' },
+    files_touched: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object', required: ['lens', 'verdict', 'findings'],
+  properties: { lens: { type: 'string' }, verdict: { type: 'string', enum: ['pass', 'fix', 'fail'] },
+    findings: { type: 'array', items: { type: 'object', required: ['severity', 'file', 'finding', 'fix'], properties: {
+      severity: { type: 'string', enum: ['blocker', 'major', 'minor'] }, file: { type: 'string' }, finding: { type: 'string' }, fix: { type: 'string' } } } } },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object', required: ['pass', 'report', 'shots'],
+  properties: { pass: { type: 'boolean' }, report: { type: 'string' }, shots: { type: 'array', items: { type: 'string' } } },
+}
+
+const RULES = `Non-negotiable while you work:
+- Build ONLY through the tree's rules: the plan's make target (\`make ${args.name.toLowerCase()}\` unless the plan names another - a CC_PACKAGE rule), the disk target, and the package's host harness. Never pass --no-gate or --quiet to cc8086.py. Read every refusal: the message names the fix, and the C function is the nearest _label: above the reported line in build/*.raw.asm.
+- After every successful build, record the os88pkg size line. If resident image+bss passes 55,000 bytes, STOP adding and move per-command code to ovl_* (LESSONS.md, "the overlay") before continuing.
+- Boot what you built: \`make test TESTAPPS=build/<img>\` (kill any stale qemu first: pkill -f qemu-system-i386; a stale one answers on build/qmp.sock with the OLD image), drive it with tools/mouse.py / tools/qmp.py, screendump with tools/shot.py --crop --zoom into build/port-shots/wave${WAVE}-*.png, and LOOK at the PNG (Read it) before believing it. Quit qemu when done (tools/qmp.py build/qmp.sock quit).
+- Take every user-visible string, mnemonic, shortcut and dialog field from the reference source files the plan names. Do not invent UI. What you cannot carry is present and greyed with its FACT (SPEC 47), never silently missing.
+- Do not commit. Do not touch apps/word, apps/cword or any other package. Do not raise KERN_BUDGET, KERN_CODE_MAX or APP_MAX_SIZE.
+- If a decision is genuinely the user's (a scope cut, a name, spending an API slot, two references disagreeing), finish everything that does not depend on it, then return status "blocked" with the question and your recommendation. Do not guess and do not stop early for anything you can decide yourself.`
+
+// ---------------------------------------------------------------- Implement
+phase('Implement')
+const impl = await agent(
+`${READ_FIRST}
+
+You are implementing WAVE ${WAVE} of the port plan for ${args.name}, in ${REPO}/${args.dir}. Wave 1 also creates the package from nothing: the .c and .asm shim (copy apps/cc/ccsmoke.asm's shape and apps/cword/cword.asm's), the CC_PACKAGE line and disk rules and phony target in the Makefile beside cword's (with an explicit prerequisite line for every #included .c/.h - make cannot see through #include), and the host harness skeleton under ${args.dir}/hosttest/ modelled on apps/cword/hosttest/ (a stub os88.h and a driver that includes the program). Later waves extend what is there.
+
+${RULES}
+
+Work until the wave's "done_when" is true on the glass and the harness passes, then return the report. Include in "report" the exact commands you ran, the size line, and where the screendumps are.`,
+  { label: `implement:wave${WAVE}`, phase: 'Implement', schema: IMPL_SCHEMA })
+
+if (!impl) return { status: 'failed', report: 'implementer returned nothing', questions: [], size: '', shots: [], reviews: [] }
+log(`implement: ${impl.status}; ${impl.size}`)
+if (impl.status === 'failed') return { ...impl, reviews: [] }
+
+// ---------------------------------------------------------------- Review / Fix
+const LENSES = [
+  { key: 'rules', prompt: `THE RULES + BUDGET LENS. Read the diff (git diff; git status for new files) and the generated build/*.raw.asm if useful. Check: every addressable object is static; no struct by value; no long/float/double/bit-field; unsigned char where a byte is compared; frames small; no C between gfx_lock/unlock that is unbounded; the shim's CC_HAS_* match the C callbacks; the Makefile has a prerequisite for every #included file; nothing opens its own section; ES-relative window fields go through os88_win_*; ovl_* functions return a status and none has its address taken; no ovl_* is called from a worker task; the size line is honest and under 61,440 with a plan for the next wave's growth; the package/dir/image/vm names collide with nothing.` },
+  { key: 'redraw', prompt: `THE REDRAW-BUDGET LENS (PERFORMANCE.md's rules as CLAUDE.md condenses them). Read the paint / key / click paths in the diff. Price them in gfx calls and glyph cells: does a keystroke repaint only what changed? Is there a shadow of the glass or an equivalent damage model? Is anything drawn twice (erase then draw)? Is a full repaint reachable from an ordinary keystroke, scroll or menu close? Does layout re-run more of the document than the edit could have changed? Do dialogs clamp to the live screen (vid_w/vid_h via os88) and stay within 12 rows? Would this be seconds on a 4.77 MHz 8088? Say what a keystroke costs, in calls and cells, from reading the code.` },
+  { key: 'fidelity', prompt: `THE FIDELITY LENS. Open the reference source files the plan names as authorities (${(args.sources || []).join(', ')}) and compare every user-visible string, order, mnemonic, shortcut caption, dialog field and status field the wave added against them, character for character. Check the greyed items each state a fact. Check the About / product name / kernel bar name are the PRODUCT's, and that the About box says nothing about how the build renders. Check nothing invented was added "for convenience". Look at the screendumps in build/port-shots/ (Read the PNGs) and say whether what they show is what the original shows.` },
+]
+
+let reviews = []
+let round = 0
+let current = impl
+while (true) {
+  phase('Review')
+  reviews = (await parallel(LENSES.map(l => () => agent(
+`${READ_FIRST}
+
+Wave ${WAVE} of the ${args.name} port has just been implemented; the implementer's report follows. Review the working tree READ-ONLY through one lens and try to find what is wrong. Be concrete: file, line, what, and the fix. Prefer few sharp findings. Do not edit anything, do not build, do not start qemu.
+
+${l.prompt}
+
+IMPLEMENTER'S REPORT:
+${JSON.stringify(current, null, 1)}`,
+    { label: `review:${l.key}:r${round}`, phase: 'Review', schema: REVIEW_SCHEMA })))).filter(Boolean)
+
+  const findings = reviews.flatMap(r => r.findings.map(f => ({ ...f, lens: r.lens })))
+  const serious = findings.filter(f => f.severity !== 'minor')
+  log(`review round ${round}: ${findings.length} findings, ${serious.length} serious`)
+  if (serious.length === 0 || round >= ROUNDS) break
+
+  phase('Fix')
+  const fixed = await agent(
+`${READ_FIRST}
+
+You are fixing wave ${WAVE} of the ${args.name} port after review. Apply every blocker and major finding below (and the minors that are cheap), rebuild through the gate, re-run the harness, re-boot and re-shoot what changed, and return the same report shape. If a finding is WRONG, say so in the report with the reason instead of applying it - do not apply a change you can show is a mistake. Do not commit.
+
+${RULES}
+
+FINDINGS:
+${JSON.stringify(serious, null, 1)}
+
+MINOR FINDINGS (apply if cheap):
+${JSON.stringify(findings.filter(f => f.severity === 'minor'), null, 1)}
+
+PREVIOUS REPORT:
+${JSON.stringify(current, null, 1)}`,
+    { label: `fix:wave${WAVE}:r${round}`, phase: 'Fix', schema: IMPL_SCHEMA })
+  if (fixed) current = fixed
+  round++
+}
+
+// ---------------------------------------------------------------- Verify
+phase('Verify')
+const verified = await agent(
+`${READ_FIRST}
+
+You are the independent verifier for wave ${WAVE} of the ${args.name} port. Do not trust the implementer's report: rebuild (the plan's make target - \`make ${args.name.toLowerCase()}\` unless it names another - and its disk target), run the host harness, kill any stale qemu (pkill -f qemu-system-i386), boot with \`make test TESTAPPS=build/<img>\`, double-click Disk B then the package, and check the plan's "done_when" for this wave with your own eyes: drive it with tools/mouse.py and tools/qmp.py, screendump with tools/shot.py --crop --zoom into build/port-shots/wave${WAVE}-verify-*.png, and Read each PNG. If the plan lists a done_when that is visible only on a 1bpp adapter, boot once with VIDEO=cga too (mouse.py --screen 640x200). Quit qemu when done. Report pass/fail with what you saw, and name any screendump that shows a defect.
+
+IMPLEMENTER'S FINAL REPORT:
+${JSON.stringify(current, null, 1)}`,
+  { label: `verify:wave${WAVE}`, phase: 'Verify', schema: VERIFY_SCHEMA })
+
+const status = current.status === 'blocked' ? 'blocked' : (verified && verified.pass ? 'done' : 'failed')
+return {
+  status,
+  report: current.report + '\n\nVERIFIER: ' + (verified ? verified.report : '(no verifier report)'),
+  questions: current.questions || [],
+  size: current.size,
+  shots: [...(current.shots || []), ...((verified && verified.shots) || [])],
+  reviews,
+}

--- a/.claude/skills/port-to-os8088/workflows/scout.js
+++ b/.claude/skills/port-to-os8088/workflows/scout.js
@@ -1,0 +1,191 @@
+// =============================================================================
+// port-to-os8088 / workflows/scout.js  --  THE SCOUTING WORKFLOW
+//
+// Invoked by the port-to-os8088 skill (SKILL.md, step 4) through the Workflow
+// tool:
+//
+//   Workflow({ scriptPath: "<repo>/.claude/skills/port-to-os8088/workflows/scout.js",
+//              args: { repo: "<abs path of the os8088 checkout>",
+//                      sources: ["<abs path of reference repo>", ...],
+//                      app: "<what the user called the program>",
+//                      name: "<proposed package name, <= 15 chars, or ''>",
+//                      notes: "<anything the user said about scope>" } })
+//
+// It reads the reference source(s) and this tree, and returns a DRAFT PORT
+// PLAN plus the list of decisions only the user can make. It writes nothing
+// under apps/ - the plan file is written by the skill after the user has
+// answered, so that a plan never records a decision nobody took.
+//
+// Under 15 agents: N source scouts (one per reference repo, capped at 4) +
+// 3 tree scouts + 1 planner + 3 adversarial reviewers + 1 reconciler.
+// =============================================================================
+export const meta = {
+  name: 'port-scout',
+  description: 'Scout a reference codebase and the os8088 tree, and draft a port plan',
+  phases: [
+    { title: 'Scout', detail: 'the reference source(s) and the os8088 constraints, in parallel' },
+    { title: 'Plan', detail: 'one planner drafts the port plan from every scout report' },
+    { title: 'Verify', detail: 'three adversarial reviewers, then a reconciler folds their findings in' },
+  ],
+}
+
+const REPO = args.repo
+const SKILL = REPO + '/.claude/skills/port-to-os8088'
+const SOURCES = (args.sources || []).slice(0, 4)
+if ((args.sources || []).length > 4) log(`scout: only the first 4 of ${args.sources.length} sources are scouted; name fewer or merge them`)
+
+const SOURCE_SCHEMA = {
+  type: 'object',
+  required: ['path', 'language', 'loc', 'summary', 'ui', 'formats', 'core', 'platform', 'license', 'authority_files'],
+  properties: {
+    path: { type: 'string' },
+    language: { type: 'string', description: 'primary language(s) and dialect/toolchain, e.g. "K&R C + MASM, Windows 2.x API"' },
+    loc: { type: 'integer', description: 'approximate lines of source, all languages' },
+    summary: { type: 'string', description: 'what the program is and does, in one paragraph' },
+    ui: { type: 'array', items: { type: 'object', required: ['element', 'file', 'detail'], properties: {
+      element: { type: 'string', description: 'menu bar / a menu / a dialog / a toolbar / status line / keyboard map / about box / icon' },
+      file: { type: 'string', description: 'the file that DEFINES it - the resource, table or string file, not a caller' },
+      detail: { type: 'string', description: 'what it contains: every string, mnemonic, shortcut, field, in the order the source gives them' } } },
+      description: 'every user-visible surface, each traced to the file that is the AUTHORITY on it' },
+    formats: { type: 'array', items: { type: 'object', required: ['name', 'files', 'notes'], properties: {
+      name: { type: 'string' }, files: { type: 'string' }, notes: { type: 'string', description: 'is it text or binary; is there a reader and a writer; how big is each; which subset a small port could carry' } } } },
+    core: { type: 'array', items: { type: 'object', required: ['feature', 'files', 'loc', 'depends', 'portable'], properties: {
+      feature: { type: 'string' }, files: { type: 'string' }, loc: { type: 'integer' },
+      depends: { type: 'string', description: 'what it needs from the platform: floats, longs, malloc, printf, files, timers, threads, graphics' },
+      portable: { type: 'string', enum: ['as-is', 'rewrite', 'no'], description: 'as-is: plain C the gate will pass; rewrite: the BEHAVIOUR ports, the code does not; no: needs something os8088 has not got' } } } },
+    platform: { type: 'string', description: 'what the program assumes of its platform that os8088 does not offer (window system calls, pcode, DOS int 21h, printer, network...)' },
+    license: { type: 'string', description: 'the license / copyright terms found in the tree, and what attribution they require. Say "none found" if none' },
+    authority_files: { type: 'array', items: { type: 'string' }, description: 'the 5-15 files a porter must read verbatim, in priority order' },
+  },
+}
+
+const TREE_SCHEMA = {
+  type: 'object', required: ['topic', 'findings'],
+  properties: { topic: { type: 'string' }, findings: { type: 'array', items: { type: 'object', required: ['fact', 'where'], properties: {
+    fact: { type: 'string' }, where: { type: 'string', description: 'file:line or SPEC section' } } } } },
+}
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['name', 'summary', 'authority', 'scope', 'files', 'budget', 'api_gaps', 'waves', 'verification', 'risks', 'questions'],
+  properties: {
+    name: { type: 'string', description: 'package name, <= 15 chars, upper case, not already in apps/' },
+    summary: { type: 'string' },
+    authority: { type: 'array', items: { type: 'object', required: ['surface', 'source'], properties: { surface: { type: 'string' }, source: { type: 'string' } } },
+      description: 'for every user-visible surface, the reference file it is taken from - "taken from the source, not from memory"' },
+    scope: { type: 'object', required: ['ships', 'greyed', 'absent'], properties: {
+      ships: { type: 'array', items: { type: 'string' } },
+      greyed: { type: 'array', items: { type: 'object', required: ['item', 'fact'], properties: { item: { type: 'string' }, fact: { type: 'string', description: 'the FACT the greying states (SPEC 47) - "no printer path in this OS", not "not done"' } } } },
+      absent: { type: 'array', items: { type: 'string' }, description: 'left out entirely and why' } } },
+    files: { type: 'array', items: { type: 'object', required: ['file', 'holds', 'resident'], properties: {
+      file: { type: 'string', description: 'apps/<dir>/<x>.c, #included by the one translation unit' }, holds: { type: 'string' },
+      resident: { type: 'boolean', description: 'true = keystroke path, stays in the package segment; false = ovl_* code' } } } },
+    budget: { type: 'object', required: ['image_est', 'bss_est', 'ovl_est', 'basis'], properties: {
+      image_est: { type: 'integer' }, bss_est: { type: 'integer' }, ovl_est: { type: 'integer' },
+      basis: { type: 'string', description: 'how the estimate was made - lines x bytes/line from cword, buffers listed with sizes' } } },
+    api_gaps: { type: 'array', items: { type: 'object', required: ['need', 'slot', 'action'], properties: {
+      need: { type: 'string' }, slot: { type: 'string', description: 'the OSAPI slot or kernel facility, or "none exists"' },
+      action: { type: 'string', description: 'add a thunk to os88thunk.asm + os88.h / write it in the package / grey the feature' } } } },
+    waves: { type: 'array', items: { type: 'object', required: ['n', 'title', 'features', 'files', 'done_when'], properties: {
+      n: { type: 'integer' }, title: { type: 'string' }, features: { type: 'array', items: { type: 'string' } },
+      files: { type: 'array', items: { type: 'string' } },
+      done_when: { type: 'string', description: 'what a screendump / the host harness shows when this wave is done' } } },
+      description: 'implementation order: 1 = window + chrome + model, then the keystroke path, then commands, then file I/O, then dialogs. Each wave builds and boots on its own' },
+    verification: { type: 'array', items: { type: 'string' }, description: 'the host harness to write, the QMP recipe, the 86Box machine, what to measure' },
+    risks: { type: 'array', items: { type: 'string' } },
+    questions: { type: 'array', items: { type: 'object', required: ['q', 'options', 'recommend', 'why'], properties: {
+      q: { type: 'string' }, options: { type: 'array', items: { type: 'string' } }, recommend: { type: 'string' }, why: { type: 'string' } } },
+      description: 'decisions only the user can make: name, scope cuts, file format, whether to add API slots, which reference wins when two disagree' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object', required: ['lens', 'verdict', 'findings'],
+  properties: { lens: { type: 'string' }, verdict: { type: 'string', enum: ['sound', 'fix', 'rethink'] },
+    findings: { type: 'array', items: { type: 'object', required: ['severity', 'finding', 'fix'], properties: {
+      severity: { type: 'string', enum: ['blocker', 'major', 'minor'] }, finding: { type: 'string' }, fix: { type: 'string' } } } } },
+}
+
+const READ_FIRST = `Read, in this order, before anything else:
+  ${SKILL}/LESSONS.md            (what the CWORD port learned - binding)
+  ${REPO}/docs/C-TOOLCHAIN.md    (the four C rules, the 60KB ceiling, the overlay)
+  ${REPO}/apps/cc/os88.h         (the API a C package can reach; its header comment)
+  ${REPO}/CLAUDE.md              (the hard rules and the performance table)`
+
+// ---------------------------------------------------------------- Scout
+phase('Scout')
+const sourceReports = await parallel(SOURCES.map((src, i) => () => agent(
+`You are scouting a reference codebase so that a program can be ported to os8088, an 8086 real-mode GUI OS written in assembly with a C toolchain (SmallerC, 16-bit, no linker, 60KB per package, no float/long/printf/malloc-as-you-know-it).
+
+Reference source root: ${src}
+The program: ${args.app}
+The user's notes: ${args.notes || '(none)'}
+
+Map the tree (ls -R, wc -l, grep) and READ the files that define what a user sees and touches: menu resources, key maps, dialog templates, string tables, status/tool bars, about text, icons; the file formats it reads and writes; the core algorithms; and its license/copyright. Distinguish the file that DEFINES a surface from the ones that merely use it - the porter will quote the defining file verbatim.
+
+For each core feature say honestly whether the CODE can port to a strict 16-bit C subset (no long/float/double, no address-of-local, no struct by value, frames < 96 bytes, no string instructions, one translation unit) or whether only the BEHAVIOUR ports and it must be rewritten. Do not read every file - read the authorities and sample the rest. Do not write anything anywhere.`,
+  { label: `scout:src${i + 1}`, phase: 'Scout', schema: SOURCE_SCHEMA })))
+
+const TREE_TOPICS = [
+  { key: 'api', prompt: `Report the API surface a C package can reach and what it cannot. Read ${REPO}/apps/cc/os88.h in full and ${REPO}/apps/cc/os88thunk.asm; list what is wrapped (windows, drawing, fonts/type library, files, menus, dialogs, clipboard, toast, timers, workers, sound, assoc), what is deliberately NOT wrapped and why, and how a new thunk is added (the pattern in os88thunk.asm, with one concrete example). Then read ${REPO}/apps/os88api.inc's slot list for facilities that exist in assembly but have no C thunk yet. Report facts with file:line.` },
+  { key: 'precedent', prompt: `Report the PRECEDENTS a port should copy. Read the header comments (first ~200 lines) of ${REPO}/apps/cword/cword.c, ${REPO}/apps/cword/cwovl.c, ${REPO}/apps/cword/hosttest/cwuitest.c, ${REPO}/apps/cword/build.sh, ${REPO}/tests/covl/covl.c and ${REPO}/tests/chello/chello.c, and the cword and allapps sections of ${REPO}/Makefile (grep -n cword Makefile). Report: how a C package is split into #included files; the shim; the Makefile rules (CC_PACKAGE, extra prerequisites for #included files, disk rules in three geometries, the vm target); how the host harness stubs the API and what it checks; how the overlay is turned on and cut; how the glass shadow / damage model keeps a keystroke to a handful of calls; where package name, About box and kernel bar name come from. Facts with file:line.` },
+  { key: 'limits', prompt: `Report the LIMITS a port must design against. Read ${REPO}/SPEC.md sections 70.5, 70.7, 70.8, 70.9, 70.11, 70.14 (grep -n '^### 70' SPEC.md for line numbers), ${REPO}/docs/KERNEL-MEMORY.md's summary, and the performance table in ${REPO}/CLAUDE.md. Report: APP_MAX_SIZE and how image/bss/sum are bounded; the frame cap and the stack sizes; the cost table (gfx call, glyph cell, OSAPI call, int 13h); the three emulator-invisible defects; the overlay's rules (only code moves, no address of ovl_*, refused load returns 0, worker tasks may not call it); the section-discipline and label-hygiene rules; SPEC 47 greying; the 12-row dialog limit on 640x200 adapters; SPEC 39's three adapters. Facts with file:line or section.` },
+]
+const treeReports = await parallel(TREE_TOPICS.map(t => () => agent(
+`${READ_FIRST}\n\nThen: ${t.prompt}\n\nReturn structured facts only; you are briefing a planner who has not read the tree.`,
+  { label: `scout:tree:${t.key}`, phase: 'Scout', schema: TREE_SCHEMA })))
+
+const srcOk = sourceReports.filter(Boolean)
+const treeOk = treeReports.filter(Boolean)
+log(`scout: ${srcOk.length}/${SOURCES.length} source reports, ${treeOk.length}/${TREE_TOPICS.length} tree reports`)
+
+// ---------------------------------------------------------------- Plan
+phase('Plan')
+const planPrompt = `${READ_FIRST}
+
+You are drafting the PORT PLAN for bringing "${args.app}" to os8088 as a C package${args.name ? ` named ${args.name}` : ''}. The user's notes: ${args.notes || '(none)'}.
+
+SOURCE SCOUT REPORTS (one per reference repo):
+${JSON.stringify(srcOk, null, 1)}
+
+OS8088 TREE REPORTS:
+${JSON.stringify(treeOk, null, 1)}
+
+Draft the plan. The standard is the CWORD port (SPEC.md 70.12): the user interface is the ORIGINAL's, taken from the source and not from memory - every menu string, mnemonic, shortcut, dialog field and status field traced to the file that defines it - and what cannot be carried is present and greyed with the FACT that greys it (SPEC 47), never silently dropped. The port is a REIMPLEMENTATION of behaviour in a strict C subset, not a compile of the old code: say which parts port as-is and which are rewritten.
+
+Rules the plan must obey, each of which cost the CWORD port real time (LESSONS.md has the detail):
+- ONE translation unit, split into #included .c files by concern; the shim and Makefile prerequisites name every included file.
+- Budget from day one: estimate image + bss against 61,440 with cword's ratio (its 9,800 lines of C = ~36KB resident image + 18.5KB overlay + 24.5KB bss). Anything past ~50KB resident plans an overlay from the start, split by FREQUENCY (keystroke path resident, per-command code ovl_*), never by size alone.
+- The redraw path is designed before a feature is written: a shadow of the glass, damage-only repaint, cost stated in calls and cells. A full repaint on every keystroke is a defect, not a first draft.
+- Every buffer is static; the biggest ones are bss; frames stay small; no long/float; no struct by value; unsigned char for bytes.
+- The 640x200 adapters bound every dialog to 12 rows and every layout reads the live screen size.
+- A host harness (stubbed os88.h + a model of the glass) is planned as part of wave 1, not at the end.
+- Verification is QMP screendumps cropped and zoomed, the host harness's cost table, and one 86Box period machine.
+- Naming: the package, the source directory, the disk images and the vm dir must not collide with anything in apps/ or vm/, and must not answer to an existing program's name.
+- License: name the attribution the reference requires and where it goes (file headers + About box).
+
+Order the WAVES so that each builds and boots on its own: 1 = window, chrome, menu bar (from the source), the document/data model, the harness stub; 2 = the keystroke / interaction path with its damage model; 3 = the commands and their menus; 4 = file format in/out; 5 = dialogs and the rest; 6 = polish (About, icon, welcome document, disk images, vm machine, README/SPEC section). Fewer waves is fine for a small program.
+
+Put in "questions" ONLY decisions the user has to make - the package name if unclear, scope cuts that change what ships, the file format if the original had several, whether to spend API slots, which reference wins where two disagree. Decide everything else yourself and record the decision in the plan.`
+const draft = await agent(planPrompt, { label: 'plan:draft', phase: 'Plan', schema: PLAN_SCHEMA })
+
+// ---------------------------------------------------------------- Verify
+phase('Verify')
+const LENSES = [
+  { key: 'fit', prompt: 'THE FIT LENS. Will this fit and run on the target? Check the byte budget against the source LOC using cword\'s ratio; check every buffer named against bss; check that the wave-1 design has a damage model and does not full-repaint; check that anything on the keystroke path is resident and anything per-command is overlay-eligible; check for float/long/printf/malloc/recursion-heavy/struct-by-value assumptions in the "as-is" features; check the frame cap; check nothing plans a dialog over 12 rows or hard-codes 640x480. Refute the plan where it hand-waves.' },
+  { key: 'fidelity', prompt: 'THE FIDELITY LENS. Is the UI the ORIGINAL\'s? For every surface in "authority", is the named source file really the definer? Is anything user-visible left to memory? Is every dropped feature present-and-greyed with a FACT, per SPEC 47, rather than missing? Are the keyboard collisions the BIOS imposes (Ctrl-H/I/M fold into BkSp/Tab/Enter; Ctrl+Space is a space) accounted for? Does the About box carry the product, the version, what this port is and the attribution - and nothing about how the build renders? Refute where the plan drifts from the source.' },
+  { key: 'process', prompt: 'THE PROCESS LENS. Can this be built and verified in the order given? Does wave 1 boot? Does each wave name what a screendump shows when done? Is the host harness in wave 1? Are the Makefile prerequisites for #included files planned? Do names collide with apps/, vm/, build/ or an existing package? Is the license attribution placed? Are the questions for the user really the user\'s, and is anything left as a question that the plan should simply decide? Refute where a wave depends on a later one.' },
+]
+const reviews = await parallel(LENSES.map(l => () => agent(
+`${READ_FIRST}\n\nA port plan has been drafted for "${args.app}". Review it adversarially through ONE lens and try to break it. Be concrete: name the section of the plan, the number, the file. Prefer few sharp findings to many soft ones. Default to "sound" only if you actually tried and failed to break it.\n\n${l.prompt}\n\nTHE PLAN:\n${JSON.stringify(draft, null, 1)}`,
+  { label: `verify:${l.key}`, phase: 'Verify', schema: REVIEW_SCHEMA })))
+
+const reviewsOk = reviews.filter(Boolean)
+const blockers = reviewsOk.flatMap(r => r.findings.filter(f => f.severity === 'blocker'))
+log(`verify: ${reviewsOk.length} reviews, ${blockers.length} blockers, ${reviewsOk.flatMap(r => r.findings).length} findings`)
+
+const final = await agent(
+`${READ_FIRST}\n\nYou are the reconciler. Fold these adversarial reviews into the draft port plan for "${args.app}": fix what is fixable in the plan itself, keep the plan's decisions unless a finding shows one wrong, and add to "questions" only what a reviewer showed is genuinely the user's call. Keep every field of the schema populated. Add a "risks" line for any major finding you could not resolve.\n\nDRAFT:\n${JSON.stringify(draft, null, 1)}\n\nREVIEWS:\n${JSON.stringify(reviewsOk, null, 1)}`,
+  { label: 'plan:final', phase: 'Verify', schema: PLAN_SCHEMA })
+
+return { plan: final || draft, sources: srcOk, tree: treeOk, reviews: reviewsOk }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,10 @@ Every `nvr/` is gitignored, so neither can reach the repo.
 **Nothing in `build/` is tracked — never commit a binary.** The toolchain is
 deterministic on purpose (`tools/os88disk.py` pins the volume serial and every
 FAT timestamp), so a released image can be rebuilt byte-for-byte. Releases are
-cut by `.claude/skills/release-os8088`.
+cut by `.claude/skills/release-os8088`; a port of an existing program to a
+C package, the way `apps/cword` was made, is driven by
+`.claude/skills/port-to-os8088` (`/port-to-os8088`), whose `LESSONS.md` is
+what that port learned.
 
 ## Hard rules (§1 — these break silently if violated)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,65 @@ Useful in this repo:
   manager. Those two break in ways that only show up as a hang.
 - `claude --permission-mode acceptEdits` if you're tired of approving edits to
   `.inc` files; keep approvals on for `Bash` so you see what it boots.
+- Two project skills live in `.claude/skills/` and Claude Code picks them up
+  automatically: `/release-os8088` cuts a release, and `/port-to-os8088`
+  ports an existing program to a C package — the next section.
+
+#### Porting a program with the agent
+
+`apps/cword` — Microsoft Word 1.1a, in C — was built by porting: the
+original's source next door, this tree's C toolchain (SPEC.md §70), and a
+coding agent finding out, one obstacle at a time, what would and would not
+carry across a 16-bit compiler, a 60KB segment and a 4.77 MHz machine.
+`.claude/skills/port-to-os8088/` is that experience turned into a procedure,
+so the second port does not rediscover the first one's problems.
+
+```
+claude                                  # from the repo root, on Opus 5 or Fable 5
+> /port-to-os8088
+```
+
+What happens, and what it needs from you:
+
+1. **It checks the model.** Opus 5 and Fable 5 are the two it supports; on
+   anything else it tells you to `/model` and stops.
+2. **It asks where the original is.** Either it scans this directory and the
+   one above for git checkouts and lets you pick, or you give it a list of
+   repositories to clone into a scratch directory. The reference source stays
+   *outside* this repo — nothing is vendored (§6 below); the port quotes
+   strings, tables and formats and cites the file.
+3. **It scouts, with a team of agents** (this is the "ultracode" multi-agent
+   orchestration; invoking the skill authorises it), and drafts a plan: which
+   file of the original is the authority for each menu, key, dialog and
+   status field; what ships, what is present-and-greyed with the fact that
+   greys it, what is left out; the byte budget against the 60KB segment and
+   whether an overlay is needed from day one; the API thunks to add; the
+   order of the waves; how it will be verified.
+4. **It asks you only what is yours to decide** — the package name, a scope
+   cut that changes what ships, which of two file formats, whether to spend an
+   API slot, which reference wins when two disagree — with its recommendation
+   first. Everything else it decides and writes into `SPEC.md` (a new section,
+   before the code, as always) and `docs/<NAME>-PORT-PLAN.md`.
+5. **It builds one wave at a time**: an implementer builds through the
+   compiler gate and the host harness and boots the result; three reviewers
+   check the four C rules and the budget, the redraw cost, and fidelity to
+   the source; a verifier boots it again and looks. Each wave is committed. A
+   wave that hits a real decision comes back to you as a question, and the
+   wave re-runs with your answer.
+6. **It finishes**: the three floppy geometries, the 86Box machine if you
+   want one, the README and SPEC paragraphs, `make clean && make`, and a pull
+   request whose body says how it was verified, with cropped screendumps.
+
+Read `.claude/skills/port-to-os8088/LESSONS.md` before you start, even if
+you are going to drive the port by hand instead. It is the list of what the
+CWORD port hit — the compiler's silent narrowing of `float`, the segment
+ceiling arriving mid-feature, the dialog that drew its OK button on the
+desktop on a 200-line screen, the stale QEMU answering with the old image —
+and what each one cost to find.
+
+You can also run any single piece by hand: the two workflow scripts under
+`.claude/skills/port-to-os8088/workflows/` are ordinary `Workflow` scripts
+that take their inputs as `args`, and the skill file says what to pass.
 
 ### Codex
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,22 @@ assembly one, which is the test of whether it was done right.
 **[docs/C-TOOLCHAIN.md](docs/C-TOOLCHAIN.md)** is the guide;
 [SPEC.md](SPEC.md) §70 is the contract.
 
+**Porting something else the same way is a skill.** The CWORD port took four
+sessions of finding out what the toolchain, the 60KB segment and a 4.77 MHz
+8088 would and would not allow, and everything it learned is written down in
+[`.claude/skills/port-to-os8088/`](.claude/skills/port-to-os8088/) as a
+Claude Code skill. Type `/port-to-os8088` in a session on this repo, point it
+at the original program's source — it offers to scan the directories next to
+this one for repositories, or to clone a list you give it — and it scouts the
+source and this tree with a team of agents, drafts a plan, asks you only the
+questions that are yours to answer (the name, a scope cut, which of two file
+formats), then builds the port one wave at a time, each wave reviewed,
+verified on QEMU and committed, and opens the pull request. It runs on Opus 5
+or Fable 5. **[CONTRIBUTING.md](CONTRIBUTING.md#porting-a-program-with-the-agent)**
+says how to use it, and `LESSONS.md` inside the skill is worth reading on its
+own even if you never run it: it is the list of everything that assembles
+cleanly and runs wrong when C meets this machine.
+
 ## Three geometries of everything
 
 | image                  | geometry                 | for                             |


### PR DESCRIPTION
## What changed and why

`apps/cword` (Microsoft Word 1.1a, in C) took four sessions of finding out what SmallerC, the 60KB segment, the overlay mechanism and a 4.77 MHz 8088 would and would not allow. This PR turns that experience into a Claude Code skill, `.claude/skills/port-to-os8088/`, so the next port of an existing program — in C or any other language — does not rediscover the first one's problems.

- **`SKILL.md`** — the procedure. A model gate (Opus 5 and Fable 5 are the two supported models; anything else is told to `/model` and stops); an interactive intake that offers to scan the current directory and its parent for repositories or to clone a list the user gives into a scratch directory; a multi-agent scouting workflow ("ultracode" — invoking the skill authorises it) that drafts the port plan; the plan's open questions put to the user with a recommendation first, ≤4 a call; SPEC section before code; one implementation workflow per wave, each committed; the finishing list and the PR body.
- **`LESSONS.md`** — 488 lines of what the CWORD port hit, in the order a port meets it, each with what fixed it: the fidelity standard (UI from the source, grey a fact), measure-before-scoping, the compiler's quirks, the four rules as actually met, the byte-budget trajectory table and the overlay's rules, the redraw path and its cost table, the host harness and its traps, the 12-row dialog on 640×200, the BIOS key collisions, the stale-QEMU trap, 86Box rewriting its config, and what was the user's to decide. Every agent the skill spawns reads it first.
- **`workflows/scout.js`** and **`workflows/implement.js`** — the two `Workflow` scripts, parameterised by `args`, each under 15 agents. Scout: one agent per reference repo (≤4) + three over this tree → planner → three adversarial lenses (fit, fidelity, process) → reconciler. Implement: one implementer (builds through the gate, runs the harness, boots and shoots) → three read-only reviewers (four rules + budget, redraw budget, fidelity to source) → fixer, up to two rounds → an independent verifier that rebuilds and reboots. Only one agent writes the tree at a time.

`README.md` (under *A package can also be written in C*), `CONTRIBUTING.md` (a new *Porting a program with the agent* subsection under Claude Code) and `CLAUDE.md` (one sentence beside the release skill) say the skill exists and how to use it.

## Which SPEC.md sections moved

None. No interface changed; the skill cites §70, §70.12, §70.14, §47, §39, §19.9 and others, and `tools/checkdocs.py` resolves every one.

## How I verified it

```
git add -A && python3 tools/checkdocs.py     # 983 headings, 127 slots, 0 problem(s) - the new .md files are tracked and checked
make                                          # exit 0, every floppy built
node -e '...'                                 # both workflow scripts parse as async function bodies
```

Nothing boots differently — this PR adds no code to any image. The skill's content was mined from the four CWORD session transcripts (toolchain + demonstrator; overlay + the port proper; Page view + typefaces; product name + disk images) and cross-checked against `docs/C-TOOLCHAIN.md`, SPEC.md §70.12–§70.14, `apps/cword/` and the Makefile.

Not verified: an end-to-end run of the skill on a new program. That is a multi-hour multi-agent job and is the first thing to do with it; the workflow scripts are written to be edited in place (`scriptPath`) if a phase needs re-shaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)