### PR TITLE
The release zip carries the C64 disks, and the GPL with them

### DIFF
--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -65,6 +65,22 @@ MANIFEST = [
                               "arcade games only."),
     ("runcpm360.img",  False, "CP/M emulator disk, 360KB. Carries the emulator and no "
                               "programs -- there is no room for them at this size."),
+    ("c64.img",        False, "Commodore 64 disk, 1.44MB. Carries the emulator, the three "
+                              "Commodore ROM images it reads at launch, and COPYING."),
+    ("c64720.img",     False, "Commodore 64 disk, 720KB."),
+    ("c64360.img",     False, "Commodore 64 disk, 360KB."),
+]
+
+# Files packed beside the images, when the image they belong to is here.
+# THE C64 IS GPL-2-OR-LATER because VICE is, and docs/C64-SPEC.md 1.2 says in
+# as many words that "the release zip carries COPYING". Its own floppies carry
+# it too -- this is the second copy, for a reader who unpacks the zip and never
+# mounts a disk. (trigger image, source path, name in the zip, description)
+EXTRAS = [
+    ("c64.img", "apps/c64/COPYING", "COPYING.C64",
+     "The GNU General Public License version 2, which is the licence the "
+     "Commodore 64 emulator is under. It applies to that one program and to "
+     "nothing else here."),
 ]
 
 README = """\
@@ -121,7 +137,11 @@ these same bytes.
 
 Built from commit {commit}.
 
-Licence: MIT. The LICENSE file in the source repository has the terms.
+Licence: MIT, with one exception. The LICENSE file in the source repository
+has the terms. The Commodore 64 emulator on c64*.img is under the GNU General
+Public License version 2 or later, because it is a port of VICE, which is; that
+licence is COPYING.C64 here when those disks are in this zip, and on the disks
+themselves. Nothing else in os8088 is affected by it.
 """
 
 
@@ -188,6 +208,18 @@ def main():
         else:
             skipped.append(name)
 
+    # An extra rides only when the image it belongs to did. A licence for a
+    # program that is not in the zip is noise; a program in the zip without
+    # its licence is the thing this list exists to stop.
+    have = {name for name, _, _ in picked}
+    for trigger, src, as_name, desc in EXTRAS:
+        if trigger in have:
+            if not os.path.isfile(src):
+                print("mkzip: %s is in the zip and %s is missing -- refusing to "
+                      "ship it without its licence." % (trigger, src), file=sys.stderr)
+                return 1
+            picked.append((as_name, src, desc))
+
     if missing:
         print("mkzip: these are built by `make` and are not in %s:" % bd,
               file=sys.stderr)
@@ -221,9 +253,10 @@ def main():
         n = len(zf.namelist())
 
     raw = sum(os.path.getsize(p) for _, p, _ in picked)
+    imgs = sum(1 for name, _, _ in picked if name.endswith(".img"))
     print("mkzip: %s" % out)
     print("  %d entries, %d images, %.1fMB packed from %.1fMB"
-          % (n, len(picked), os.path.getsize(out) / 1e6, raw / 1e6))
+          % (n, imgs, os.path.getsize(out) / 1e6, raw / 1e6))
     print("  sha256 %s" % sha256(out))
     if skipped:
         print("  on-demand disks NOT built, so not in the zip: %s"


### PR DESCRIPTION
`docs/C64-SPEC.md` §1.2 already says *"the release zip carries `COPYING` (`.claude/skills/release-os8088`)"* — and the packer's allowlist had never heard of the C64. The release that introduces the emulator would have shipped a zip without it, and `MANIFEST` is deliberately an allowlist rather than a glob, so nothing would have noticed.

- Three optional rows: `c64.img`, `c64720.img`, `c64360.img`.
- An `EXTRAS` list for files that ride **beside** an image rather than being one. One entry: the C64's `COPYING`, packed as `COPYING.C64`, and only when a C64 disk is in the zip. The rule is symmetric and stated at the list — a licence for a program that is not here is noise, and a program here without its licence is what the list exists to stop — so a missing `COPYING` with a `c64` image present **fails** the pack rather than dropping quietly.
- The README's licence line says MIT with one named exception instead of MIT flat, because with those disks in the zip that sentence was not true.
- The summary line counts `.img` files rather than picked entries, or `COPYING.C64` would have been reported as a twenty-first image.

Verified: packs 23 entries / 20 images, 3.1MB from 17.3MB; `SHA256SUMS` checks; the same version packs to the same bytes twice.

Found while cutting the v1.0.20260822 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)