### PR TITLE
apps-all.img carries the C64, licence and all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4348,9 +4348,10 @@ $(MEDIAIMG360): $(MEDIA_DISK_DATA) tools/os88disk.py
 # THE EVERYTHING DISK (ON DEMAND: `make allapps`) - SPEC.md 19.10
 # =============================================================================
 # build/apps-all.img: ONE 1.44MB floppy with every application this project
-# ships on it, including the four that have their own disks and therefore
+# ships on it, including the five that have their own disks and therefore
 # never appear on the shipped apps disk - FROTZ (SPEC.md 61), WORD (SPEC.md
-# 65), CWORD (SPEC.md 73.12) and RUNCPM (SPEC.md 74). It is a CONVENIENCE, offered beside the
+# 65), CWORD (SPEC.md 73.12), RUNCPM (SPEC.md 74) and C64 (docs/C64-SPEC.md).
+# It is a CONVENIENCE, offered beside the
 # shipped images on a release page for somebody who wants one disk rather
 # than four, and nothing in the tree boots it by default.
 #
@@ -4394,8 +4395,8 @@ $(MEDIAIMG360): $(MEDIA_DISK_DATA) tools/os88disk.py
 # the tree above has besides RUNCPM\A\0, one cluster each at 1.44MB's 16
 # entries a cluster - DERIVED from ALLAPPSARGS below (ALLAPPSDIRS: every
 # DIR: prefix, each one's parent, --folder DOCS, and RUNCPM\A, the
-# selection's own parent; ten today: APPS, GAMES, MEDIA, WORD, CWORD,
-# RUNCPM, RUNCPM\A, SYSTEM, SYSTEM\DOS, DOCS), so the budget is derived
+# selection's own parent; eleven today: APPS, GAMES, MEDIA, WORD, CWORD,
+# RUNCPM, RUNCPM\A, C64, SYSTEM, SYSTEM\DOS, DOCS), so the budget is derived
 # here as it is for build/runcpm.img, and a folder added to the tree above
 # is priced without anyone remembering a constant. One parent level is
 # taken (the tree nests one deep); a DIR/SUB/SUB2: entry would need its
@@ -4405,6 +4406,8 @@ ALLAPPSIMG := $(BUILD)/apps-all.img
 ALLAPPSFILES := $(APPS) $(BUILD)/frotz.o88 \
                 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC \
                 $(BUILD)/cword.o88 $(BUILD)/CWORD.OVL $(BUILD)/WELCOME.RTF \
+                $(BUILD)/c64.o88 $(BUILD)/C64.OVL $(BUILD)/c64-rom/C64.ROM \
+                apps/c64/README.TXT apps/c64/COPYING \
                 $(RUNCPMDISK)
 ALLAPPS := $(ALLAPPSFILES) $(RUNCPMDEPS)
 
@@ -4416,6 +4419,9 @@ ALLAPPSARGS := $(addprefix APPS:,$(APPS_TOOLS) $(BUILD)/frotz.o88) \
                $(addprefix CWORD:,$(BUILD)/cword.o88 $(BUILD)/CWORD.OVL \
                                   $(BUILD)/WELCOME.RTF) \
                $(addprefix RUNCPM:,$(RUNCPMDISK)) \
