### PR TITLE
README: the disks built on demand, and what ships on them

### DIFF
--- a/.claude/skills/release-os8088/SKILL.md
+++ b/.claude/skills/release-os8088/SKILL.md
@@ -266,23 +266,49 @@ python3 - <<'EOF'
 import glob, os, re
 def n(p):
     return open(p, 'rb').read().count(b'\n')
-inc = re.findall(r'^\s*%include\s+"([^"]+)"', open('kernel/kernel.asm').read(), re.M)
-kern = [os.path.join('kernel', k) for k in inc]
+def incs(path, dirs):
+    out = []
+    for f in re.findall(r'^\s*%include\s+"([^"]+)"', open(path).read(), re.M):
+        for d in dirs:                  # an .asm names its include EITHER
+            q = os.path.normpath(os.path.join(d, f))   # beside itself or
+            if os.path.exists(q):       # apps/-relative, because that is the
+                out.append(q)           # -I nasm is given. Resolve BOTH: the
+                break                   # apps/-relative form is how cword and
+    return out                          # runcpm name theirs, and only trying
+                                        # the sibling form silently drops them
+kern = incs('kernel/kernel.asm', ['kernel'])
 apps = sorted(glob.glob('apps/*/*.asm'))
 pkg = []
 for a in apps:
-    d = os.path.dirname(a)
-    for f in re.findall(r'^\s*%include\s+"([^"]+)"', open(a).read(), re.M):
-        p = os.path.join(d, f)
-        if os.path.exists(p) and p not in pkg and 'zharness' not in p:
-            pkg.append(p)
+    for q in incs(a, [os.path.dirname(a), 'apps']):
+        if q not in pkg and 'zharness' not in q and 'crt0' not in q:
+            pkg.append(q)               # crt0.asm is the C runtime, counted
+                                        # once with the SDK rather than per
+                                        # C package that includes it
 files = ['boot/boot.asm', 'kernel/kernel.asm'] + kern + ['apps/os88api.inc'] + apps + pkg
+files = list(dict.fromkeys(files))
 print('sourceLines', sum(n(p) for p in files if os.path.exists(p)))
 print('modules    ', len(kern))
