### PR TITLE
release-os8088: one zip per release, not eleven loose images

### DIFF
--- a/.claude/skills/release-os8088/SKILL.md
+++ b/.claude/skills/release-os8088/SKILL.md
@@ -5,9 +5,18 @@ description: Build os8088 and publish the floppy images to the os8088.com websit
 
 # Release os8088
 
-Builds the four floppy images, publishes them into the website repository next
+Builds the floppy images, publishes them into the website repository next
 door along with the notes for its releases page, opens a pull request there,
-and cuts a GitHub release on this repo with the images attached.
+and cuts a GitHub release on this repo.
+
+**The GitHub release carries ONE asset: a zip.** `os8088-<version>.zip` holds
+every image, a README that says which two of them a reader needs, and a
+SHA256SUMS covering all of them. Eleven loose `.img` files used to hang off
+the release, and a reader had to know which pair they wanted before they could
+download anything. Step 3a builds it. The website is unchanged -- its download
+page still serves the images individually out of `public/disk/`, because the
+browser demo streams them and a table of per-image checksums is the point of
+that page.
 
 The release notes get written once and used twice: `data/releases.json` in the
 website repo (step 4a) and the GitHub release (step 6) say the same thing, and
@@ -143,31 +152,38 @@ to a fresh branch off `main` and would otherwise sweep unrelated work into it.
 ```bash
 cd "$OS_REPO"
 make clean && make
-ls -l build/os8088.img build/os8088-360.img build/apps.img build/apps360.img
+ls -l build/os8088.img build/os8088-720.img build/os8088-360.img \
+      build/apps.img build/apps720.img build/apps360.img build/media360.img
 ```
 
-All four must exist. The build enforces its own invariants -- a 512-byte boot
-sector and a kernel that fits under offset 0xA000 -- so a build failure here is
-a real problem, not something to work around. Report the kernel size; if it has
+All seven must exist -- step 3a refuses to pack without them. The build
+enforces its own invariants -- a 512-byte boot sector and a kernel that fits
+under offset 0xA000 -- so a build failure here is a real problem, not
+something to work around. Report the kernel size; if it has
 grown, say by how much and how much headroom is left (the ceiling is 0xA000 =
 40,960 bytes for image + bss).
 
-**The optional fifth image** is `build/apps-all.img` (SPEC.md 19.9): one
-1.44MB floppy with every application on it, Frotz and both Words included, for
-somebody who wants one disk rather than four. It is not built by `make`,
-because `cword` needs a compiler this tree does not contain:
+**Then the on-demand disks**, which `make` does not build and the zip carries
+when they exist:
 
 ```bash
-tools/setup-cc.sh && make allapps
-ls -l build/apps-all.img
+tools/setup-cc.sh                     # SmallerC; needed by cword and allapps
+make allapps                          # apps-all.img -- every program, one disk
+make worddisk cworddisk               # word*.img, cword*.img
+make runcpm-src && make runcpmdisk    # runcpm*.img
 ```
 
-Offer it, do not assume it. If `tools/setup-cc.sh` cannot run -- no network,
-no host toolchain -- **release the four and say the fifth was skipped**; it is
-a convenience, and a release that waits on it is a release that does not
-happen. When it is included, boot it in step 3 like any other image (it goes
-in B:, `make test TESTAPPS=build/apps-all.img`) and list it last everywhere,
-so the four shipped images stay the obvious download.
+Offer these, do not assume them. If `tools/setup-cc.sh` cannot run -- no
+network, no host toolchain -- **release the seven and say which on-demand disks
+were skipped**; they are a convenience, and a release that waits on one is a
+release that does not happen. `mkzip.py` prints the ones it did not find, so
+that list is generated rather than remembered. Boot any that were built in step
+3 like any other image (they go in B:, `make test TESTAPPS=build/word.img`).
+
+**Do not build the story disk for a release.** `make zdisk` fetches Infocom
+story files that nobody here has the right to redistribute, and they are not
+release content. `mkzip.py` will not pack them -- its manifest is an allowlist,
+not a glob -- but do not put them in `build/` on a release run either.
 
 ### 3. Smoke-test the build before publishing
 
