### PR TITLE
xt-sound-1.44: an XT with a sound card and every app in a 1.44MB B: (§16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,8 @@ sees an up-to-date `kernel.bin`, boots the previous configuration, and it reads
 exactly like the feature being broken.
 
 86Box targets for period hardware, one per `vm/` directory: `xt`, `xt-640`,
-`xt-cga`, `xt-hercules`, `xt-multimon`, `xt-sound`, `286`, `286-sound`,
+`xt-cga`, `xt-hercules`, `xt-multimon`, `xt-sound`, `xt-sound-1.44`, `286`,
+`286-sound`,
 `386sx`, `386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`, `xt-word`,
 `386-word`, `386-c-word`, `xt-runcpm`, `286-runcpm`, `386-runcpm`; plus
 `marty` (MartyPC). `xt-multimon` is the

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ MEDIAIMG360 := $(BUILD)/media360.img
 BOX   := /Applications/86Box.app/Contents/MacOS/86Box
 
 # RESET= clears a machine's non-volatile state on the way in, and it reaches
-# EVERY 86Box target at once because all eighteen of them launch through
+# EVERY 86Box target at once because all twenty-three of them launch through
 # $(BOX) and differ only in which vm/ directory they point at:
 #
 #   make 386-c-word RESET=1       the CMOS  (the one you almost always want)
@@ -71,10 +71,11 @@ VM386DX := $(CURDIR)/vm/386dx
 # that asked for it - a machine whose BIOS claimed 3MB extended and whose Task
 # Manager showed no XMS bar.
 VM386XMS := $(CURDIR)/vm/386-xms
-# ...and the same three machines with a sound card in them (SPEC.md 51.4).
+# ...and the sound-card profiles for those machines (SPEC.md 51.4).
 # QEMU's -device adlib/sb16 is the only other way to give the driver
 # something to attach to, and it is not a real card: these are.
 VMXTSND := $(CURDIR)/vm/xt-sound
+VMXTSND144 := $(CURDIR)/vm/xt-sound-1.44
 VM286SND := $(CURDIR)/vm/286-sound
 VM386SND := $(CURDIR)/vm/386-sound
 # The top of the range: a 486DX2/66 and a Pentium 133, both with an SB16.
@@ -697,7 +698,8 @@ KERNEL_SRC := kernel/kernel.asm
 KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc
 
 .PHONY: small kernsplit all run run-640 run-720 debug test test-snd xt xt-640 xt-cga \
-        xt-hercules xt-multimon 286 386sx 386 386-xms xt-sound 286-sound 386-sound 486 pentium \
+        xt-hercules xt-multimon 286 386sx 386 386-xms xt-sound xt-sound-1.44 \
+        286-sound 386-sound 486 pentium \
         bench field combo combo144 combo720 stackprobe trklog npbench clicktest marty \
         comscan lptlink calcref \
         fonts fontsheets fontlist \
@@ -4672,15 +4674,23 @@ xt-multimon: $(IMG360) $(APPSIMG360)
 	@$(UNPROTECT) $(VM386XMS)/86box.cfg
 	$(BOX) -P $(VM386XMS) -N
 
-# The three sound machines: an XT with a Sound Blaster 2.0 (so the OPL2 is
-# the FM tier and the DSP the stream tier on the CPU this OS is FOR), and the
-# 286/386 with an SB16. `make test ADLIB=1` / `SB16=1` gives the driver
-# something to attach to under QEMU; these give it a card on a machine whose
-# bus and clock are period-correct, which is the only place a stream's pacing
-# means anything (SPEC.md 34.5/51.4).
+# The sound machines: an XT with a Sound Blaster 2.0 (so the OPL2 is the FM
+# tier and the DSP the stream tier on the CPU this OS is FOR), a second XT
+# with an SB 1.0 and the everything disk in a 1.44MB B: drive, and the 286/386
+# with an SB16. `make test ADLIB=1` / `SB16=1` gives the driver something to
+# attach to under QEMU; these give it a card on a machine whose bus and clock
+# are period-correct, which is the only place a stream's pacing means anything
+# (SPEC.md 34.5/51.4).
 xt-sound: $(IMG360) $(APPSIMG360)
 	@$(UNPROTECT) $(VMXTSND)/86box.cfg
 	$(BOX) -P $(VMXTSND) -N
+
+# Keep the period-correct 360KB system disk in A:, but expose every application
+# through the only geometry large enough for $(ALLAPPSIMG). The 1986 XT board
+# supplies the full 640KB needed by the larger applications.
+xt-sound-1.44: $(IMG360) $(ALLAPPSIMG)
+	@$(UNPROTECT) $(VMXTSND144)/86box.cfg
+	$(BOX) -P $(VMXTSND144) -N
 
 286-sound: $(IMG) $(APPSIMG)
 	@$(UNPROTECT) $(VM286SND)/86box.cfg

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ make 386      # 86Box: 386DX @ 25MHz, 2MB, VGA
 make 486      # 86Box: 486DX2 @ 66MHz, 8MB, VGA, Sound Blaster 16
 make pentium  # 86Box: Pentium @ 133MHz, 16MB, VGA, Sound Blaster 16
 make xt-sound # the 640KB XT with a Sound Blaster 2.0 (OPL2 + DSP)
+make xt-sound-1.44 # the 640KB XT with SB 1.0 and every app on a 1.44MB B:
 make 286-sound  # 86Box: the 286, with a Sound Blaster 16
 make 386-sound  # 86Box: the 386DX, with a Sound Blaster 16
 make worddisk # build the Microsoft Word floppy, all three geometries
@@ -552,16 +553,17 @@ a config claiming a P133 boots a P75. And unlike an XT, these machines have a
 CMOS — on the first launch the BIOS stops at its setup screen, and picking
 "EXIT FOR BOOT" once writes `vm/<machine>/nvr/`.)
 
