### PR TITLE
mkzip README: the one-disk floppy has a Commodore 64 on it now

### DIFF
--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -50,9 +50,9 @@ MANIFEST = [
                               "There is no 1.44MB or 720KB version -- at those sizes it is "
                               "already on the software disk."),
     ("apps-all.img",   False, "Every program on one 1.44MB software disk, including both "
-                              "word processors, the story reader and the CP/M emulator. "
-                              "Use this instead of apps.img if you would rather swap one "
-                              "disk than four."),
+                              "word processors, the story reader, the CP/M emulator and "
+                              "the Commodore 64. Use this instead of apps.img if you "
+                              "would rather swap one disk than five."),
     ("word.img",       False, "Word processor disk, 1.44MB."),
     ("word720.img",    False, "Word processor disk, 720KB."),
     ("word360.img",    False, "Word processor disk, 360KB."),
@@ -128,7 +128,7 @@ THE FILES
 CHECKING WHAT YOU GOT
 ---------------------
 
-SHA256SUMS lists a checksum for every image here. On macOS or Linux:
+SHA256SUMS lists a checksum for every file here. On macOS or Linux:
 
   shasum -a 256 -c SHA256SUMS
 


### PR DESCRIPTION
Two lines of the zip README, read off an actual unpacked release.

- `apps-all.img` said "both word processors, the story reader and the CP/M emulator ... swap one disk than four". #108 put the C64 on that disk, so it is five things and four disks, and the newest program on the floppy was the one the description did not name.
- "SHA256SUMS lists a checksum for every image here" -- since #109 it also covers `COPYING.C64`, which is not an image. Every *file*.

Verified by packing and unpacking: 23 entries, `shasum -c` clean, and the README-s own QEMU command line run from the unpacked directory boots to the desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)