### PR TITLE
mkzip: cite C64-SPEC the way checkdocs reads a citation

### DIFF
--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -72,7 +72,7 @@ MANIFEST = [
 ]
 
 # Files packed beside the images, when the image they belong to is here.
-# THE C64 IS GPL-2-OR-LATER because VICE is, and docs/C64-SPEC.md 1.2 says in
+# THE C64 IS GPL-2-OR-LATER because VICE is, and C64-SPEC 1.2 says in
 # as many words that "the release zip carries COPYING". Its own floppies carry
 # it too -- this is the second copy, for a reader who unpacks the zip and never
 # mounts a disk. (trigger image, source path, name in the zip, description)


### PR DESCRIPTION
The comment added in #109 wrote the C64 contract as `docs/C64-SPEC.md 1.2`, and `SPEC.md 1.2` is a substring of that -- so `tools/checkdocs.py` read it as a SPEC.md section, could not find §1.2, and `make` failed on main.

The form C64-SPEC asks for from outside is `C64-SPEC §N.M` (the file itself by name, without a section number). One word changed.

`checkdocs` 0 problems, `make` 10/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)