-`make xt-sound`, `make 286-sound` and `make 386-sound` add a sound card to
-three of the machines above: a Sound Blaster 2.0 on a 640KB XT
-(`vm/xt-sound`), so the OPL2 is the FM tier and the DSP the streaming tier on
-the CPU this OS is actually for, and an SB16 on the 286 and the 386
+`make xt-sound`, `make xt-sound-1.44`, `make 286-sound` and `make 386-sound`
+add a sound card to four of the machines above. The first XT has a Sound
+Blaster 2.0 (`vm/xt-sound`); the 1.44MB variant has a Sound Blaster 1.0 and
+mounts `build/apps-all.img` in B: (`vm/xt-sound-1.44`), putting every
+application on the same 4.77MHz machine. The 286 and 386 use an SB16
 (`vm/286-sound`, `vm/386-sound`). `make test ADLIB=1` and `SB16=1` give the
 driver a card to attach to under QEMU, but only these give it one on a
 machine whose bus and clock are period-correct — and pacing a stream is the
 one thing that means nothing anywhere else.
 
-All twelve, at a glance:
+All targets, at a glance:
 
 | target | machine | CPU | RAM | video | sound |
 |---|---|---|---|---|---|
@@ -570,6 +572,7 @@ All twelve, at a glance:
 | `xt-cga` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | CGA | — |
 | `xt-hercules` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | Hercules | — |
 | `xt-sound` | XT, 1986 board | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | Sound Blaster 2.0 |
+| `xt-sound-1.44` | XT, 1986 board | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | Sound Blaster 1.0 |
 | `286` | AMI 286 clone | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
 | `286-sound` | AMI 286 clone | 286 @ 12.5MHz | 1MB | OTI-067 VGA | Sound Blaster 16 |
 | `386sx` | Shuttle HOT-304 | 386SX @ 16MHz | 2MB | OTI-067 VGA | — |
@@ -583,8 +586,9 @@ All twelve, at a glance:
 | `xt-word` | XT, 1986 board | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | — |
 | `386-word` | Micronics 386 | 386DX @ 25MHz | 2MB | OTI-067 VGA | — |
 