+               $(addprefix C64:,$(BUILD)/c64.o88 $(BUILD)/C64.OVL \
+                                $(BUILD)/c64-rom/C64.ROM \
+                                apps/c64/README.TXT apps/c64/COPYING) \
                $(SYSAPPSARGS) \
                $(addprefix SYSTEM/DOS:,$(APPS_DOS))
 ALLAPPSDIRS := $(sort $(foreach a,$(ALLAPPSARGS),$(firstword $(subst :, ,$a))) \

--- a/SPEC.md
+++ b/SPEC.md
@@ -17885,19 +17885,20 @@ one: Note Pad, Paint, TeXPad and Word write **documents**, which are the user's
 and belong exactly where the user put them.
 ### 19.10 `apps-all.img` — one floppy with everything, and why it is on demand
 
-The shipped apps floppy is built in three geometries and carries the fifteen
-packages that fit the smallest of them. Three applications are deliberately not
+The shipped apps floppy is built in three geometries and carries the nineteen
+packages that fit the smallest of them. Five applications are deliberately not
 on it, each with a disk of its own and for the same reason — they are large and
-they travel with data: **Frotz** (§61), **Word** (§68.5) and **cword**
-(§73.12). That is right for the machines this runs on and awkward for a person
-downloading it, who wants to try the software rather than curate a shelf of
-floppies.
+they travel with data: **Frotz** (§61), **Word** (§68.5), **cword** (§73.12),
+**RUNCPM** (§74.5) and **C64** (`docs/C64-SPEC.md` §14.2). That is right for
+the machines this runs on and awkward for a person downloading it, who wants to
+try the software rather than curate a shelf of floppies.
 
 `make allapps` builds **`build/apps-all.img`**: one 1.44MB volume with every
 application on it, offered beside the shipped images on a release page. It is a
 convenience and nothing in the tree boots it by default.
 
-**It is 1.44MB and has no smaller variants.** The contents are ~430KB, so a
+**It is 1.44MB and has no smaller variants.** The contents are ~1,230KB with
+RUNCPM's drive A and the C64's ROM sidecar on it, so a
 720KB or 360KB build of this list does not exist rather than being declined —
 and the machines those geometries are for are already served by the shipped
 disks. One size means no set of variants to keep in step.
@@ -17910,15 +17911,18 @@ The tree, and the one part of it that is a correctness requirement:
 
 | folder | what |
 |---|---|
-| `APPS/` | the ten tools, plus `FROTZ.O88` |
-| `GAMES/` | the five games |
+| `APPS/` | the thirteen tools, plus `FROTZ.O88` |
+| `GAMES/` | the six games |
 | `WORD/` | `WORD.O88`, `WORD.OVL`, `WELCOME.DOC` |
 | `CWORD/` | `CWORD.O88`, `CWORD.OVL`, `WELCOME.RTF` |
-| `MEDIA/` | the module and the two `.TEX` documents — where a File Open starts (§38.10) |
+| `RUNCPM/`, `RUNCPM/A/0/` | `RUNCPM.O88`, `RUNCPM.OVL`, the CCP and its `LICENSE` — and CP/M drive A below them (§74.5) |
+| `C64/` | `C64.O88`, `C64.OVL`, `C64.ROM`, `README.TXT` and `COPYING` (`docs/C64-SPEC.md` §14.2) |
+| `MEDIA/` | the module, the two `.TEX` documents and `DEMO.HTM` — where a File Open starts (§38.10) |
 | `SYSTEM/`, `SYSTEM/DOS/` | the Task Manager (§28.3) and `OS88NET.COM` (§62) |
 | `DOCS/` | empty, for the user's own saves |
 
-**Each Word gets a folder of its own, and that is not tidiness.** Both carry an
+**Each Word gets a folder of its own, and that is not tidiness** — and so do
+RUNCPM and the C64, for the same reason. Both Words carry an
 overlay resolved in the launching instance's current directory (§68.10, §73.14,
 §19.2.1), and a double-click on a document leaves that directory on the
 **document's** (§54.9). Package, overlay and welcome document therefore have to

--- a/docs/C64-SPEC.md
+++ b/docs/C64-SPEC.md
@@ -3472,7 +3472,10 @@ listings (§14.4). A released C64 disk boots to `READY.` and the user types.
 
 On `apps-all.img` the package gets **a folder of its own, `C64\`, never a
 place in `APPS/`** (SPEC.md §19.9, SPEC.md §19.10) — three files that must
-resolve in one directory.
+resolve in one directory, and `README.TXT` and `COPYING` beside them for the
+reason above: that disk is a distributed form of the binary exactly as the
+dedicated ones are, so the licence travels there too. Five files, ~120 of
+2,847 clusters.
 
 ### 14.3 The three 86Box machines
 


### PR DESCRIPTION
`docs/C64-SPEC.md` §14.2 already said what this disk was to do — *"on `apps-all.img` the package gets a folder of its own, `C64\`, never a place in `APPS/`"* — and the Makefile did not do it. So the one floppy that exists to save a reader curating a shelf of floppies was missing the newest program on the shelf, and the website's in-browser demo, which boots this image in B:, could not reach the C64 at all.

**Five files in `C64\`, not three.** `README.TXT` and `COPYING` ride with the binary here for the reason §14.2 gives for the dedicated disks: this image is a distributed form of a GPL-2-or-later program too. ~120 of 2,847 clusters; the image lands at **2,455/2,847**, `--verify`'d.

**SPEC.md §19.10 was already stale** and is brought back to the tree: RUNCPM has had a folder on this disk since §74.5 and the table never grew one; the shipped apps floppy carries nineteen packages and not fifteen; the tools are thirteen and the games six; and the contents are ~1,230KB rather than ~430KB — which is the sentence that justifies there being no 720KB or 360KB variant, so it is worth being true.

Verified: `make` 10/0, `checkdocs` 0 problems, `os88disk.py --verify` on the rebuilt image.

Found while cutting the v1.0.20260822 release, which needs this disk to carry the release's headline program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)