@@ -184,10 +200,56 @@ magick build/smoke.ppm build/smoke.png    # or: convert, on older ImageMagick
 ```
 
 **Look at `build/smoke.png` with the Read tool.** You are checking for: the
-menu bar across the top with the chip glyph, File and Special; the dithered
-desktop; a Disk A (and Disk B) icon at the right; the dock strip at the bottom.
+menu bar across the top with the chip glyph, then Locator, File and Builtins;
+a Disk A and a Disk B icon down the right-hand side; the mouse pointer.
 If the screen is blank or garbled, stop -- do not publish. Delete the two
 scratch files afterwards; `build/` is gitignored, but leave it tidy.
+
+### 3a. Pack the release zip
+
+The one asset the GitHub release gets. Build it only after step 3 has booted
+the images -- the zip is what people download, and packing an unbooted image is
+the same mistake with an extra layer of wrapping on it.
+
+```bash
+cd "$OS_REPO"
+python3 .claude/skills/release-os8088/mkzip.py --version "$VERSION"
+```
+
+It writes `build/os8088-<version>.zip` and prints the entry count, the packed
+and unpacked sizes, the zip's own sha256, and which on-demand disks were not
+built. **Quote that sha256 in the release notes** -- it is the only checksum a
+reader of the GitHub release gets, since there is no longer a per-file table
+there.
+
+The script does three things worth knowing about:
+
+- **Its file list is an allowlist, not a glob.** `build/` also holds the story
+  disks and every test gate's scratch image, and a glob ships those the first
+  time somebody runs an unrelated target before cutting a release. If a new
+  disk should be in releases, add it to `MANIFEST` in `mkzip.py` -- that is the
+  only place the list lives.
+- **It refuses to pack a partial release.** A missing image that `make` builds
+  stops it; a missing on-demand disk is reported and skipped.
+- **The zip is byte-for-byte reproducible.** Timestamps come from the date in
+  the version string and the images are already deterministic, so the same
+  version from the same commit packs to the same bytes. Do not add anything
+  that varies per run.
+
+Then look inside it, the same way step 3 makes you look at the screenshot:
+
+```bash
+cd "$(mktemp -d)" && unzip -q "$OS_REPO/build/os8088-$VERSION.zip"
+cd "os8088-$VERSION" && shasum -a 256 -c SHA256SUMS && cat README.txt
+```
+
+**Read the README with the Read tool.** It is written for someone who has never
+seen this project, so "Writing the copy" governs it exactly as it governs the
+release notes. Check the version, the commit and the file list are this
+release's, and that every image listed is one that was actually built. The
+QEMU command line in it is the real one -- if `make run`'s invocation ever
+changes, `README` in `mkzip.py` has to change with it, and the way to know is
+to run the command out of the unpacked directory and see the desktop come up.
 
 ### 4. Publish into the website repo
 
@@ -489,7 +551,7 @@ End the PR body with:
 
 ### 6. Tag and cut the GitHub release
 
-Only after the images are verified.
+Only after the images are booted and the zip is unpacked and checked.
 
 ```bash
 cd "$OS_REPO"
@@ -498,13 +560,20 @@ git push origin "$VERSION"
 gh release create "$VERSION" \
   --title "os8088 $VERSION" \
   --notes "<notes>" \