-The XT-class machines boot the 360KB pair; the AT-class ones boot the 1.44MB
-pair.
+The XT-class machines boot the 360KB system disk; most pair it with the 360KB
+apps disk, while `xt-sound-1.44` mounts the everything disk in a 1.44MB B:
+drive. The AT-class machines boot the 1.44MB pair.
 
 `xt-multimon` is the **two-card** XT — a CGA and a Hercules, a monitor window
 each — and the only 86Box machine that can show the extended desktop. It boots

--- a/SPEC.md
+++ b/SPEC.md
@@ -12451,6 +12451,11 @@ Three things about it are deliberate:
   board maximum without a word (which is why the 286 is not `ibmat` — the
   5170 planar stops at 512KB), and an empty CMOS makes the BIOS stop at its
   setup screen once, until `vm/<machine>/nvr/` exists.
+- Complete-app XT sound target: `xt-sound-1.44` (`vm/xt-sound-1.44`) keeps
+  the 360KB system disk in A:, mounts §19.10's `apps-all.img` in a 1.44MB B:
+  drive, and runs the full 640KB 1986 XT board at 4.77MHz with a Sound Blaster
+  1.0 at 220h, IRQ 5, DMA 1. It is separate from `xt-sound`, whose Sound
+  Blaster 2.0 and 360KB apps disk remain the ordinary period baseline.
 - Gate packages ride their own scratch images and are mounted in place of
   the apps disk with `make test-snd TESTAPPS=<img>` (the `test` target's B:
   drive is fixed):  and `build/filetest.img` / `-frag` (§18.4). A write

--- a/vm/xt-sound-1.44/86box.cfg
+++ b/vm/xt-sound-1.44/86box.cfg
@@ -1,0 +1,41 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 31399867-2bdc-4de1-a6e7-f5d04e3a63cb
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 8088
+cpu_multi = 1
+cpu_speed = 4772728
+cpu_use_dynarec = 0
+machine = ibmxt86
+mem_size = 640
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_pc_xt
+mouse_type = msserial
+
+[Sound]
+sndcard = sb
+
+[Sound Blaster v1.0 #1]
+base = 0220
+irq = 5
+dma = 1
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-360.img
+fdd_02_fn = ../../build/apps-all.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1


### PR DESCRIPTION
## What

A second XT sound profile. `make xt-sound` pairs the 360KB system disk with the 360KB apps disk — period-correct, and it leaves the larger applications off the machine this OS is actually for. `make xt-sound-1.44` keeps the 360KB system disk in A: and mounts §19.10's `apps-all.img` in a 1.44MB B: drive, so Frotz, both Words and RunCPM are reachable at 4.77MHz on a 640KB 1986 XT board.

The card is a **Sound Blaster 1.0** (220h, IRQ 5, DMA 1). `xt-sound`'s SB 2.0 stays the ordinary period baseline, so the two profiles cover both DSP generations the driver tiers against (§51.4).

`vm/xt-sound-1.44/86box.cfg` is `vm/xt-sound`'s byte for byte apart from the UUID, the card, and the B: drive:

```
 sndcard = sb2.0            ->  sndcard = sb
 [Sound Blaster v2.0 #1]    ->  [Sound Blaster v1.0 #1]
 fdd_02_fn = apps360.img    ->  fdd_02_fn = apps-all.img
                            +   fdd_02_type = 35_2hd
```

## Docs, updated in step

- **SPEC.md §16** — the machine and why it is separate from `xt-sound`
- **README.md** — the target list and the at-a-glance table (the table's lead-in said "All twelve"; it has not been twelve for a while, so it now says "All targets", and the XT/AT disk-pairing sentence names the exception)
- **CLAUDE.md** — the `vm/` roster
- **Makefile** — the `RESET=` comment counted eighteen 86Box targets; there are twenty-three (`grep -c '$(BOX) -P'`), and this one reaches `RESET=` like every other because it launches through the same `$(BOX)`

## Testing

- `python3 tools/checkdocs.py` — 1091 headings, 135 slots, 0 problems
- `make -n xt-sound-1.44` resolves to `$(IMG360)` + `$(ALLAPPSIMG)` and launches 86Box against the new directory

Not booted on 86Box in this session — `allapps` needs the C toolchain and the RunCPM fetch, and nothing under `kernel/` or `apps/` changed: this is a machine profile plus its docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)