### PR TITLE
review-fork-pr: the incoming pull request from someone else's fork, as a skill (/review-fork-pr)

### DIFF
--- a/.claude/skills/review-fork-pr/LESSONS.md
+++ b/.claude/skills/review-fork-pr/LESSONS.md
@@ -1,0 +1,321 @@
+# What seven of these reviews cost to learn
+
+Read before step 2 of [`SKILL.md`](SKILL.md). Every item below happened on a
+real incoming PR to this repository — #47, #54, #61, #66, #73, #80 and #92 —
+and every one of them was silent: the build passed, git reported nothing, and
+the emulator looked right.
+
+`docs/UPSTREAM.md` is the companion to this file and is not repeated here: it
+owns the fork topology, the squash cycle, the shallow-clone trap and the
+merge-resolution defaults. This file is the maintainer's side — reviewing,
+fixing and pushing someone else's branch.
+
+---
+
+## 1. The git mechanics that quietly do the wrong thing
+
+**Pushing to `origin` does not update the PR.** The PR's head lives on the
+contributor's fork. `git push origin HEAD:elendilon-pr` succeeds, creates a
+branch of that name on *your* repository, and leaves PR #66 exactly as it was.
+The session that did it noticed only because it checked `gh pr view --json
+commits` afterwards, and the cleanup was `git push origin --delete`. The
+target is always the fork:
+
+```sh
+git push git@github.com:<owner>/os8088.git HEAD:<headRefName>
+# or, with the remote added once:
+git remote add <owner> git@github.com:<owner>/os8088.git
+git push <owner> pr-<N>:<headRef>
+```
+
+**Check `maintainer_can_modify` before planning to push at all.** It is the
+"allow edits by maintainers" box on the contributor's side. `gh pr view` calls
+it `maintainerCanModify`; `gh api repos/jggonz/os8088/pulls/<N>` calls it
+`maintainer_can_modify`. If it is false, the whole push path is closed and the
+work goes into an integration PR on `origin` instead (#47's shape: their
+commits plus yours, one PR the user merges themselves).
+
+**Re-fetch immediately before pushing.** Contributors work while you review.
+Twice a branch moved mid-review; once the fix was `git rebase FETCH_HEAD`
+(#61) and once `git rebase --onto <owner>/<headRef> <your base> pr-<N>` (#80).
+Test first, and never resolve a divergence with `--force`:
+
+```sh
+git fetch <owner> <headRef>
+git merge-base --is-ancestor <owner>/<headRef> HEAD && echo "fast-forward OK"
+git log --oneline <your base>..<owner>/<headRef>     # what they added
+```
+
+**Work in a worktree, not the user's checkout.** `git worktree add -q
+"$SCRATCH/wt" pr-<N>` keeps the user's tree usable for the hours this takes,
+and keeps a failed merge out of it. Remove it with `--force` at the end and
+`git worktree prune`; the local `pr-<N>` branch survives for the user to test.
+
+**A scratchpad path is too long for a QMP socket.** `AF_UNIX` caps the path at
+~104 bytes and the session scratchpad eats most of that. Boot with
+`/tmp/q<N>.sock`, or build in the worktree and point `BUILD=` somewhere short.
+The failure mode is QEMU refusing to start in a way that reads like a broken
+image.
+
+**A stale QEMU from a previous session answers on `build/qmp.sock`** with the
+*old* kernel. Every screendump succeeds and shows unchanged behaviour, which
+reads exactly like a fix that did nothing. `pgrep -fl qemu-system` before you
+believe a negative result, and compare its start time to `build/kernel.bin`.
+
+## 2. The defect class unique to a long-lived fork: things `main` had and the branch does not
+
+This is the highest-yield review lens in this repository, and **git reports no
+conflict for it**. A branch cut months ago never received the fix `main`
+landed last week; the merge is clean; the fix is simply gone from the result.
+
+- #47 deleted `wm_destroy_seg` — `main`'s sweep that closes a dying package's
+  unbound windows — and documented the resulting use-after-free as an author
+  rule in SPEC.md. The branch's own SPEC section said, in effect, "an orphaned
+  window carries `W_SEG`/`W_DISP` into a freed region and the next repaint far
+  calls whatever claimed it." A rule in the SPEC is not a substitute for the
+  guard it replaced; the sweep was restored.
+- #47 also lost `snd_unhook`'s obligation when the card code moved into
+  `SOUND.DRV`: `int 19h` resets no hardware, so a hooked Sound Blaster rode
+  the reboot with its vector pointing into a heap segment the next boot reuses.
+- #73's second pass found `cache_for()` reading `wm_su_seg` and `wm_su_win` —
+  two variables **the same branch had deleted**.
+
+How to find them, mechanically:
+
+```sh
+BASE=$(git merge-base main pr-<N>)
+git diff --diff-filter=D --name-only $BASE...pr-<N>       # files deleted outright
+git log --oneline $BASE..main                             # every commit the branch has not got
+git log --oneline $BASE..main -- <file>                   # per file, for anything the PR rewrites
+git show main:<file>                                      # what main's version actually says
+```
+
+Read every hunk that *deletes* rather than adds. For each, ask what it was
+guarding and whether the guard exists anywhere else in the merged tree.
+
+## 3. The API slot table breaks the ABI in silence
+
+`apps/os88api.inc` maps a slot number to a far-call cell. A package built
+against `main`'s SDK carries **numbers**, not names.
+
+#47 retired the paragraph arena and moved every entry from `0x01B8` upward
+down three cells. Everything assembled. Everything ran. From `0x01B8` up, a
+package built against `main` called `wm_resize` where it meant `cm_alloc`.
+The resolution: **every slot `main` has published keeps `main`'s number**;
+retired ones stay live at their address, and new work starts at a fresh block.
+
+Cross-check mechanically, by address and by name, and check the *contract* as
+well as the number — `docs/UPSTREAM.md` has the loop. The same address meaning
+something different is the version of this that survives a name check:
+`OSAPI_FONT_GLYPHS` answering `DX:SI` rather than `SI`, the file-dialog
+completion proc gaining `DX:CX`, worker stacks halving from 512 to 256 bytes.
+
+The driver tables have the same shape one level down: #92 grew `FSV_SIZE` from
+28 to 30 verbs without bumping the driver header version, so an older `.DRV`
+and a newer kernel disagreed about the length of a table they both index.
+SPEC's own table still said 28.
+
+## 4. SPEC section numbers collide, and `checkdocs` cannot see it
+
+Both sides add sections; git merges both cleanly; the file now has two `§67`
+headings and `tools/checkdocs.py` — which checks that a citation *resolves* —
+is happy, because it resolves to the first one.
+
+```sh
+grep -oE '^#+ [0-9.]+' SPEC.md | sort | uniq -d     # run after EVERY merge, both directions
+```
+
+The branch's numbering wins at the squash (`docs/UPSTREAM.md`), so the section
+coming *from `main`* is the one that renumbers. In #92 `main`'s §67 C
+toolchain became §70 and its Word/TeXPad references followed those to §68/§69
+— 323 lines. Scope the rewrite to the lines `main` added
+(`git diff $BASE <main-commit>`), never to the whole file, and inventory the
+reference forms before writing the script: `§67`, `SPEC.md 67`, `section 67`,
+`(67.3)`, and headings. Check for false positives — bare `67`s that are menu
+indices or counts. Record the renumbering in `docs/UPSTREAM.md`; that file
+already carries two precedents and is where the next session will look.
+
+`git show c257e9f:SPEC.md | grep -oE '^#+ [0-9.]+' | sort | uniq -d` on the
+*base* tells you which duplicates predate the PR and are not yours to fix.
+
+## 5. What rides in that should not
+
+- **Binaries.** #47 carried a Protracker `.MOD` ("OS8088 TEST") that arrived
+  with an unrelated commit. `git ls-files build | wc -l` must be `0`
+  (SPEC.md §16), and `git ls-files | grep -E '\.(bin|o88|img|mod|drv)$'`
+  finds the rest.
+- **`.claude/`.** #54 checked in a settings file and a session-start hook. Ask
+  the user; the answer has been "no" both times, and the resolution is to
+  take `main`'s version of the directory rather than delete blindly.
+- **`.gitignore` regressions.** #47 lost three `vm/*/nvr/` ignores in a merge,
+  so an emulator's non-volatile state was one boot away from being committed.
+- **Host paths hard-coded in tools.** #92's `tests/heapcheck.py` drives
+  MartyPC with `/home/user/os8088` baked in. Check whether the pattern
+  predates the PR (`git show main:<file>`) before reporting it — that one did,
+  so it was a nit and not a finding.
+
+## 6. The memory-safety defects these PRs actually shipped
+
+The hard rules in `CLAUDE.md` say what the invariants are. This is what
+breaking them has looked like in practice, and every item was found by
+reading, not by running:
+
+- **A pointer banked across a call that can move memory.** `clip_put` held the
+  caller's segment in `BP` across `mem_claim`, then copied from it. With heap
+  compaction (#92) that segment can move inside the call, and the copy reads
+  whatever now lives there. Anything holding a segment or an offset across a
+  claim, a free, a yield or a callback is suspect.
+- **A register promise broken inside a wait.** `inst_park_wait` clobbered `CL`
+  while only `AX`/`BX`/`DI` were pushed above it — quietly breaking
+  `TASK_ALIVE`'s documented register contract for every caller.
+- **A callback clobbering more than the caller banked.** `mem_reloc_call` must
+  save `AX/BX/CX/DX/SI/DI/ES`, because a package's relocation callback may use
+  all of them. "The loop keeps its cursor in SI across the callback" is the
+  same bug written optimistically.
+- **A movable buffer under a `rep movsb` from another task.** The Sound
+  Blaster staging pool stayed movable while a client task copied into it. The
+  fix kept the contributor's design (the pool stays movable) and chunked the
+  copy under the existing guard, rather than pinning the pool because pinning
+  was easier.
+- **State not cleared on slot reuse.** `inst_parksafe[]` survived into the
+  next instance to occupy the slot.
+- **`ES` and `DS` at a boundary.** A callback is entered with
+  `ES = KERNEL_SEG`, so it is `[es:bx+W_W]`; `SS ≠ DS`, so kernel code holding
+  a pointer in `BP` needs `[ds:bp+…]`. #47's `ui_dispatch` read a
+  package-owned `AM_ONCMD` through kernel `DS` and took the right branch only
+  while a random word of kernel `.text` happened to be non-zero.
+- **A critical section that does not cover its own parameters.**
+  `mem_claim`/`_hi`/`_dma` stored their parameter globals *before* the
+  `pushf`/`cli`, so a pre-empted claim could run with another task's
+  constraint — and a lost DMA-page constraint means the 8237 wraps and moves
+  the wrong memory.
+- **A teardown wait measured in the wrong units.** A driver's 40-yield wait
+  completed in microseconds against a worker that sleeps a 55 ms tick, so
+  unload-during-playback freed an image with the worker's `CS` still in it.
+  The kernel counts the *death*, inside `task_exit`'s `cli`.
+
+## 7. Disk, files and formats
+
+- **A failure that does not propagate.** A failed FAT write reported success
+  up the stack (#61).
+- **The right refusal with the wrong reason.** When those writes were made to
+  propagate, both callers reported `FERR_FULL` — "Disk full" — on a marginal
+  drive with thousands of free clusters, which sends the user deleting files
+  that were never the problem. A wrong error message is a real defect; the
+  follow-up comment on #61 exists because of it.
+- **Names from the wire.** #92's `NET.DRV` server took a name from the client
+  and joined it to a path with no validation, so `..\` reached a recursive
+  delete. The fix went into `path_join` — the single choke point every
+  name-taking verb already passed through — and each caller routed the refusal
+  into the `FERR_NOENT` path it already had.
+- **A size that only fits in a word.** A synthesized directory entry clamped
+  the file size to `0xFFFF`, so a 116 KB file listed as 65535 bytes.
+- **512-byte alignment** for anything disk-visible, or `int 13h` answers `09h`
+  on a transfer crossing a 64 KB boundary. The symptom is "Disk error" on a
+  large save.
+
+## 8. Cost, not pixels
+
+Review against `CLAUDE.md`'s table and `PERFORMANCE.md` Part 5's standing
+budget. **A change that reintroduces a full repaint is a regression against a
+documented number, not a neutral refactor.** The three defects an emulator
+cannot show you — a visible redraw, a double-draw flash, input overrun — are
+found by counting primitive calls in the diff, so count them: a `gfx_*` call
+is 756 µs whatever it draws, an `int 13h` ~400 ms whatever it moves.
+
+A PR that says of itself "damage rects in progress but not finished" (#80's
+body did) is telling you where its visible defects are. Read that sentence as
+a review assignment.
+
+## 9. Verification that has actually caught things
+
+- `make` **and** `make KERN_SMALL=1`. A change can fit one kernel and not the
+  other, and a symbol can exist only in the big one — a fix that used
+  `vid_disp_find` broke `kern_small`, which has no second display, until it
+  went under the same guard as its neighbour.
+- `python3 tools/kernsize.py --build … --bless` for **both** variants, in the
+  same commit as the change, as `docs/KERNEL-MEMORY.md` asks.
+- `tools/os88disk.py --verify` on all three geometries.
+- **Boot it.** Then exercise the feature the PR is about: #92's compaction
+  fixes were only believable once Paint drew a stroke, saved `PICTURE.BMP`,
+  and the disk fsck'd clean with a sane 448×280 header afterwards.
+- **Run the PR's own gate** if it ships one (`tests/heapfrag` for compaction,
+  `make zcheck`/`make zgfx` for Frotz, `make rczex` for the Z80 core).
+- **Look at it on a 1bpp adapter.** Grey rounds to black on Hercules and CGA,
+  so a greying change that looks right on VGA can be pixel-identical to a live
+  control there.
+- A driver needs a card to attach to: `make test ADLIB=1` (QEMU's SB16 OPL
+  stub does not answer the boot probe on its own — add the AdLib device too).
+
+## 10. Reviewing at scale
+
+- **Split by subsystem *and* by lens.** `kernel/wm.inc` has arrived with 4,200
+  changed lines; one reviewer takes window state and events, another takes
+  painting and redraw cost, and each is told the other exists so they do not
+  duplicate. 8–14 units for a PR of 100+ files.
+- **Give every reviewer the hard rules verbatim**, and the performance table,
+  and tell it that violations of those rules are the highest-value findings.
+  Tell it what *not* to report: style, naming, "could be refactored",
+  speculation it cannot point at a line for. Three solid findings beat twelve
+  soft ones, and a cap of ~8 per unit keeps the tail honest.
+- **Verify adversarially.** A second agent tries to *refute* each finding and
+  returns `CONFIRMED`/`REFUTED`/`UNCERTAIN` with a corrected fix. Roughly a
+  third do not survive. Two independent reviewers landing on the same defect
+  is the strongest signal available — both the `CL` clobber and the SB pool
+  hazard came in twice.
+- **Read the top findings yourself** before calling anything a blocker. Both
+  #92 blockers were confirmed by eye in a couple of minutes.
+- Do the mechanical work while the agents run: the slot cross-check, the
+  deletion sweep, the size guards, a boot.
+
+## 11. Fixing inside someone else's PR
+
+- Minimal and surgical; match the surrounding style exactly, down to the
+  trailing-comment column and the way `§` is written.
+- **Keep their intent.** Fix the hazard the way their design already handles
+  that class of hazard.
+- **Decline what is not real.** A bad edit to working code is worse than a
+  missed fix, and the report should say why you declined.
+- **Update SPEC.md in the same edit** as anything it pins, and add the author
+  rule where the design already keeps its author rules.
+- **Never raise `KERN_BUDGET` or `KERN_CODE_MAX` as a build fix.** Align a
+  stale symbol to the real value; widen an instrumented-build exemption; but
+  the shipped guard is the user's decision, with whoever asked for the feature.
+- One commit for the merge, one for the fixes, each message naming the § it
+  touches. Do not amend, rebase or squash the contributor's commits.
+
+## 12. The comment on the PR
+
+The reader is the contributor, in a browser, semi-technical. What has worked:
+
+- Two opening lines: what you merged, how many commits you pushed, and that
+  the PR is now mergeable.
+- **One item per fix**, in this order: what would have gone wrong *in the
+  user's world*, then the mechanism in one sentence, then the change and its
+  sha. The disk-full example is the model — "a machine with thousands of free
+  clusters would have told you the disk was full, which sends you off deleting
+  files that were never the problem."
+- A **flagged, not fixed** section, and a line about what you checked and
+  cleared — "I looked and it was fine" is only worth reading if it says where.
+- No blame. These defects live in code that took real work, and the review is
+  a second pair of eyes, not a verdict.
+
+## 13. The checklist
+
+```
+[ ] gh pr view: headRepositoryOwner, headRefName, maintainer_can_modify, mergeable
+[ ] not a shallow clone; PR fetched; scratch worktree; user's tree untouched
+[ ] merge base found; main-side commits read; DELETED files read one by one
+[ ] main merged in; conflicts resolved per docs/UPSTREAM.md defaults
+[ ] duplicate § headings checked by hand; renumber scoped to main-added lines
+[ ] git ls-files build == 0; no .claude/, no binaries, no lost .gitignore lines
+[ ] API slots cross-checked by address AND contract; driver table versions bumped
+[ ] review units written; every finding adversarially verified; blockers read by eye
+[ ] plan presented; user approved before anything was written
+[ ] fixes minimal, SPEC updated with them, no guard relieved
+[ ] make; make KERN_SMALL=1; kernsize --bless both; disk --verify; boot; VIDEO=cga
+[ ] the PR's own gate run; the feature exercised end to end
+[ ] re-fetched the fork; fast-forward proven; pushed to the FORK, not origin
+[ ] PR comment posted: per-fix consequence, mechanism, sha; flagged section
+[ ] worktree removed, no QEMU left running, local branch left for the user
+```

--- a/.claude/skills/review-fork-pr/SKILL.md
+++ b/.claude/skills/review-fork-pr/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: review-fork-pr
+description: Review an incoming pull request that comes from someone else's fork of os8088 - fetch it, merge main into it, review it with a team of agents for memory safety, lost-from-main regressions, redraw cost and disk/data integrity, present a plan, apply the fixes, verify them, push them back to the contributor's branch, and post a hand-holding comment on the PR. Use when the user says a PR came from a fork or another repo, names a PR number to review, or asks to prepare an incoming PR for merge.
+---
+
+# Review a pull request from a fork
+
+A contributor works in their own fork of os8088 and opens a PR against
+`jggonz/os8088:main`. It is usually **large** (98 files and +27,500 lines was
+PR #92; 193 files and +73,000 was #80), usually **long-lived** — cut from a
+`main` that has since moved — and often **conflicting**. Your job is the
+maintainer's: understand it, merge `main` into it, find what would break real
+hardware, fix that, verify it, push the fixes back **to the contributor's
+branch on their fork** so the PR itself becomes mergeable, and explain every
+change on the PR in language a semi-technical reader can follow.
+
+Invoking this skill **authorises the multi-agent orchestration below** — the
+`Agent` fan-out and the two `Workflow` scripts (what the user calls
+"ultracode"). Every decision that is the user's comes back through
+`AskUserQuestion`; everything else you decide and record.
+
+Three files travel with this skill:
+
+| file | what |
+|---|---|
+| [`LESSONS.md`](LESSONS.md) | what seven of these reviews cost to learn — the git mechanics that silently do the wrong thing, and the defect classes this repo's forks actually ship. **Read it in full before step 2.** |
+| [`workflows/review.js`](workflows/review.js) | the review workflow: the PR split into logical units, one reviewer per unit, every finding adversarially verified |
+| [`workflows/fix.js`](workflows/fix.js) | the fix workflow: verified findings in sequential batches, each fixer building and verifying its own batch |
+
+Also binding, and already in the tree: **[`docs/UPSTREAM.md`](../../../docs/UPSTREAM.md)**
+— the fork topology, the squash cycle, the shallow-clone trap and the
+merge-resolution rules. It is written from the *contributor's* side; this
+skill is the same cycle seen from `main`. Read its "Merging upstream in" and
+"The PR back to main" sections before step 4. Then `CLAUDE.md` (hard rules,
+performance table), `SPEC.md` (the binding contract), `CONTRIBUTING.md`
+(what the repo asks of a contribution).
+
+Reviews were sized on **Opus 5** and **Fable 5**. On a smaller model, run the
+review workflow with fewer, narrower units rather than trusting a wide one.
+
+---
+
+## 1. Which PR, and what is it
+
+The PR number may arrive as the argument (`/review-fork-pr 92`). If not, list
+what is open and ask:
+
+```sh
+gh pr list --repo jggonz/os8088 --state open \
+   --json number,title,author,headRepositoryOwner,headRefName,changedFiles
+```
+
+Then get the facts before forming any opinion — **the topology decides what
+you are even able to do**:
+
+```sh
+gh pr view <N> --json title,body,author,headRepository,headRepositoryOwner,headRefName,\
+baseRefName,state,mergeable,mergeStateStatus,maintainerCanModify,additions,deletions,changedFiles,commits
+gh api repos/jggonz/os8088/pulls/<N> --jq \
+   '{maintainer_can_modify, head_repo:.head.repo.full_name, head_ref:.head.ref, head_sha:.head.sha}'
+gh pr view <N> --json comments --jq '.comments[] | "=== " + .author.login + " ===\n" + .body'
+```
+
+| field | why you need it |
+|---|---|
+| `headRepositoryOwner` + `headRefName` | **the push target**: `git@github.com:<owner>/os8088.git HEAD:<headRef>`. Pushing anywhere else does not touch the PR |
+| `maintainer_can_modify` | false ⇒ you cannot push to their branch at all; take the fallback in step 9 |
+| `mergeable` / `mergeStateStatus` | `CONFLICTING` is normal and is step 4's work |
+| `changedFiles`, `additions` | the size gate in step 5 — inline agents or the workflow |
+| the comments | the contributor may have already answered half of what you are about to ask |
+
+State the shape back to the user in two or three lines (who, what, how big,
+how far behind `main`, what conflicts) before you go further.
+
+## 2. Preflight
+
+```sh
+git rev-parse --is-shallow-repository        # true ⇒ every ancestry answer below is a lie
+git fetch --unshallow                        # ...so do this FIRST (docs/UPSTREAM.md rule 0)
+git status --short                           # the user's tree must stay untouched
+pgrep -fl qemu-system                        # a stale QEMU answers on build/qmp.sock with an OLD image
+gh auth status
+```
+
+Read `LESSONS.md` now, in full.
+
+**Fetch the PR and work in a scratch worktree, never in the user's checkout:**
+
+```sh
+git fetch origin pull/<N>/head:pr-<N>
+git worktree add -q "$SCRATCH/wt" pr-<N>          # $SCRATCH = the session scratchpad
+git remote add <owner> git@github.com:<owner>/os8088.git 2>/dev/null || true
+git fetch <owner> <headRef>
+```
+
+The worktree is where every build, boot, edit and commit happens. The user
+keeps a working tree they can use while the review runs, and step 10 hands
+them the branch when it is over. **One caveat that has cost a session:** a
+scratchpad path is long, and QEMU's QMP socket is an `AF_UNIX` path with a
+~104-byte limit — boot with a short socket path (`/tmp/q<N>.sock`), or build
+in the worktree and boot from a short `BUILD=` directory.
+
+Then measure the gap:
+
+```sh
+BASE=$(git merge-base main pr-<N>)
+git log --oneline $BASE..main                       # what main gained since the fork point
+git diff --stat $BASE pr-<N> | tail -40
+git diff --name-status $BASE pr-<N> | awk '{print $1}' | sort | uniq -c   # A/M/D counts
+git diff --diff-filter=D --name-only $BASE...pr-<N>  # DELETIONS - read every one
+```
+
+Deletions are the highest-yield list on the whole PR. A long-lived fork branch
+loses things `main` added, and **git reports no conflict for a file the branch
+simply never received** (LESSONS.md §2).
+
+## 3. Ask the user what shape this run takes
+
+One `AskUserQuestion` call, four questions, recommendation first:
+
+1. **Where do the fixes land?**
+   - *Push to the contributor's branch on their fork* `(Recommended)` — the PR
+     itself updates; requires `maintainer_can_modify`
+   - *A new integration PR on our repo, which I merge myself* — the PR #47
+     shape: their work plus your fixes, one PR you own
+   - *Local branch only* — review and fix, push nothing; the user tests by hand
+2. **Merge `main` into the PR branch first?**
+   - *Yes* `(Recommended)` when `main` has moved — otherwise you are reviewing
+     code against a base that no longer exists
+   - *No* — review as submitted
+3. **What should the review weigh hardest?** (multiSelect; default all)
+   memory safety · lost-from-`main` regressions · redraw/CPU cost against the
+   4.77 MHz budget · disk and file-format integrity · the package/driver ABI
+4. **Stop for your approval after the review?**
+   - *Yes — plan first, change nothing until I say go* `(Recommended)`
+   - *No — review, fix and push in one pass*
+
+Default to plan-first. It is what the last several runs asked for, and on a
+PR this size the plan is the deliverable the user actually reads.
+
+## 4. Merge `main` in — and find what git cannot see
+
+In the worktree:
+
+```sh
+git merge --no-commit --no-ff main
+git diff --name-only --diff-filter=U        # the textual conflicts
+```
+
+Resolve per file with `docs/UPSTREAM.md`'s defaults: **ours** for what the
+branch deliberately changed, **theirs** for what it merely lacks, **theirs**
+for gratuitous divergence. Never blanket `--ours`; for a big file use that
+document's difflib script to list every line `main` added that your side lacks.
+
+Then the four checks git merges cleanly and reports nothing about:
+
+```sh
+grep -oE '^#+ [0-9.]+' SPEC.md | sort | uniq -d      # DUPLICATE § headings - checkdocs cannot see these
+git ls-files build | wc -l                           # must be 0 (SPEC.md 16)
+git ls-files | grep -E '^\.claude/|\.(bin|o88|img|mod|drv)$'   # what rode in that should not have
+python3 tools/checkdocs.py
+```
+
+- **Duplicate `§` numbers are the standard collision.** `main`'s §67 C
+  toolchain met the branch's §67 Cyclone 88 in #92; `main`'s §52 ModPlug met
+  the branch's §52 HDD before that. The branch's numbering wins at the squash,
+  so the *incoming-from-main* section renumbers, and every reference to it
+  moves with it — scope the rewrite to the lines `main` added
+  (`git diff $BASE <main-commit>`), not to the whole file. Record the
+  renumbering in `docs/UPSTREAM.md` beside the existing precedents.
+- **Compare API slot addresses mechanically** — a slot that changed meaning
+  assembles cleanly and calls the wrong routine (LESSONS.md §3).
+- Commit the merge on its own, with a message that says what collided and how
+  it was resolved. Fixes go in a separate commit.
+
+Now build both kernels and boot once, **before** reviewing, so the reviewers
+argue about a tree that works: `make`, `make KERN_SMALL=1` (or `make small`),
+`make test` + a screendump, plus whatever gate the feature owns
+(`tests/heapfrag`, `make zcheck`, `make rczex`, …).
+
+## 5. Review — split it into units, verify every finding
+
+**Under ~30 changed files:** spawn 3–5 read-only `Agent`s in one message, one
+per subsystem, each pointed at the worktree with "do NOT modify any files",
+each told to read `CLAUDE.md` first and to ground every finding in a line it
+actually read. Then confirm the top findings yourself by reading the code.
+
+**Larger:** run the workflow.
+
+```
+Workflow({ scriptPath: "<abs repo>/.claude/skills/review-fork-pr/workflows/review.js",
+           args: { wt: "<abs worktree>", pr: <N>, base: "<merge-base sha>",
+                   emphasis: ["memory", "regression", "redraw", "disk", "abi"],
+                   units: [ { key: "kernel-core", title: "...", paths: "kernel/memory.inc ...",
+                              focus: "..." }, ... ] } })
+```
+
+You write the `units` — that is the part no agent can do for you. Split by
+**subsystem and by lens**, not by file count: `kernel/wm.inc` alone has been
+4,200 changed lines and wants two reviewers, one for window *state* and one
+for *painting*, each told the other exists so they do not duplicate. Every
+unit's `focus` should name what the PR body itself admits is unfinished, what
+it deleted, and which § it claims to obey. Aim for 8–14 units; the workflow
+adversarially verifies each finding and returns only what survived, with a
+`CONFIRMED` / `REFUTED` / `UNCERTAIN` verdict and a corrected fix.
+
+While the agents run, do the mechanical checks yourself: the slot table
+address↔name cross-check, `git log main -- <file>` on every deleted hunk, the
+kernel size guards, and a boot. Two independent reviewers landing on the same
+defect is the strongest signal you will get; read the code yourself for
+anything you are about to call a blocker.
+
+## 6. The plan, and the gate
+
+Present, in the chat and in this order:
+
+1. **What the PR is** — one paragraph, in the user's terms.
+2. **Merge state** — what conflicted, what you resolved, and the semantic
+   collisions git did not report.
+3. **Findings**, ranked, each as: what breaks, when it breaks, and how you
+   would fix it. Say which were confirmed by two reviewers and which you read
+   yourself. Keep refuted findings out of the list; say how many there were.
+4. **What you will not change** — the contributor's design decisions, style,
+   and anything whose fix is a decision rather than a repair (raising a
+   budget, spending an API slot, changing an ABI).
+5. **The plan**: fix these, verify like this, push there, comment that.
+
+Then `AskUserQuestion`. Nothing is written to the fork, the PR, or the user's
+repo before that answer. If the user says "fix all high and medium", that is
+the authorisation for step 7 and no further asking is needed unless a fix
+turns into a design decision.
+
+## 7. Fix
+
+The rules that make a fix acceptable in **someone else's** PR:
+
+- **Minimal and surgical.** No refactors, no reformatting, no improving
+  neighbouring code, nothing outside the finding. Match the surrounding style
+  exactly — comment density, the trailing-comment column, how `§` is written.
+- **Keep the contributor's intent.** If their design says the pool is movable,
+  the fix guards the copy; it does not pin the pool because pinning is easier.
+- **A finding that turns out not to be real is declined, not "fixed".** A bad
+  edit to working code is worse than a missed fix.
+- **SPEC.md is updated in the same edit** as anything it pins — a constant, a
+  register contract, a struct offset, a slot number, an author rule.
+- **Never relieve a guard to make the build pass.** `KERN_BUDGET` and
+  `KERN_CODE_MAX` are the user's call (CLAUDE.md), not a build fix. Align a
+  *stale* symbol to the real value; never raise the real value.
+- `python3 tools/kernsize.py --build build --bless` in the same commit as any
+  kernel size change, both variants.
+
+Up to about eight fixes, do them inline, one at a time, each with its SPEC
+line. More than that, batch them:
+
+```
+Workflow({ scriptPath: "<abs repo>/.claude/skills/review-fork-pr/workflows/fix.js",
+           args: { wt: "<abs worktree>", pr: <N>, batches: [ { key: "B1-...", title: "...",
+                   findings: [...], extra: "batch-specific verification commands" } ] } })
+```
+
+Batches run **sequentially** — they share one worktree, and two agents editing
+one tree do not merge. Each fixer builds, runs its own verification, and
+commits only its own batch. Never let a fixer push.
+
+## 8. Verify
+
+Nothing is pushed until every one of these has run in the worktree and you can
+quote its output:
+
+```sh
+make                                   # nasm -w+error, and checkdocs is a prerequisite
+make KERN_SMALL=1                      # both kernels, both under their guards
+python3 tools/kernsize.py --build build          # and --build build/smallk -DKERN_SMALL
+python3 tools/os88disk.py --verify build/*.img   # structural fsck, all three geometries
+make test                              # boot; screendump the desktop
+make test VIDEO=cga                    # the 1bpp look at anything that draws or greys
+```
+
+Plus, driven over QMP (`tools/mouse.py`, `tools/shot.py`), **the feature the
+PR is about, exercised end to end**: the gate the PR ships if it ships one,
+the file it saves opened again, the app it adds launched and closed. #92's
+compaction fixes were only believable because Paint saved a BMP that fsck'd
+clean afterwards. Crop and zoom before concluding anything about a small
+change.
+
+## 9. Push, and say what you did
+
+**Re-fetch before pushing — the contributor has been working while you were.**
+
+```sh
+git fetch <owner> <headRef>
+git merge-base --is-ancestor <owner>/<headRef> HEAD && echo "fast-forward OK"
+# if not: rebase onto their new head, never force-push
+git rebase --onto <owner>/<headRef> <the sha you started from> pr-<N>
+git push <owner> pr-<N>:<headRef>
+```
+
+- **Push to the fork's remote, not `origin`.** `git push origin HEAD:<headRef>`
+  creates a stray branch on *your* repo and leaves the PR untouched — it has
+  happened, and the cleanup is `git push origin --delete <headRef>`.
+- **Never `--force`** a branch you do not own.
+- If `maintainer_can_modify` is false: take the #47 shape instead — a branch
+  on `origin` carrying their commits plus yours, and a PR whose body says
+  plainly that it contains all of theirs and reverts nothing.
+- Confirm the PR moved: `gh pr view <N> --json mergeable,mergeStateStatus,commits`.
+  `MERGEABLE` + `BLOCKED` means blocked on review approval, which is the user's.
+
+Then the comment. Its reader is **the contributor, semi-technical, reading in
+a browser** — `gh pr comment <N> --body-file <file>`:
+
+- Open with what you did in two lines: merged `main`, pushed N commits, the PR
+  is now mergeable.
+- **One item per fix**: what could have gone wrong *in the user's world* ("a
+  save on a marginal drive would have told you the disk was full, sending you
+  off deleting files that were never the problem"), then the mechanism in one
+  sentence, then what you changed, with the commit sha.
+- A **flagged, not fixed** section — anything you left alone and why.
+- No blame anywhere in it. The defects are in code that took real work.
+
+## 10. Hand back
+
+```sh
+git worktree remove --force "$SCRATCH/wt"
+git worktree prune
+git fetch origin pull/<N>/head:pr-<N> --force && git checkout pr-<N>   # if the user wants to test
+pgrep -fl qemu-system                       # leave nothing running
+git -C <the user's checkout> status --short  # must be exactly what it was in step 2
+```
+
+Leave the local branch pointing at the reviewed code when the user has said
+they want to test by hand — that is the usual request — and say in one line
+which branch and what to run. Then summarise: what the PR is, what you merged,
+what you fixed, what you flagged, what is left for the user (the approval, the
+squash, the merge).
+
+## What this skill does not do
+
+- **It does not merge the PR.** That is the user's, always.
+- **It does not squash or rewrite the contributor's history.**
+- **It does not raise a budget, spend an API slot, or change an ABI** to make
+  something fit; those come back as questions.
+- **It does not vendor anything** or re-add `build/`.

--- a/.claude/skills/review-fork-pr/workflows/fix.js
+++ b/.claude/skills/review-fork-pr/workflows/fix.js
@@ -1,0 +1,164 @@
+// =============================================================================
+// review-fork-pr / workflows/fix.js  --  THE FIX WORKFLOW
+//
+// Invoked by the review-fork-pr skill (SKILL.md, step 7), AFTER the user has
+// approved the plan:
+//
+//   Workflow({ scriptPath: "<repo>/.claude/skills/review-fork-pr/workflows/fix.js",
+//              args: { wt: "<abs path of the scratch worktree holding the PR>",
+//                      pr: <PR number>,
+//                      model: "Claude Opus 5 (1M context)",   // for Co-Authored-By
+//                      batches: [ { key:   "B1-compactor-pointers",
+//                                   title: "Pointers banked across a call that can move memory",
+//                                   findings: [ <verified finding objects from review.js> ],
+//                                   extra: "<batch-specific verification, commands and what they
+//                                            must print>" }, ... ] } })
+//
+// Batches run SEQUENTIALLY on purpose: they share one worktree, and two agents
+// editing one tree do not merge. Each fixer applies its batch, builds, runs its
+// own verification and commits ONLY its own changes. No fixer ever pushes.
+//
+// Returns { reports[], applied, declined, failed[] }.
+// =============================================================================
+export const meta = {
+  name: 'fix-fork-pr',
+  description: 'Apply verified fork-PR review findings in sequential batches, each fixer verifying its own work',
+  phases: [{ title: 'Fix', detail: 'one agent per batch, in order, each building and committing its own' }],
+}
+
+const WT = args.wt
+const PR = args.pr
+const MODEL = args.model || 'Claude Opus 5 (1M context)'
+const BATCHES = args.batches || []
+if (!BATCHES.length) throw new Error('fix.js: args.batches is empty')
+
+const RULES = `You are fixing VERIFIED defects in pull request #${PR} of os8088 - a Macintosh System 1-style GUI
+operating system for the Intel 8086/8088, written entirely in real-mode NASM assembly.
+
+THE PR IS SOMEONE ELSE'S WORK, from a contributor's fork, and the repository owner has approved
+exactly these fixes. That shapes everything below.
+
+WORK IN THIS WORKTREE, and nowhere else:  ${WT}
+Every edit, build and commit happens there. Do NOT push. Do NOT rebase, amend, squash or touch any
+commit that is not your own.
+
+FIRST read ${WT}/CLAUDE.md in full. Its hard rules bind your edits:
+- 8086 only: no pusha/popa, no "push imm", no "shl reg,imm" other than 1, no movzx/movsx, no 32-bit
+  registers.
+- Near model: CS = DS = KERNEL_SEG for kernel code and every task; SS = LOW_SEG. SS != DS, so
+  [bp+disp] addresses SS - kernel code holding a pointer in BP needs [ds:bp+...].
+- Register discipline: public routines preserve every register but their documented outputs. ISRs
+  push DS/ES, load DS = KERNEL_SEG, cld before string ops. Critical sections are pushf/cli ... popf,
+  never cli/sti, and they must cover the operation's parameters as well as its body.
+- Section discipline: a module that switches sections must switch back to .text before the file ends.
+- Label hygiene: every module-internal label carries its module prefix or is a NASM local label.
+- Three adapters, one binary: the live screen is [vid_w]/[vid_h]/[vid_stride], never the VGA
+  reference constants. On 1bpp adapters grey rounds to black, so greying is a pattern through the pen.
+- Package/driver boundary: callbacks are NEAR procs with a near ret, entered with ES = KERNEL_SEG, so
+  a callback reads window fields as [es:bx+W_W], never [bx+W_W].
+- SPEC.md is the binding contract and is updated BEFORE the change, not after. A bare "S" sign
+  anywhere in the repo means SPEC.md. If your fix changes anything SPEC.md pins - a constant, a
+  register contract, a struct offset, a slot number, an author rule - you MUST update SPEC.md in the
+  same edit, in the section that already owns that rule.
+- Performance: the target is a 4.77 MHz 8088. Any gfx_* call costs 756 us whatever it draws; one
+  int 13h call costs ~400 ms whatever it moves. Do not add a redraw, a doubled draw, or a disk round
+  trip. A redraw is priced by how many primitive calls it makes, not how many pixels it covers.
+- NEVER relieve a guard to make something fit. Raising KERN_BUDGET or KERN_CODE_MAX is the repository
+  owner's decision, not a build fix. Align a STALE symbol to the real value if that is the defect;
+  widen an instrumented-build exemption if that is the defect; never move the shipped kernel's guard.
+
+HOW TO WORK:
+1. Your batch's findings are below. Each has already been reviewed and adversarially verified by a
+   second agent: "reasoning" records how the defect was confirmed and "corrected_fix" is the fix that
+   verifier settled on. It is usually precise enough to apply directly.
+2. Before editing, open the cited file at the cited line and confirm the code really is as described.
+3. Apply the corrected fix. Prefer it to inventing your own - it was derived with more context than
+   you have. BUT you are not a typist: if the real code shows the prescribed fix is wrong, incomplete
+   or would break something else, do the RIGHT thing and say in your report exactly what you did
+   differently and why.
+4. KEEP THE CONTRIBUTOR'S INTENT. Fix the hazard the way this design already handles that class of
+   hazard. If their design makes something movable, guard the copy; do not pin it because pinning is
+   easier to write.
+5. If a finding turns out on inspection NOT to be a real defect, do NOT edit. Report it as declined,
+   with your reasoning. A bad edit to working code is worse than a missed fix.
+6. Keep every edit MINIMAL and surgical. No refactoring, no reformatting, no improving nearby code,
+   nothing outside your batch. Match the surrounding style exactly: comment density, the alignment of
+   the trailing comment column, capitalisation, and the way section references are written.
+
+VERIFICATION IS PART OF THE JOB - a fix you have not verified is not done:
+- "cd ${WT} && make" MUST succeed. It runs nasm with -w+error, so any 8086 violation or bad symbol
+  fails the build, and it runs tools/checkdocs.py, so a stale citation fails it too.
+- If you touched anything under kernel/ or the Makefile, ALSO run "cd ${WT} && make KERN_SMALL=1".
+  Both kernels must assemble and both must stay under their size guards - a symbol that exists only
+  in the big kernel is a real and recurring break.
+- If a kernel size moved, run "python3 tools/kernsize.py --build build --bless" (and the small
+  variant) in the same commit, as docs/KERNEL-MEMORY.md asks.
+- Run every batch-specific verification listed in your assignment, and quote what it printed.
+- If your build fails, fix it. Never report a batch whose build does not pass.
+
+COMMIT WHEN DONE, and only then, in the worktree:
+  cd ${WT} && git add -A && git commit
+Write the message in this repo's style: one summary line naming the section or subsystem and what
+changed, a blank line, then one bullet per fix saying what would have gone wrong. End with:
+Co-Authored-By: ${MODEL} <noreply@anthropic.com>
+Commit ONLY your own batch's changes.`
+
+const FIX_SCHEMA = {
+  type: 'object',
+  required: ['batch', 'applied', 'declined', 'verification', 'build_ok', 'commit', 'notes'],
+  properties: {
+    batch: { type: 'string' },
+    applied: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'file', 'what_changed', 'consequence', 'deviated'],
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          what_changed: { type: 'string', description: 'plain description of the actual edit made' },
+          consequence: { type: 'string', description: 'what would have gone wrong for a USER without this fix - one sentence, no jargon; the PR comment is written from this' },
+          deviated: { type: 'string', description: 'empty if the prescribed fix was applied as-is; otherwise what you did differently and why' },
+        },
+      },
+    },
+    declined: {
+      type: 'array',
+      items: { type: 'object', required: ['title', 'reason'], properties: { title: { type: 'string' }, reason: { type: 'string' } } },
+    },
+    spec_updated: { type: 'string', description: 'which SPEC.md sections you edited, or empty if none needed' },
+    verification: { type: 'string', description: 'exactly which commands you ran and what they printed' },
+    build_ok: { type: 'boolean' },
+    commit: { type: 'string', description: 'the commit sha you created, or empty if you made no changes' },
+    notes: { type: 'string', description: 'anything the maintainer should know before pushing this to the contributor' },
+  },
+}
+
+phase('Fix')
+const reports = []
+for (let i = 0; i < BATCHES.length; i++) {
+  const b = BATCHES[i]
+  log(`batch ${i + 1}/${BATCHES.length}: ${b.key} (${(b.findings || []).length} findings)`)
+  const r = await agent(
+`${RULES}
+
+YOUR BATCH: ${b.key} - ${b.title}
+
+${b.extra || ''}
+
+THE FINDINGS, already verified:
+${JSON.stringify(b.findings || [], null, 1)}`,
+    { label: `fix:${b.key}`, phase: 'Fix', schema: FIX_SCHEMA })
+
+  if (!r) { log(`batch ${b.key}: the fixer returned nothing - it is NOT applied`); reports.push({ batch: b.key, failed: true }); continue }
+  if (!r.build_ok) log(`batch ${b.key}: BUILD NOT OK - read this report before pushing anything`)
+  reports.push(r)
+}
+
+const ok = reports.filter(r => r && !r.failed)
+const applied = ok.flatMap(r => r.applied || [])
+const declined = ok.flatMap(r => r.declined || [])
+const failed = reports.filter(r => r && (r.failed || r.build_ok === false)).map(r => r.batch)
+log(`fix: ${applied.length} applied, ${declined.length} declined, ${failed.length} batches needing attention`)
+
+return { reports: ok, applied, declined, failed }

--- a/.claude/skills/review-fork-pr/workflows/review.js
+++ b/.claude/skills/review-fork-pr/workflows/review.js
@@ -1,0 +1,234 @@
+// =============================================================================
+// review-fork-pr / workflows/review.js  --  THE REVIEW WORKFLOW
+//
+// Invoked by the review-fork-pr skill (SKILL.md, step 5) through the Workflow
+// tool:
+//
+//   Workflow({ scriptPath: "<repo>/.claude/skills/review-fork-pr/workflows/review.js",
+//              args: { wt:   "<abs path of the scratch worktree holding the PR>",
+//                      pr:   <PR number>,
+//                      base: "<merge-base sha, or the sha to diff against>",
+//                      emphasis: ["memory","regression","redraw","disk","abi"],
+//                      units: [ { key:  "kernel-core",
+//                                 title:"Kernel core, memory ladder, scheduler, loader",
+//                                 paths:"kernel/kernel.asm kernel/memory.inc ...",
+//                                 focus:"<what this reviewer must look at, in detail>" },
+//                               ... ] } })
+//
+// One reviewer per unit, then one adversarial verifier per unit that tries to
+// REFUTE that unit's findings. Nothing here edits the tree - every agent is
+// read-only, and the skill (not this workflow) decides what gets fixed.
+//
+// Returns { confirmed[], uncertain[], refuted, summaries[], units }.
+//
+// Units are the caller's job: split by SUBSYSTEM and by LENS, not by file
+// count. Ten is the cap here; a PR that wants more wants two runs.
+// =============================================================================
+export const meta = {
+  name: 'review-fork-pr',
+  description: 'Review an incoming fork PR unit by unit, then adversarially verify every finding',
+  phases: [
+    { title: 'Review', detail: 'one read-only reviewer per logical unit of the PR' },
+    { title: 'Verify', detail: 'one adversary per unit, trying to refute each finding' },
+  ],
+}
+
+const WT = args.wt
+const PR = args.pr
+const BASE = args.base || 'main'
+const EMPH = (args.emphasis && args.emphasis.length) ? args.emphasis : ['memory', 'regression', 'redraw', 'disk', 'abi']
+const UNITS = (args.units || []).slice(0, 10)
+if ((args.units || []).length > 10) log(`review: only the first 10 of ${args.units.length} units are reviewed - split the rest into a second run`)
+if (!UNITS.length) throw new Error('review.js: args.units is empty - the caller must split the PR into units')
+
+const EMPHASIS_TEXT = {
+  memory: 'MEMORY SAFETY: a pointer or segment banked across anything that can move, free or reallocate memory (a claim, a free, a yield, a callback, a compaction); a buffer written past its end; state not cleared when a slot is reused; a wait that does not actually wait for the thing it names.',
+  regression: 'LOST-FROM-MAIN REGRESSIONS: this branch is long-lived, and a guard main added after the fork point is simply ABSENT here with no conflict reported. For every hunk that DELETES or rewrites something, run "git -C ' + WT + ' log main --oneline -- <file>" and "git -C ' + WT + ' show main:<file>" and ask what the deleted code was guarding.',
+  redraw: 'REDRAW AND CPU COST against the 4.77 MHz target: an added full repaint, a doubled draw, a per-pixel primitive call, an int 13h call inside a loop. A redraw is priced by how many primitive calls it makes, not how many pixels it covers. Check PERFORMANCE.md Part 5 - if the operation is in that table, that row is the bar.',
+  disk: 'DISK AND DATA INTEGRITY: a failure that does not propagate, a refusal reported with the wrong reason, a size or offset that does not fit its type, a name taken from outside the machine and used unvalidated, a disk-visible base that is not 512-byte aligned.',
+  abi: 'THE PACKAGE/DRIVER ABI: an API slot whose number, contract or register answer changed without every caller changing with it; a driver verb table that grew without a header version bump; a callback that is not a near proc, or reads window fields without the ES override.',
+}
+
+const COMMON = `You are reviewing pull request #${PR} against os8088 - a Macintosh System 1-style GUI
+operating system for the Intel 8086/8088, written entirely in real-mode NASM assembly, booted from
+floppy. The PR comes from a contributor's FORK and is being prepared for merge into main.
+
+A git worktree holding the PR (with main already merged into it, unless told otherwise) is at:
+  ${WT}
+Read files there. To see your unit's diff:   git -C ${WT} diff ${BASE} HEAD -- <paths>
+To read main's version of a file:            git -C ${WT} show main:<path>
+DO NOT MODIFY ANY FILE. This phase is read-only; the fixes are applied later, by someone else.
+
+FIRST read ${WT}/CLAUDE.md in full - it states the project's hard rules and the performance model,
+and both are binding. Then grep SPEC.md for the section numbers your code cites; SPEC.md is the
+binding contract and is far too large to read end to end. A bare "S" sign anywhere in this repo
+means SPEC.md.
+
+THE HARD RULES. Violations are silent - they assemble cleanly and run wrong - and they are the
+highest-value findings you can return:
+- 8086 only: no pusha/popa, no "push imm", no "shl reg,imm" other than 1, no movzx/movsx, no 32-bit
+  registers, no 0F-prefix instructions.
+- Near model: CS = DS = KERNEL_SEG for kernel code and every task; SS = LOW_SEG. SS != DS, so
+  [bp+disp] addresses SS - kernel code holding a pointer in BP needs [ds:bp+...].
+- Register discipline: public routines preserve every register but their documented outputs. ISRs
+  push DS/ES, load DS = KERNEL_SEG, cld before string ops. Critical sections are pushf/cli ... popf,
+  never cli/sti - and the section must cover the operation's parameters, not just its body.
+- Section discipline: a module that switches sections must switch back to .text before the file
+  ends, or the next %include lands in the wrong section.
+- Label hygiene: one flat namespace - every module-internal label carries its module prefix (vga_,
+  wm_, menu_, fm_, dsk_, ...) or is a NASM local label.
+- Three adapters, one binary: the live screen is [vid_w]/[vid_h]/[vid_stride], NOT the VGA reference
+  constants SCREEN_W/SCREEN_H/ROW_BYTES. Anything that clips, centres or anchors to a screen edge
+  must read the live values or it is wrong on two adapters of three. On 1bpp adapters grey rounds to
+  black, so greying must be a pattern and must go through the pen.
+- Every disk-visible base is 512-byte aligned: int 13h answers error 09h on a transfer straddling a
+  64KB physical boundary.
+- Package/driver boundary: calling out is a far call through an API cell that switches DS; calling in
+  goes through the 3-byte dispatcher in the package header, so every callback is a NEAR proc with a
+  near ret, entered with ES = KERNEL_SEG - a callback reads window fields as [es:bx+W_W], never
+  [bx+W_W]. Missing the override assembles cleanly and reads the package's own image.
+- Memory: KERN_BUDGET is the kernel's whole RAM footprint; KERN_CODE_MAX is .text + .bss inside one
+  64KB window. Raising either is the repository owner's decision, never a build fix - so "raise the
+  budget" is not a finding, and neither is a fix that relieves a guard.
+
+THE PERFORMANCE MODEL. The target is an IBM PC/XT, 8088 at 4.77 MHz; the emulator you would test on
+is ~1000x faster and is exact about work done, useless about time taken. Measured on a real 5150:
+  any gfx_* drawing call, whatever it draws: 756 us FIXED      one 8x8 glyph cell: ~900 us
+  one 78-cell row of text: ~71 ms                              an OSAPI_* far call: 46.7 us
+  a near call+ret: 11 us      a full task switch: 693 us       system tick: 18.2 Hz
+  one int 13h call, near enough whatever it moves: ~400 ms  (cost disk work in CALLS, not sectors)
+A redraw is priced by how many primitive calls it makes, not by how many pixels it covers. Three
+defects are invisible in an emulator and have cost this project bug after bug: a VISIBLE REDRAW, a
+DOUBLE-DRAW FLASH, and INPUT OVERRUN.
+
+WHAT THIS REVIEW WEIGHS HARDEST:
+${EMPH.map(k => '- ' + (EMPHASIS_TEXT[k] || k)).join('\n')}
+
+WHAT NOT TO REPORT: style preferences, comment wording, naming taste, "could be refactored",
+anything speculative you cannot point at a specific line for, and anything you have not read the
+code for. Do not report a design decision you merely disagree with - this is someone else's pull
+request. It is far better to return 3 solid findings than 12 soft ones.
+
+Ground every finding in code you actually read, and cite file and line in the POST-MERGE file.
+Cap your output at 8 findings, ranked most severe first.`
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['unit', 'summary', 'findings'],
+  properties: {
+    unit: { type: 'string' },
+    summary: { type: 'string', description: '2-4 sentences: what this unit changes and your overall read on it' },
+    findings: {
+      type: 'array', maxItems: 8,
+      items: {
+        type: 'object',
+        required: ['title', 'file', 'severity', 'category', 'description', 'evidence', 'failure_scenario', 'suggested_fix', 'confidence'],
+        properties: {
+          title: { type: 'string', description: 'one line, <= 90 chars' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+          category: { type: 'string', description: 'correctness | hard-rule | regression | performance | resource | abi | data-integrity' },
+          description: { type: 'string', description: 'what is wrong and why it matters' },
+          evidence: { type: 'string', description: 'the actual code lines or git output that prove it' },
+          failure_scenario: { type: 'string', description: 'concrete: what a user does -> what goes wrong, on real hardware' },
+          suggested_fix: { type: 'string', description: 'specific, minimal, in the shape the surrounding design already uses' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+      },
+    },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['verdicts'],
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'file', 'verdict', 'reasoning', 'severity', 'corrected_fix'],
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
+          reasoning: { type: 'string', description: 'what you checked and what you found - name the lines you read' },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'], description: 'your severity, which may differ from the reporter s' },
+          corrected_fix: { type: 'string', description: 'the fix, corrected if the reporter got it wrong; empty if REFUTED' },
+        },
+      },
+    },
+  },
+}
+
+// Pipeline, not a barrier: a unit's findings go to its adversary the moment
+// that unit's reviewer is done, while the other units are still reading.
+phase('Review')
+const results = await pipeline(
+  UNITS,
+  u => agent(
+`${COMMON}
+
+YOUR UNIT: ${u.title}
+PATHS: ${u.paths}
+
+${u.focus || ''}
+
+Start with:  git -C ${WT} diff ${BASE} HEAD -- ${u.paths}
+Then read the post-merge files themselves for anything the diff does not make clear. Other reviewers
+cover the other units of this PR - stay inside yours and do not duplicate them.`,
+    { label: `review:${u.key}`, phase: 'Review', schema: FINDINGS_SCHEMA }),
+
+  (review, u) => {
+    if (!review || !review.findings || !review.findings.length) return { unit: u.key, review, verdicts: [] }
+    return agent(
+`${COMMON}
+
+YOU ARE THE ADVERSARY. Another agent reviewed the "${u.title}" unit of PR #${PR} and returned the
+findings below. Your job is to TRY TO REFUTE each one, not to agree with it. For every finding:
+
+1. Open the cited file at the cited line in ${WT} and read the real code, plus enough of its callers
+   and callees to judge it. The reporter may have misread, may have missed a guard elsewhere, or may
+   be describing behaviour that main already had.
+2. Check whether the "failure_scenario" can actually happen: is the path reachable, is the state it
+   needs achievable, does an existing guard already prevent it?
+3. Check whether it is NEW in this PR at all: "git -C ${WT} show main:<file>" and
+   "git -C ${WT} log main --oneline -- <file>". A defect that predates the PR is REFUTED for the
+   purposes of this review (say so in reasoning) - this PR is not the place to fix it.
+4. Judge the suggested fix. If it is wrong, incomplete, or would break something else, write the
+   corrected one, in the shape the surrounding design already uses.
+
+Return CONFIRMED only for a defect you traced yourself. Return REFUTED when you can say why it
+cannot happen. Return UNCERTAIN only when the answer needs hardware or a run you cannot do, and say
+what would settle it. Default towards REFUTED when you genuinely cannot ground it - a false finding
+costs a maintainer more than a missed one at this stage, because it becomes an edit to working code.
+
+THE FINDINGS:
+${JSON.stringify(review.findings, null, 1)}`,
+      { label: `verify:${u.key}`, phase: 'Verify', schema: VERDICT_SCHEMA })
+      .then(v => ({ unit: u.key, review, verdicts: (v && v.verdicts) || [] }))
+  }
+)
+
+const ok = results.filter(Boolean)
+const merged = ok.flatMap(r => {
+  const byTitle = {}
+  ;(r.review && r.review.findings || []).forEach(f => { byTitle[f.title] = f })
+  return r.verdicts.map(v => Object.assign({}, byTitle[v.title] || {}, v, { unit: r.unit }))
+})
+
+const RANK = { critical: 0, high: 1, medium: 2, low: 3 }
+const bySeverity = (a, b) => (RANK[a.severity] ?? 9) - (RANK[b.severity] ?? 9)
+const confirmed = merged.filter(f => f.verdict === 'CONFIRMED').sort(bySeverity)
+const uncertain = merged.filter(f => f.verdict === 'UNCERTAIN').sort(bySeverity)
+const refuted = merged.filter(f => f.verdict === 'REFUTED').length
+
+log(`review: ${UNITS.length} units, ${merged.length} findings judged - ${confirmed.length} confirmed, ${uncertain.length} uncertain, ${refuted} refuted`)
+
+return {
+  units: UNITS.map(u => u.key),
+  summaries: ok.map(r => ({ unit: r.unit, summary: r.review && r.review.summary })),
+  confirmed, uncertain, refuted,
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,12 @@ FAT timestamp), so a released image can be rebuilt byte-for-byte. Releases are
 cut by `.claude/skills/release-os8088`; a port of an existing program to a
 C package, the way `apps/cword` was made, is driven by
 `.claude/skills/port-to-os8088` (`/port-to-os8088`), whose `LESSONS.md` is
-what that port learned.
+what that port learned; and an incoming pull request **from a contributor's
+fork** — fetch it, merge `main` into it, review it, fix it, push the fixes
+back to their branch, comment — is `.claude/skills/review-fork-pr`
+(`/review-fork-pr <PR#>`), whose `LESSONS.md` is what seven of those reviews
+learned. `docs/UPSTREAM.md` is the same cycle seen from the fork's side and
+binds both.
 
 ## Hard rules (§1 — these break silently if violated)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,11 @@ Useful in this repo:
   manager. Those two break in ways that only show up as a hang.
 - `claude --permission-mode acceptEdits` if you're tired of approving edits to
   `.inc` files; keep approvals on for `Bash` so you see what it boots.
-- Two project skills live in `.claude/skills/` and Claude Code picks them up
-  automatically: `/release-os8088` cuts a release, and `/port-to-os8088`
-  ports an existing program to a C package — the next section.
+- Three project skills live in `.claude/skills/` and Claude Code picks them up
+  automatically: `/release-os8088` cuts a release, `/port-to-os8088` ports an
+  existing program to a C package — the next section — and
+  `/review-fork-pr <PR#>` is the maintainer's side of a pull request that
+  arrives from a fork.
 
 #### Porting a program with the agent
 
@@ -211,6 +213,44 @@ and what each one cost to find.
 You can also run any single piece by hand: the two workflow scripts under
 `.claude/skills/port-to-os8088/workflows/` are ordinary `Workflow` scripts
 that take their inputs as `args`, and the skill file says what to pass.
+
+#### Reviewing a pull request that comes from a fork
+
+Most substantial work on os8088 arrives as a pull request from someone's fork,
+cut from a `main` that has since moved: large, long-lived and usually
+conflicting. `/review-fork-pr <PR#>` is that review as a procedure.
+
+```
+claude                                  # from the repo root
+> /review-fork-pr 92
+```
+
+It reads the PR's topology first — whose fork, which branch, whether
+"allow edits by maintainers" is on, because that decides whether the fixes can
+go back to the contributor's branch at all — fetches the PR into a scratch
+worktree so your own checkout stays usable, merges `main` into it and resolves
+the collisions git reports *and the ones it does not* (a duplicated SPEC
+section number merges perfectly cleanly and `checkdocs` cannot see it), then
+reviews the result with a team of agents split by subsystem, every finding
+adversarially verified by a second agent that tries to refute it. It stops
+there and shows you a plan. Nothing is written to your repo, the fork or the
+PR until you answer.
+
+After you approve, it applies the fixes — minimal, in the contributor's style,
+declining anything that turns out not to be real — verifies them (both
+kernels, the size guards, all three disk geometries, a boot, the 1bpp adapter,
+and whatever gate the feature owns), pushes them to the contributor's branch
+so the PR itself becomes mergeable, and posts a comment that explains each fix
+in terms of what would have gone wrong for a user. Merging is always yours.
+
+`.claude/skills/review-fork-pr/LESSONS.md` is what seven of these reviews cost
+to learn, and is worth reading even if you review by hand: the git mechanics
+that silently do the wrong thing (a push to `origin` that leaves the PR
+untouched), the defect class unique to a long-lived fork (a guard `main` added
+after the fork point is simply absent, with no conflict reported), and the
+memory-safety patterns these PRs have actually shipped.
+[`docs/UPSTREAM.md`](docs/UPSTREAM.md) is the same cycle seen from the fork's
+side, and binds both.
 
 ### Codex
 


### PR DESCRIPTION
Most substantial work on os8088 arrives as a pull request from a contributor's fork, cut from a `main` that has since moved: large, long-lived, usually conflicting. That review has been driven by hand seven times now — **#47, #54, #61, #66, #73, #80, #92** — and rediscovered the same traps each time. This turns it into a skill.

```
claude
> /review-fork-pr 92
```

## What it does

1. **Topology before opinions.** `headRepositoryOwner`/`headRefName` (the push target), `maintainer_can_modify` (whether the fixes can reach their branch at all), `mergeable`, and the comments already on the PR.
2. **Preflight.** Unshallow check, stale-QEMU check, and the PR fetched into a **scratch worktree** so your own checkout stays usable for the hours this takes.
3. **Four questions, one prompt.** Where the fixes land (their branch / an integration PR you merge yourself / local only), whether to merge `main` in first, what the review weighs hardest, and whether to stop for approval. **Plan-first is the default.**
4. **Merge `main` in** — and then the four checks git reports nothing about: duplicate `§` headings, `git ls-files build`, a checked-in `.claude/`, stray binaries.
5. **Review.** Under ~30 changed files, a handful of read-only agents; larger, `workflows/review.js` with a unit split you write.
6. **The plan, and the gate.** Nothing is written to this repo, the fork, or the PR before you answer.
7. **Fix** — inline, or `workflows/fix.js` in batches.
8. **Verify** — both kernels, `kernsize --bless`, three geometries, a boot, `VIDEO=cga`, the PR's own gate, the feature exercised end to end.
9. **Push to the fork** (re-fetch, prove fast-forward, never `--force`) and **comment**, per fix, in terms of what would have gone wrong for a user.
10. **Hand back** — worktree removed, nothing left running, the local branch left for manual testing.

Merging is never the skill's, and neither is raising a budget, spending an API slot, or changing an ABI to make something fit.

## `LESSONS.md` — why it exists

- **A push to `origin` succeeds, creates a stray branch here, and leaves the PR untouched** (#66). The target is always the fork's remote.
- **A long-lived branch is missing what `main` added after the fork point, and git reports no conflict for it.** #47 deleted `wm_destroy_seg` and documented the resulting use-after-free as an author rule; #73 read two variables the same branch had deleted. The deletion sweep is the highest-yield lens in this repo.
- **The API slot table renumbers silently** (#47): every slot `main` published keeps `main`'s number, or a package built against `main`'s SDK calls `wm_resize` where it meant `cm_alloc`.
- **Duplicate SPEC section headings merge cleanly and `checkdocs` cannot see them** (#92's `§67`, `§52` before it).
- The memory-safety shapes these PRs have actually shipped: a segment banked across a call that can move memory, a register promise broken inside a wait, a movable buffer under another task's `rep movsb`, state not cleared on slot reuse.
- And the ones that cost a session rather than a machine: a stale QEMU answering with the old kernel, a QMP socket path too long for `AF_UNIX` in a scratchpad directory.

## The workflows

Both are ordinary `Workflow` scripts taking their inputs as `args`, so either runs alone:

- **`workflows/review.js`** — one reviewer per unit, then one adversary per unit that tries to **refute** each finding and returns `CONFIRMED`/`REFUTED`/`UNCERTAIN` with a corrected fix. Roughly a third do not survive.
- **`workflows/fix.js`** — verified findings in **sequential** batches, because they share one worktree and two agents editing one tree do not merge. Each fixer builds, runs its own verification, commits only its own batch, and never pushes.

## Not duplicated

`docs/UPSTREAM.md` already owns the fork topology, the squash cycle, the shallow-clone trap and the merge-resolution defaults — it is the same cycle seen from the fork's side, and the skill cites it rather than restating it. `CLAUDE.md` and `CONTRIBUTING.md` now name all three skills.

## Verified

`python3 tools/checkdocs.py` → **990 headings, 130 slots, 0 problems**, with the new files tracked. Both workflow scripts parse. Docs and skill files only — no code, no build path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