-  build/os8088.img build/os8088-360.img build/apps.img build/apps360.img
+  "build/os8088-$VERSION.zip"
 ```
 
-Add `build/apps-all.img` to that argument list **only if step 2 built it**, and
-last, after the four. A missing asset makes `gh release create` fail with the
-tag already pushed, which is the one failure in this whole procedure that
-cannot simply be re-run.
+**One asset, and it is the zip.** Do not attach loose `.img` files beside it --
+that is the arrangement this replaced, and half of each is worse than either.
+Confirm the file exists before running the command: a missing asset makes `gh
+release create` fail with the tag already pushed, which is the one failure in
+this whole procedure that cannot simply be re-run.
+
+Because the release page no longer lists a file per image, the notes have to
+say what the zip contains and how big it is -- one sentence naming the two
+images a reader actually needs, the packed size, and the sha256 step 3a
+printed. Someone who wants a per-image checksum finds it in the SHA256SUMS
+inside the zip, or on the download page, and the notes should say which.
 
 `gh` infers the repository from the checkout's remote, so this works for a
 fork or a rename without any edit here.
@@ -524,8 +593,11 @@ and update `data/releases.json` to match before the website PR is merged.
 ### 7. Report
 
 Tell the user: the version, the PR URL, the release URL, the kernel size and
-its delta, the Spotlight page's URL if step 4b ran, and anything you skipped or
-that needs their attention. If the website PR is merged, the site's own CI
+its delta, the zip's packed size and how many images went into it, the
+Spotlight page's URL if step 4b ran, and anything you skipped or that needs
+their attention -- naming any on-demand disk that did not get built, since a
+reader of the zip's README cannot tell a disk that was left out from one that
+does not exist. If the website PR is merged, the site's own CI
 deploys from its `main` branch -- say so, and say the site is not live until
 that merge happens.
 
@@ -536,7 +608,15 @@ them in a status line is how they get lost.
 
 ## Rules
 
-- **Never publish an unbooted image.** Step 3 is not optional.
+- **Never publish an unbooted image.** Step 3 is not optional, and packing one
+  into a zip does not make it booted.
+- **The GitHub release gets the zip and nothing else.** Never attach loose
+  images beside it, and never build the zip from a glob of `build/` -- the
+  manifest in `mkzip.py` is the list, and it exists so a story disk or a test
+  gate's scratch image cannot ride out with a release.
+- **Never hand-assemble the zip.** `mkzip.py` writes the README, the checksums
+  and a reproducible archive; a `zip -r` by hand gets none of those and looks
+  identical until somebody checks.
 - **Never invent a checksum or a size.** Everything on the download page comes
   from `releases.json`, which `release.py` computes from the actual bytes.
 - **Never ship a release with an empty entry on the releases page.** Step 4a is

--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Pack a release into ONE zip.
+
+A release used to attach eleven loose `.img` files to the GitHub release, and
+a reader had to know which two of them they wanted before they could download
+anything. This builds a single `os8088-<version>.zip` instead: every image the
+build produced, a README that says which ones to use, and a SHA256SUMS file
+covering all of them.
+
+TWO THINGS THIS DELIBERATELY DOES NOT DO.
+
+It does not glob `build/*.img`. The manifest below is an ALLOWLIST, and it is
+one because `build/` also holds disks that must never leave this machine --
+`zork*.img` carries Infocom story files that `tools/getstories.py` fetched and
+nobody here has the right to redistribute, and every `tests/` gate writes its
+scratch image into the same directory. A glob ships those the first time
+somebody runs an unrelated target before cutting a release, and the mistake is
+invisible in the zip listing until it is public.
+
+It does not build anything. Run `make` (and any on-demand target you want in
+the zip) first; a missing REQUIRED image stops the script, and a missing
+optional one is reported and skipped. That split is the point -- the seven
+images `make` produces are the release, and `apps-all`/`word`/`cword`/`runcpm`
+are on-demand disks that a tree without the C toolchain cannot build at all.
+
+The zip is byte-for-byte reproducible: entries are written in manifest order,
+every timestamp is the date in the version string, and permissions are fixed.
+The images are already deterministic (tools/os88disk.py pins the volume serial
+and every FAT timestamp), so the same version built from the same commit
+produces the same zip, and a reader can check that.
+"""
+import argparse
+import hashlib
+import os
+import re
+import sys
+import zipfile
+
+# (filename, required, description). ORDER IS THE ZIP'S ORDER and the README's.
+# Required = built by a bare `make`. Optional = its own on-demand target.
+MANIFEST = [
+    ("os8088.img",     True,  "System disk, 1.44MB. Boots the OS. Goes in drive A."),
+    ("apps.img",       True,  "Software disk, 1.44MB. Goes in drive B."),
+    ("os8088-720.img", True,  "System disk, 720KB."),
+    ("apps720.img",    True,  "Software disk, 720KB."),
+    ("os8088-360.img", True,  "System disk, 360KB. This is the one a real IBM PC/XT reads."),
+    ("apps360.img",    True,  "Software disk, 360KB."),
+    ("media360.img",   True,  "Music disk, 360KB. The music module does not fit beside the "
+                              "programs at this size, so it rides a disk of its own. "
+                              "There is no 1.44MB or 720KB version -- at those sizes it is "
+                              "already on the software disk."),
+    ("apps-all.img",   False, "Every program on one 1.44MB software disk, including both "
+                              "word processors, the story reader and the CP/M emulator. "
+                              "Use this instead of apps.img if you would rather swap one "
+                              "disk than four."),
+    ("word.img",       False, "Word processor disk, 1.44MB."),
+    ("word720.img",    False, "Word processor disk, 720KB."),
+    ("word360.img",    False, "Word processor disk, 360KB."),
+    ("cword.img",      False, "Word processor disk built by the C compiler, 1.44MB."),
+    ("cword720.img",   False, "Word processor disk built by the C compiler, 720KB."),
+    ("cword360.img",   False, "Word processor disk built by the C compiler, 360KB."),
+    ("runcpm.img",     False, "CP/M emulator disk, 1.44MB. Carries the emulator and the "
+                              "CP/M programs that run under it."),
+    ("runcpm720.img",  False, "CP/M emulator disk, 720KB. Carries the emulator and the "
+                              "arcade games only."),
+    ("runcpm360.img",  False, "CP/M emulator disk, 360KB. Carries the emulator and no "
+                              "programs -- there is no room for them at this size."),
+]
+
+README = """\
+os8088 {version}
+{rule}
+
+os8088 is a graphical operating system for the Intel 8086, written in assembly
+and booted from a floppy disk. It has overlapping windows, a menu bar, a mouse
+and programs you can run several copies of at once.
+
+WHICH FILES YOU NEED
+--------------------
+
+You need two images: a system disk for drive A and a software disk for drive B.
+Pick the pair that matches the disk size your machine or emulator uses.
+
+  1.44MB   os8088.img       and  apps.img
+  720KB    os8088-720.img   and  apps720.img
+  360KB    os8088-360.img   and  apps360.img  (and media360.img, see below)
+
+If you are not sure, use the 1.44MB pair. A real IBM PC/XT of the period reads
+360KB disks and nothing larger.
+
+RUNNING IT
+----------
+
+With QEMU, from the directory you unpacked this into:
+
+  qemu-system-i386 \\
+    -drive file=os8088.img,format=raw,if=floppy -boot a \\
+    -drive file=apps.img,format=raw,if=floppy,index=1 \\
+    -chardev msmouse,id=m0 -serial chardev:m0
+
+The system disk goes in the first floppy drive and the software disk in the
+second. The last line is the mouse: os8088 drives a serial mouse, so the
+emulator has to put one on a serial port, and that is QEMU's way of doing it.
+Other emulators have their own; the project's site has the current recipe and
+the 86Box machine files.
+
+THE FILES
+---------
+
+{files}
+
+CHECKING WHAT YOU GOT
+---------------------
+
+SHA256SUMS lists a checksum for every image here. On macOS or Linux:
+
+  shasum -a 256 -c SHA256SUMS
+
+The build is deterministic, so anyone who builds this version from source gets
+these same bytes.
+
+Built from commit {commit}.
+
+Licence: MIT. The LICENSE file in the source repository has the terms.
+"""
+
+
+def version_date(version):
+    """A fixed timestamp, so the same version packs to the same bytes.
+
+    The zip format cannot store a date before 1980, so a version string that
+    carries no date falls back to the epoch the format itself starts at.
+    """
+    m = re.search(r"(\d{4})(\d{2})(\d{2})", version)
+    if m:
+        y, mo, d = (int(x) for x in m.groups())
+        if 1980 <= y <= 2107 and 1 <= mo <= 12 and 1 <= d <= 31:
+            return (y, mo, d, 12, 0, 0)
+    return (1980, 1, 1, 0, 0, 0)
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def add(zf, name, data, when):
+    """One entry, with everything the OS would otherwise vary pinned flat."""
+    info = zipfile.ZipInfo(name, date_time=when)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o644 << 16
+    info.create_system = 3          # unix, whatever host packed it
+    zf.writestr(info, data)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Pack one release zip.")
+    ap.add_argument("--version", required=True, help="e.g. v1.0.20260819")
+    ap.add_argument("--build-dir", default="build")
+    ap.add_argument("--out", help="default: <build-dir>/os8088-<version>.zip")
+    ap.add_argument("--commit", default="", help="the OS commit it was built from")
+    args = ap.parse_args()
+
+    bd = args.build_dir
+    out = args.out or os.path.join(bd, "os8088-%s.zip" % args.version)
+    root = "os8088-%s" % args.version
+    when = version_date(args.version)
+
+    commit = args.commit
+    if not commit:
+        import subprocess
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], text=True).strip()
+        except Exception:
+            commit = "unknown"
+
+    picked, missing, skipped = [], [], []
+    for name, required, desc in MANIFEST:
+        p = os.path.join(bd, name)
+        if os.path.isfile(p):
+            picked.append((name, p, desc))
+        elif required:
+            missing.append(name)
+        else:
+            skipped.append(name)
+
+    if missing:
+        print("mkzip: these are built by `make` and are not in %s:" % bd,
+              file=sys.stderr)
+        for m in missing:
+            print("  %s" % m, file=sys.stderr)
+        print("mkzip: run `make` and try again -- refusing to pack a partial "
+              "release.", file=sys.stderr)
+        return 1
+
+    sums = ["%s  %s" % (sha256(p), name) for name, p, _ in picked]
+    files = "\n\n".join(
+        "  %s\n      %s" % (name, "\n      ".join(_wrap(desc, 66)))
+        for name, _, desc in picked)
+    readme = README.format(version=args.version, rule="=" * (7 + len(args.version)),
+                           files=files, commit=commit)
+
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+        add(zf, "%s/README.txt" % root, readme.encode(), when)
+        add(zf, "%s/SHA256SUMS" % root, ("\n".join(sums) + "\n").encode(), when)
+        for name, p, _ in picked:
+            with open(p, "rb") as f:
+                add(zf, "%s/%s" % (root, name), f.read(), when)
+
+    # Read it back rather than trusting the write: a truncated member is a
+    # perfectly valid-looking zip until somebody unpacks it.
+    with zipfile.ZipFile(out) as zf:
+        bad = zf.testzip()
+        if bad:
+            print("mkzip: %s is corrupt in %s" % (bad, out), file=sys.stderr)
+            return 1
+        n = len(zf.namelist())
+
+    raw = sum(os.path.getsize(p) for _, p, _ in picked)
+    print("mkzip: %s" % out)
+    print("  %d entries, %d images, %.1fMB packed from %.1fMB"
+          % (n, len(picked), os.path.getsize(out) / 1e6, raw / 1e6))
+    print("  sha256 %s" % sha256(out))
+    if skipped:
+        print("  on-demand disks NOT built, so not in the zip: %s"
+              % ", ".join(skipped))
+    return 0
+
+
+def _wrap(s, w):
+    out, line = [], ""
+    for word in s.split():
+        if line and len(line) + 1 + len(word) > w:
+            out.append(line)
+            line = word
+        else:
+            line = (line + " " + word).strip()
+    if line:
+        out.append(line)
+    return out
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The GitHub release used to hang eleven `.img` files off itself, and a reader had
to know which pair they wanted before they could download anything. It now
carries one asset:

```
os8088-<version>.zip
  os8088-<version>/
    README.txt      which two images you need, the real QEMU command, what each file is
    SHA256SUMS      every image
    os8088.img  apps.img  os8088-720.img  apps720.img
    os8088-360.img  apps360.img  media360.img
    apps-all.img  runcpm{,720,360}.img   (whichever on-demand disks were built)
```

On the tree this was written against: 11 images, 9.6MB packed to 2.7MB.

## What changed

**`.claude/skills/release-os8088/mkzip.py`** (new) builds the zip. Three
properties are why it is a script and not a `zip -r` line in the procedure:

- **Its file list is an allowlist, not a glob.** `build/` also holds the story
  disks -- `zork*.img` is fetched Infocom material nobody here may redistribute
  -- and every test gate's scratch image. A glob ships those the first time
  somebody runs an unrelated target before cutting a release, and the mistake is
  invisible in the zip listing until it is public.
- **It refuses to pack a partial release.** A missing image that `make` builds
  stops it and writes nothing. A missing on-demand disk is named and skipped, so
  the "what did not get built" line in the release report is generated rather
  than remembered.
- **The zip is byte-for-byte reproducible.** Timestamps come from the date in
  the version string and the images are already deterministic.

**`SKILL.md`**: new step 3a builds the zip and makes you unpack it and read the
README; step 6 attaches the zip and nothing else; step 2 lists all seven `make`
images plus the on-demand targets and says not to build the story disk on a
release run; three new rules.

## Verified rather than assumed

- **Reproducible** -- two runs, identical sha256.
- **The allowlist holds** -- `rcmemtest.img` was sitting in `build/` during the
  test and was left out; a planted `zork.img` was never considered.
- **Refusal works** -- partial build dir gives exit 1 and no file on disk.
- **The README's boot command works** -- unpacked the zip, ran the exact command
  out of it, got the desktop with both drive icons. It is `make run`'s real
  invocation. The first draft invented one (`-fda` plus a socket chardev instead
  of `-drive` and `msmouse`) and this is how it was caught.

## Deliberately not in this PR

- **The website is unchanged.** Its download page still serves the images
  individually out of `public/disk/` -- the browser demo streams them, and a
  table of per-image checksums is what that page is for.
- **Existing releases keep their loose assets.** Nothing published was touched.

## One fix that is not about zips

Step 3's smoke-test checklist told you to look for "File and Special" menus and
a dock strip at the bottom. The build shows Locator, File and Builtins, and the
dock carries tiles for running windows so there is nothing to see at idle. That
checklist would have stopped a good release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)