+# The C is NOT in sourceLines -- the page labels that figure "lines of
+# assembly". Count it separately and quote it in the entry when it moves.
+csrc = [p for p in sorted(glob.glob('apps/*/*.c') + glob.glob('apps/*/*.h'))
+        if 'hosttest' not in p]
+print('C lines    ', sum(n(p) for p in csrc))
 EOF
 ```
 
-**This recipe changed at v1.0.20260810 and the series steps there.** It used
+**This recipe changed AGAIN at v1.0.20260818 and the series steps there too.**
+Package includes are named `apps/`-relative as often as they are named beside
+the `.asm` -- `%include "cword/cwmove.inc"` -- and resolving only the sibling
+form dropped them, cword's and runcpm's bulk among them; the same pass also
+counted `apps/os88api.inc` and `apps/cc/os88thunk.asm` twice, once as a glob
+hit and once as an include, hence the `dict.fromkeys`. Net 9,324 lines out on
+that tree: the old recipe reported 222,280 lines, this one 231,604, and the
+previous release recounts to 228,855 -- **which is the number that entry's
+note quotes, so the +2,749 that is real growth is not read as +9,765.**
+Entries before v1.0.20260818 still hold their own recipe's numbers.
+
+**And it changed at v1.0.20260810 before that.** It used
 to glob `apps/*/*.asm` only, which missed the `.inc` files four packages keep
 their bulk in -- ArtfulType, ModPlug, Tracker and Frotz, 37,309 lines between
 them at that release. The old recipe reported 115,528 lines and 35 modules for

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ make 386-sound  # 86Box: the 386DX, with a Sound Blaster 16
 make worddisk # build the Microsoft Word floppy, all three geometries
 make xt-word  # 86Box: the 640KB XT with the Word disk in B:
 make 386-word # 86Box: the 386DX with the Word disk in B:
+make zdisk    # build the Frotz story floppies (fetches the stories first)
+make xt-z     # 86Box: the 640KB XT with a story disk in B:
+make 386-z    # 86Box: the 386DX with a story disk in B:
+make cworddisk  # build the floppy for the word processor written in C
+make 386-c-word # 86Box: the 386DX with that disk in B:
+make runcpmdisk # build the RunCPM floppies - the CP/M 2.2 emulator, its
+                # overlay, DR's CCP and the master disk as CP/M drive A
+make 386-runcpm # 86Box: the 386DX with the RunCPM disk in B:
+make allapps  # one 1.44MB floppy with every program on it, both word
+              # processors, Frotz and RunCPM included
 make test     # boot headless with a QMP socket for scripted testing
 make debug    # boot with QEMU halted, waiting for gdb on :1234
 make marty    # a cycle-accurate IBM 5150 (MartyPC) with a debugger attached -
@@ -64,6 +74,13 @@ make marty    # a cycle-accurate IBM 5150 (MartyPC) with a debugger attached -
               # what you are testing runs on an 8088 (docs/MARTYPC-DEBUG.md)
 make clean
 ```
+
+`make` builds the six shipping floppies and needs nothing but `nasm` and
+`python3`. The three disks written in C — `cworddisk`, `runcpmdisk` and
+`allapps`, which carries both — want the compiler first: `tools/setup-cc.sh`
+fetches and builds it into `build/cc`, and nothing else in the tree depends on
+it. `runcpmdisk` and `allapps` also fetch RunCPM's command processor and
+master disk (`make runcpm-src`); neither is committed here.
 
 ![what it looks like: gray dithered desktop, menu bar, drive icons, Note Pad,
 Timer, Bounce, Control Panel and Task Manager windows, and the dock
@@ -113,13 +130,14 @@ a Standard File dialog for opening and saving.
 
 **Software**
 
-Sixteen loadable packages ship on the software disk, all closable and most
+Eighteen loadable packages ship on the software disk, all closable and most
 multi-instance:
 
 - **Apps** — Note Pad (word wrap, DOS-readable text files), TeXPad, Paint,
-  ArtfulType, Fractal, Piano, Recorder, Tracker and ModPlug Player (both play
-  Amiga MOD files).
-- **Games** — Minesweeper, Solitaire, Arkanoid, Missile Command and TameGram.
+  ArtfulType, Fractal, Calculator, Piano, Recorder, Tracker and ModPlug Player
+  (both play Amiga MOD files).
+- **Games** — Minesweeper, Solitaire, Arkanoid, Missile Command, Cyclone 88
+  and TameGram.
 - ...plus the Task Manager itself, and HELLO, a minimal package that exists to
   be the smallest thing the SDK can build.
 
@@ -161,6 +179,14 @@ every menu string is verbatim from it. The disk carries `WORD.O88`,
 `WORD.OVL`, a generated `WELCOME.DOC` and an empty `DOCS\`. **`all` does not
 build it and no shipped disk grows a byte** — `make wordcheck` is the format
 gate, which round-trips the `.DOC` through an independent host-side reader.
+
+**Two more ship on disks of their own, and both are written in C** (below):
+`make cworddisk` builds a second Word 1.1a that saves RTF, and `make
+runcpmdisk` builds **RunCPM**, a CP/M 2.2 emulator in a window — a Z80 with
+Digital Research's own command processor at the `A>` prompt, its drives kept
+as folders on the floppy, and RunCPM's master disk in drive A so MBASIC, PIP,
+SUBMIT, TE and Z80ASM run. `make allapps` puts every one of these on one
+1.44MB floppy.
 
 **Hardware**
 
@@ -418,6 +444,7 @@ cleanly and runs wrong when C meets this machine.
 | `build/word*.img`      | 1.44MB / 720KB / 360KB   | Microsoft Word floppies (`make worddisk`) |
 | `build/cword*.img`     | 1.44MB / 720KB / 360KB   | Word in C, package + `CWORD.OVL` (`make cworddisk`) |
 | `build/runcpm*.img`    | 1.44MB / 720KB / 360KB   | RunCPM, package + `RUNCPM.OVL` + CP/M drive A (`make runcpmdisk`) |
+| `build/apps-all.img`   | 1.44MB FAT12             | every program on one floppy, the four above included (`make allapps`) |
 
 The boot sector takes its geometry from `-DSPT` / `-DHEADS` at assembly
 time and reads exactly as many sectors as the measured kernel occupies.


### PR DESCRIPTION
Documentation only -- no image, no kernel byte changes. Cut alongside the
v1.0.20260818 release.

**README.** The `make` block ended at `worddisk` / `xt-word` / `386-word`, so
nothing in it built the CWORD disk, the RunCPM disks, the story disk or
`apps-all.img` -- the four targets a reader most wants after the sections that
describe them. Added, plus a short paragraph saying which need
`tools/setup-cc.sh` and the RunCPM fetch first.

The software list said sixteen packages and omitted Calculator and Cyclone 88;
the disk has carried eighteen since v1.0.20260817. "What it does" also had
nothing about the two C programs that ship on floppies of their own, so it
gains a paragraph naming them and saying what RunCPM runs. `apps-all.img` had
no row in the geometries table.

**Release skill.** The `sourceLines` recipe resolved a package's `%include`
only beside the `.asm`. Packages name theirs `apps/`-relative as often --
`%include "cword/cwmove.inc"` -- so cword's and runcpm's bulk was dropped, and
`apps/os88api.inc` and `apps/cc/os88thunk.asm` were each counted twice. Net
9,324 lines out on this tree: 222,280 reported against 231,604 actual. The
recipe now resolves both forms, dedupes, and counts the C separately, since
the website labels that figure "lines of assembly". The step is recorded the
way the v1.0.20260810 one is, and `data/releases.json` in the website PR
quotes the previous release recounted the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)