### PR TITLE
Live media: bootable USB image and live CD (SPEC.md 80)

### DIFF
--- a/.claude/skills/release-os8088/SKILL.md
+++ b/.claude/skills/release-os8088/SKILL.md
@@ -171,6 +171,10 @@ tools/setup-cc.sh                     # SmallerC; needed by cword and allapps
 make allapps                          # apps-all.img -- every program, one disk
 make worddisk cworddisk               # word*.img, cword*.img
 make runcpm-src && make runcpmdisk    # runcpm*.img
+make live                             # os8088-usb.img + os8088.iso -- the live
+                                      # USB image and the live CD (SPEC.md 80).
+                                      # Needs the fetch on the line above and
+                                      # the C toolchain, like allapps
 ```
 
 Offer these, do not assume them. If `tools/setup-cc.sh` cannot run -- no
@@ -204,6 +208,25 @@ menu bar across the top with the chip glyph, then Locator, File and Builtins;
 a Disk A and a Disk B icon down the right-hand side; the mouse pointer.
 If the screen is blank or garbled, stop -- do not publish. Delete the two
 scratch files afterwards; `build/` is gitignored, but leave it tidy.
+
+**If `make live` ran, boot both live images the same way** -- the rule is
+per image, and a zip does not exempt the two biggest files in it:
+
+```bash
+qemu-system-i386 -display none -qmp unix:build/qmp.sock,server,nowait \
+  -drive file=build/os8088-usb.img,format=raw -boot c \
+  -chardev msmouse,id=m0 -serial chardev:m0 &
+sleep 10
+python3 tools/qmp.py build/qmp.sock 'screendump build/smoke-usb.ppm'
+python3 tools/qmp.py build/qmp.sock 'quit'
+# ...then the same five lines with `-cdrom build/os8088.iso -boot d`
+```
+
+**Look at both screenshots.** The desktop must show a Disk A icon AND a
+Disk C icon down the right-hand side -- C: is the live partition the kernel
+adopted, and its absence means the image booted the kernel and lost the
+volume, which is exactly the failure a screenshot catches and a checksum
+cannot.
 
 ### 3a. Pack the release zip
 
@@ -572,7 +595,10 @@ this whole procedure that cannot simply be re-run.
 Because the release page no longer lists a file per image, the notes have to
 say what the zip contains and how big it is -- one sentence naming the two
 images a reader actually needs, the packed size, and the sha256 step 3a
-printed. Someone who wants a per-image checksum finds it in the SHA256SUMS
+printed. When the zip carries the live media, name them too: a reader with no
+floppy drive needs to hear that `os8088-usb.img` and `os8088.iso` boot a PC
+or an emulator directly, or the two files that serve them best read as
+padding. Someone who wants a per-image checksum finds it in the SHA256SUMS
 inside the zip, or on the download page, and the notes should say which.
 
 `gh` infers the repository from the checkout's remote, so this works for a

--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -170,6 +170,11 @@ unmounted:
 
   dd if=os8088-usb.img of=/dev/sdX bs=1M
 
+On a Mac with the os8088 source checkout, `make burn` does this with an
+interactive guide instead -- it lists the attached USB flash drives, has
+you confirm the one to erase by typing its name, and verifies the write.
+It burns the CD too, when a burner is attached.
+
 os8088.iso is the same system as a CD image, for burning to a disc or for an
 emulator. In QEMU, one or the other:
 

--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -20,8 +20,9 @@ invisible in the zip listing until it is public.
 It does not build anything. Run `make` (and any on-demand target you want in
 the zip) first; a missing REQUIRED image stops the script, and a missing
 optional one is reported and skipped. That split is the point -- the seven
-images `make` produces are the release, and `apps-all`/`word`/`cword`/`runcpm`
-are on-demand disks that a tree without the C toolchain cannot build at all.
+images `make` produces are the release, and `apps-all`/`word`/`cword`/
+`runcpm` and the live media (`make live`, SPEC.md 80) are on-demand targets
+that a tree without the C toolchain cannot build at all.
 
 The zip is byte-for-byte reproducible: entries are written in manifest order,
 every timestamp is the date in the version string, and permissions are fixed.
@@ -49,6 +50,14 @@ MANIFEST = [
                               "programs at this size, so it rides a disk of its own. "
                               "There is no 1.44MB or 720KB version -- at those sizes it is "
                               "already on the software disk."),
+    ("os8088-usb.img", False, "Live USB image. The whole system and every program on one "
+                              "bootable hard-disk image. Write it raw to a USB stick and "
+                              "boot a PC from it in legacy BIOS mode -- no floppy drive "
+                              "needed. The LIVE USB AND LIVE CD section says how."),
+    ("os8088.iso",     False, "Live CD. The same system as a bootable CD image, for "
+                              "burning to a disc or booting in an emulator. A CD is "
+                              "read-only, so settings and saved files last until "
+                              "power-off; the USB image keeps them."),
     ("apps-all.img",   False, "Every program on one 1.44MB software disk, including both "
                               "word processors, the story reader, the CP/M emulator and "
                               "the Commodore 64. Use this instead of apps.img if you "
@@ -119,7 +128,7 @@ second. The last line is the mouse: os8088 drives a serial mouse, so the
 emulator has to put one on a serial port, and that is QEMU's way of doing it.
 Other emulators have their own; the project's site has the current recipe and
 the 86Box machine files.
-
+{live}
 THE FILES
 ---------
 
@@ -142,6 +151,37 @@ has the terms. The Commodore 64 emulator on c64*.img is under the GNU General
 Public License version 2 or later, because it is a port of VICE, which is; that
 licence is COPYING.C64 here when those disks are in this zip, and on the disks
 themselves. Nothing else in os8088 is affected by it.
+"""
+
+
+# The live-media section of the README, present only when the zip carries
+# the images it describes -- a README that explains a file the reader does
+# not have reads as a packing mistake.
+LIVE = """\
+
+LIVE USB AND LIVE CD
+--------------------
+
+os8088-usb.img and os8088.iso carry the whole system and every program with
+no floppies at all. os8088-usb.img is a raw hard-disk image: write it to a
+USB stick -- everything already on the stick is erased -- and boot a PC from
+it in legacy BIOS mode. On macOS or Linux, with the stick at /dev/sdX and
+unmounted:
+
+  dd if=os8088-usb.img of=/dev/sdX bs=1M
+
+os8088.iso is the same system as a CD image, for burning to a disc or for an
+emulator. In QEMU, one or the other:
+
+  qemu-system-i386 -drive file=os8088-usb.img,format=raw -boot c \\
+    -chardev msmouse,id=m0 -serial chardev:m0
+
+  qemu-system-i386 -cdrom os8088.iso -boot d \\
+    -chardev msmouse,id=m0 -serial chardev:m0
+
+Booted this way the system runs from a hard-disk partition that appears as
+drive C, with every program on it. The CD is read-only, so settings and
+saved files last until power-off; the USB stick keeps them.
 """
 
 
@@ -233,8 +273,9 @@ def main():
     files = "\n\n".join(
         "  %s\n      %s" % (name, "\n      ".join(_wrap(desc, 66)))
         for name, _, desc in picked)
+    live = LIVE if "os8088-usb.img" in have and "os8088.iso" in have else ""
     readme = README.format(version=args.version, rule="=" * (7 + len(args.version)),
-                           files=files, commit=commit)
+                           files=files, commit=commit, live=live)
 
     with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
         add(zf, "%s/README.txt" % root, readme.encode(), when)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ nothing here duplicates it — a second copy is a copy that goes stale.
 | **[docs/FIELD-MACHINES.md](docs/FIELD-MACHINES.md)** | asking for a field run — who has the hardware, what is in it, what a run costs them, and the two rules that bind whoever reads a result |
 | **[docs/FIELD-NOTES.md](docs/FIELD-NOTES.md)** | a bug that reproduces on hardware and not here — open, reproduced, unfixed, with what has already been ruled out for each |
 | **[docs/FTP-PERF.md](docs/FTP-PERF.md)** | picking the FTP server's speed back up (§77, §72.15) — what moved it from 7 to 15 KB/s, the four things that did NOT work, where the time goes now (57% of it is ABOVE the driver), and the next five candidates in the order the evidence ranks them |
+| **[docs/LIVE-MEDIA.md](docs/LIVE-MEDIA.md)** | answering any user-facing "how do I write, burn or boot the live USB/CD" — it is the reader's guide (dd, Rufus, BIOS settings, troubleshooting) and the README links it; §80 stays the design record and this file must follow it, never lead |
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,19 @@ make allapps  # build/apps-all.img (§19.10): ONE 1.44MB floppy with every app
               #   on it, Frotz, both Words and RunCPM (with its drive A)
               #   included, for a release page. Needs the C toolchain and
               #   the RunCPM fetch, so it is on demand like cworddisk —
-              #   it is the only target outside §73/§74 that does
+              #   it and the live media below are the only targets outside
+              #   §73/§74 that do
+make usb      # THE LIVE MEDIA (§80): build/os8088-usb.img is §52.10's
+make iso      #   hard-disk boot built into an image — system disk contents
+make live     #   plus the allapps payload on one FAT16 partition that the
+              #   kernel adopts as C:. Written raw to a stick it boots a
+              #   legacy-BIOS machine; `iso` wraps the SAME image in an El
+              #   Torito hard-disk-emulation CD, `live` builds both. On
+              #   demand for allapps' reason and needing the same fetch
+              #   (`make runcpm-src` once, first). A CD cannot write, and
+              #   §80.3 says what that costs; QEMU boots them with
+              #   `-drive file=build/os8088-usb.img,format=raw -boot c` /
+              #   `-cdrom build/os8088.iso -boot d`
 make clean
 ```
 
@@ -186,7 +198,9 @@ and in raw QEMU). **`make wiredisk`** is the same shape for a package that
 DOES NOT SHIP: WIREFRAME is an instrument rather than an application (§78.9),
 so `all` builds `wire.o88` and no shipped floppy carries it, and the three
 tests that drive it — `wireflick`, `wirefps`, `uilat` — default to that disk.
-`make allapps` collapses all of them onto one 1.44MB floppy (§19.10).
+`make allapps` collapses all of them onto one 1.44MB floppy (§19.10), and
+`make live` puts that same payload plus the system on the bootable live
+USB image and live CD (§80).
 
 **`RESET=` clears a machine's non-volatile state on the way in**, and it
 reaches every one of those targets because they all launch through the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,11 @@ make live     #   plus the allapps payload on one FAT16 partition that the
               #   §80.3 says what that costs; QEMU boots them with
               #   `-drive file=build/os8088-usb.img,format=raw -boot c` /
               #   `-cdrom build/os8088.iso -boot d`
+make burn     # the macOS guide onto REAL media (§80.4, tools/os88burn.py):
+              #   lists the attached USB flash drives (USB + external +
+              #   never the boot disk), typed-identifier confirmation,
+              #   read-back SHA-256 verify; burns the CD when drutil sees
+              #   a burner. Interactive; --scan just lists and exits
 make clean
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1009,7 +1009,7 @@ KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc
         cc-note chello covl cword cworddisk 386-c-word runcpm runcpmdisk \
         runcpm-src cpmsw rcz80test rcmemtest rczex 386-runcpm \
         xt-runcpm 286-runcpm \
-        allapps rcbandbench \
+        allapps usb iso live rcbandbench \
         c64 c64disk c64rom c64bandbench c64cputest c64memtest 386-c64 xt-c64 286-c64 \
         checkdocs test-fast test-full test-soak clean clean-cc clean-marty distclean
 
@@ -4940,6 +4940,73 @@ $(ALLAPPSIMG): $(ALLAPPS) tools/os88disk.py
 	@python3 tools/os88disk.py --verify $@
 	@echo "allapps: $@ - every app on one 1.44MB floppy; boot the system"
 	@echo "         disk with it in B: (make run RUNAPPS=$@)"
+
+# =============================================================================
+# THE LIVE MEDIA (ON DEMAND: `make usb` / `make iso` / `make live`) - SPEC.md 80
+# =============================================================================
+# build/os8088-usb.img: SPEC.md 52.10's hard-disk boot, built into an image at
+# release time instead of written by the installer at run time - boot/mbr.asm,
+# boot/boothd.asm as the volume boot record, one FAT16 partition with
+# KERNEL.SYS first and contiguous - carrying the system disk's contents AND
+# the everything-disk's payload (SPEC.md 19.10). Written raw to a USB stick
+# (dd, or any raw-image writer) it boots a legacy-BIOS machine, and the kernel
+# adopts the partition as C: exactly as an installed machine's (SPEC.md
+# 52.10.3) - which is the verification this inherits rather than needs.
+#
+# build/os8088.iso is the SAME IMAGE wrapped in an El Torito
+# hard-disk-emulation CD (SPEC.md 80.2): the BIOS presents the file as drive
+# 80h and nothing that runs can tell it from the stick. The image and the
+# readme ride the ISO as plain files too, so a host that mounts the CD can
+# copy the raw image off it. What a CD cannot do - remember settings, take a
+# save - is SPEC.md 80.3, stated rather than handled.
+#
+# ON DEMAND for allapps' reason exactly: the payload is that disk's, so
+# cword, the C64 and RUNCPM need the compiler and the pinned fetches. A clone
+# with nasm and python3 still builds every shipped floppy and neither of
+# these.
+#
+# THE PAYLOAD IS DERIVED, NOT LISTED: ALLAPPSARGS plus the system disk's own
+# arguments (the drivers, the readme, the logo, the fonts), so a package
+# added to either shipped list is on the live media without anyone
+# remembering it here. The RunCPM drive-A selection is allapps' own - same
+# --select, same reserve list, same folder count - so the two
+# everything-payloads cannot drift apart, LEFT-OFF.TXT and all; the live
+# volume has ~30MB free, so a selection priced for a 1.44MB floppy always
+# fits it. SYSTEM/APPDATA exists here for the floppy system disk's reason
+# (SPEC.md 19.9), and every option precedes the positional list because an
+# option taking a value mid-list stops argparse collecting it (see
+# APPDATAFOLDER's note above).
+USBIMG := $(BUILD)/os8088-usb.img
+LIVEISO := $(BUILD)/os8088.iso
+
+LIVEARGS := $(DRIVERS) $(SYSDOC) $(SYSLOGOARG) $(FACESARG) $(ALLAPPSARGS)
+
+usb: $(USBIMG)
+iso: $(LIVEISO)
+live: $(USBIMG) $(LIVEISO)
+
+$(USBIMG): $(BUILD)/mbr.bin $(BUILD)/boothd.bin $(BUILD)/kernel.bin \
+           $(DRIVERS) $(SYSDOC) $(SYSLOGO) $(FACES) $(FACELIC) \
+           $(ALLAPPS) tools/os88disk.py
+	sel="$$(python3 tools/getruncpm.py -o $(RUNCPMDIR) --select 1440 --dir-slots $(RUNCPMSLOTS) --folders $(ALLAPPSFOLDERS) --reserve $(ALLAPPSFILES) | sed 's,^,RUNCPM/A/0:,')"; \
+	[ -n "$$sel" ] || { echo "usb: getruncpm.py --select 1440 chose nothing"; exit 1; }; \
+	python3 tools/os88disk.py -o $@ --hdd \
+		--mbr $(BUILD)/mbr.bin --boot $(BUILD)/boothd.bin \
+		--kernel $(BUILD)/kernel.bin \
+		--deep-folders --dir-slots RUNCPM/A/0=$(RUNCPMSLOTS) \
+		--folder DOCS $(APPDATAFOLDER) $(LIVEARGS) $$sel
+	@python3 tools/os88disk.py --verify-hdd $@
+	@echo "usb:    $@ - the live USB image (SPEC.md 80.1). Write it raw"
+	@echo "        to a stick and boot a legacy-BIOS machine from it; the"
+	@echo "        partition mounts as C:. QEMU: qemu-system-i386 -drive"
+	@echo "        file=$@,format=raw -boot c"
+
+$(LIVEISO): $(USBIMG) $(SYSDOC) tools/os88iso.py
+	python3 tools/os88iso.py -o $@ --boot-image $(USBIMG) \
+		--file README.TXT=$(SYSDOC)
+	@echo "iso:    $@ - the live CD (SPEC.md 80.2): the same image, El"
+	@echo "        Torito hard-disk emulation. QEMU: qemu-system-i386"
+	@echo "        -cdrom $@ -boot d"
 
 # `make combo` -> build/combo.img: ONE 360KB bootable disk with the system,
 # every application AND the four benchmarks on it.

--- a/Makefile
+++ b/Makefile
@@ -1009,7 +1009,7 @@ KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc
         cc-note chello covl cword cworddisk 386-c-word runcpm runcpmdisk \
         runcpm-src cpmsw rcz80test rcmemtest rczex 386-runcpm \
         xt-runcpm 286-runcpm \
-        allapps usb iso live rcbandbench \
+        allapps usb iso live burn rcbandbench \
         c64 c64disk c64rom c64bandbench c64cputest c64memtest 386-c64 xt-c64 286-c64 \
         checkdocs test-fast test-full test-soak clean clean-cc clean-marty distclean
 
@@ -5007,6 +5007,15 @@ $(LIVEISO): $(USBIMG) $(SYSDOC) tools/os88iso.py
 	@echo "iso:    $@ - the live CD (SPEC.md 80.2): the same image, El"
 	@echo "        Torito hard-disk emulation. QEMU: qemu-system-i386"
 	@echo "        -cdrom $@ -boot d"
+
+# `make burn` - the macOS guide that puts the live media on real media
+# (SPEC.md 80.4): lists the attached USB flash drives, walks through the
+# erase-and-write with a typed confirmation and a read-back verify, and
+# burns the CD when a burner is attached. Interactive by design, so it has
+# NO image prerequisites: on a tree where `make live` has not run it says
+# so and takes a path (an unpacked release zip has the same files).
+burn:
+	@python3 tools/os88burn.py
 
 # `make combo` -> build/combo.img: ONE 360KB bootable disk with the system,
 # every application AND the four benchmarks on it.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ apps, a dock — and pre-emptive multitasking, which the real 1984 Macintosh
 never had (switchable to cooperative from the Control Panel, if you want to
 feel what they were up against).
 
+## 💾 New: boot it from a USB stick or a CD — no floppy drive needed
+
+[![Live USB](https://img.shields.io/badge/Live_USB-os8088--usb.img-2ea44f?style=for-the-badge&logo=usb&logoColor=white)](docs/LIVE-MEDIA.md)
+[![Live CD](https://img.shields.io/badge/Live_CD-os8088.iso-1f6feb?style=for-the-badge)](docs/LIVE-MEDIA.md)
+[![The guide](https://img.shields.io/badge/How%3F-docs%2FLIVE--MEDIA.md-e36209?style=for-the-badge)](docs/LIVE-MEDIA.md)
+
+> [!TIP]
+> The whole OS and **every application** — both word processors, Frotz, the
+> CP/M emulator, the Commodore 64, all the games — on one bootable image
+> that starts straight into the desktop as drive **C:**, on a real PC
+> (legacy BIOS), in QEMU, or burned to a CD-R.
+> **[docs/LIVE-MEDIA.md](docs/LIVE-MEDIA.md)** walks through all of it:
+> grab the images from a [release](https://github.com/jggonz/os8088/releases)
+> or `make live`, then `make burn` guides you through writing the stick on a
+> Mac — it shows only the drives that could be the right answer, makes you
+> type the disk's name before erasing anything, and verifies every byte it
+> wrote by reading it back.
+
 ```
 make          # build all seven floppy images
 make run      # boot it in QEMU (with an emulated serial mouse)
@@ -79,6 +97,12 @@ make 286-c64  # 86Box: the 12.5MHz 286 with the 720KB one
 make 386-c64  # 86Box: the 386DX with the 1.44MB one
 make allapps  # one 1.44MB floppy with every program on it, both word
               # processors, Frotz and RunCPM included
+make live     # the live media (docs/LIVE-MEDIA.md): os8088-usb.img, a
+              # bootable hard-disk image for a USB stick, and os8088.iso,
+              # the same image as a live CD - the whole OS and every app
+              # on one C: drive (make usb / make iso build them singly)
+make burn     # macOS: interactively write the stick / burn the CD, with a
+              # typed confirmation and a read-back verify
 make test     # boot headless with a QMP socket for scripted testing
 make debug    # boot with QEMU halted, waiting for gdb on :1234
 make marty    # a cycle-accurate IBM 5150 (MartyPC) with a debugger attached -
@@ -89,11 +113,12 @@ make clean
 ```
 
 `make` builds the six shipping floppies and needs nothing but `nasm` and
-`python3`. The three disks written in C — `cworddisk`, `runcpmdisk` and
-`allapps`, which carries both — want the compiler first: `tools/setup-cc.sh`
+`python3`. The disks that carry the C applications — `cworddisk`,
+`runcpmdisk`, `allapps` and the live media (`make live`) — want the compiler
+first: `tools/setup-cc.sh`
 fetches and builds it into `build/cc`, and nothing else in the tree depends on
-it. `runcpmdisk` and `allapps` also fetch RunCPM's command processor and
-master disk (`make runcpm-src`), and `runcpmdisk` the CP/M software that
+it. `runcpmdisk`, `allapps` and `live` also fetch RunCPM's command processor
+and master disk (`make runcpm-src`), and `runcpmdisk` the CP/M software that
 rides beside it (`make cpmsw`); none of it is committed here.
 
 ![what it looks like: gray dithered desktop, menu bar, drive icons, Note Pad,

--- a/SPEC.md
+++ b/SPEC.md
@@ -66703,3 +66703,21 @@ installed disk it is.
 The 720KB and 1.44MB floppy *images* still matter to the same reader — a USB
 floppy drive and a Gotek take them — so the live media are additions to the
 release zip, not replacements for anything in it.
+
+### 80.4 Writing the media on a Mac, guided
+
+`tools/os88burn.py` (`make burn`) is the interactive text-mode guide that
+puts the two images on real media, because the raw alternative is `dd`
+against a typed device node and a mistyped node is somebody's backup drive.
+It lists only the disks that could be the right answer — USB bus, external,
+and never the disk macOS is running from, filtered out rather than warned
+about — and the erase is confirmed by **typing the disk's identifier back**,
+not by pressing `y`. The wizard itself stays unprivileged; only the write is
+escalated, into a hidden mode of the same file that streams the image to the
+raw device and then **reads the whole length back and compares SHA-256s**,
+because a stick that silently drops bytes (fake-capacity flash) is the
+failure a successful-looking write cannot show. The CD half is Apple's own
+machinery — `drutil list` to know a burner is attached at all (none: the
+menu row says so and does nothing, §47's shape), `hdiutil burn` to burn and
+verify. macOS only, and it says so: on Linux the same job is `lsblk` and
+`dd`, and a guide pretending to cover both would test as neither.

--- a/SPEC.md
+++ b/SPEC.md
@@ -60218,7 +60218,7 @@ rules that turn `apps/<dir>/<name>.c` plus `apps/<dir>/<name>.asm` into
 | `cword` | `build/cword.o88` + `build/CWORD.OVL` (§73.12) |
 | `cworddisk` | `build/cword.img`, `cword720.img`, `cword360.img`, each carrying both files plus `WELCOME.RTF` and an empty `DOCS/` (§73.12.3), and each `os88disk.py --verify`ed |
 | `386-c-word` | boots `$(IMG)` in A: and `build/cword.img` in B: on `vm/386-c-word` |
-| `allapps` | `build/apps-all.img` — one 1.44MB floppy with every application on it (§19.10). The only target outside this section that needs the compiler, which is why it is on demand too |
+| `allapps` | `build/apps-all.img` — one 1.44MB floppy with every application on it (§19.10). Outside this section, only it and the live media (§80) — whose payload is this disk's — need the compiler, which is why all of them are on demand |
 | `clean-cc` | removes `build/cc`, which plain `clean` spares |
 
 **Nothing in `all` depends on the compiler, and that is the requirement rather
@@ -66609,3 +66609,97 @@ zero that turns the feature off.
 **No per-mode settings.** Speeds, star counts and figure sizes are constants
 chosen against the 4.77 MHz frame budget (§79.5). A user who wants a slower
 starfield wants a different starfield, and the place for that is the source.
+
+## 80. Live media — one bootable hard-disk image, a USB stick and a CD
+
+The shipped floppies assume a machine that has a floppy drive. A modern PC
+that still boots MS-DOS-era code has none — what it has is legacy (BIOS/CSM)
+boot from a USB stick or from a CD, and both of those present the medium
+through int 13h exactly as a hard disk is presented. So the live media are
+not a new boot path: they are §52.10's hard-disk boot, built into an image at
+release time instead of written by the installer at run time.
+
+`make usb` builds **`build/os8088-usb.img`**, a raw hard-disk image a reader
+writes to a USB stick with `dd` (or any raw-image writer) and boots. `make
+iso` wraps the same image in **`build/os8088.iso`**, a live CD. `make live`
+builds both. All three are on demand for §19.10's reason — the payload is the
+everything-disk's, and `cword`, the C64 and RUNCPM need the compiler and the
+pinned fetches — so a clone with `nasm` and `python3` still builds every
+shipped floppy and none of this.
+
+### 80.1 The image is §52.10's disk, made by the build instead of the installer
+
+`tools/os88disk.py --hdd` is the builder, and it writes what
+§52.10.4's installer writes, in the same order and for the same reasons:
+`boot/mbr.asm`'s 446 bytes and one active partition entry at LBA 0;
+`boot/boothd.asm` as the volume boot record, this volume's BPB over its first
+62 bytes and the kernel's sector count in the pinned word at offset 508; a
+FAT16 volume whose `KERNEL.SYS` is **first and contiguous from cluster 2**
+(§52.10.2 reads it as a flat run); and then the payload. It shares the floppy
+builder's whole middle — the folder tree, the attribute rules (§19.6), the
+warm `ASSOC.DAT` (§54.7), `--deep-folders` and `--dir-slots` — because a
+second copy of any of that is a copy that goes stale, and it is checked by
+the same `--verify-hdd` that checks an installer-written disk.
+
+The kernel needs nothing new. `boot/boothd.asm` takes its geometry from int
+13h AH=08h and its partition base from `BPB_HiddSec` (§52.10.2), the kernel
+adopts the boot partition as C: through `dsk_boot_from` before any driver
+loads (§52.10.3), and A: stays the floppy. A machine booted from the stick is
+an *installed* machine as far as every line of the OS is concerned — which is
+the point, because §52.10.3 was verified on a cycle-accurate 8088 and this
+inherits that verification rather than needing its own.
+
+**The geometry is 16 heads × 63 sectors, 65 cylinders, partition base 63.**
+The base is the era convention the driver's own partitioner uses (one track
+for the MBR); 65 cylinders puts the partition at 65,457 sectors, just under
+the **65,535-sector volume ceiling** the kernel's 16-bit sector arithmetic
+imposes (§52.10.3's `hd_chs` proof) — a hair under 32MB, so the type byte is
+04h (FAT16 under 32M) and there is free space to save into. 16×63 is chosen
+for the one consumer the floppies never had: a BIOS asked to boot a USB stick
+or an El Torito hard disk has no CMOS row for it, so it *derives* a geometry,
+and what it derives it from is the partition table's own CHS fields. The
+entry's CHS and LBA columns therefore describe the same sectors under
+exactly this geometry, start to end — a table whose two columns disagree
+boots on the BIOSes that read one column and not on the ones that read the
+other, and which column a BIOS reads is the one thing this image cannot ask.
+`boot/mbr.asm` reads the CHS column (§52.10.1).
+
+### 80.2 The CD is the same image, El Torito hard-disk emulation
+
+`tools/os88iso.py` writes an ISO9660 volume whose El Torito boot catalog
+names `OS8088HD.IMG` — the usb image, carried as an ordinary file on the CD —
+with media type 4, *hard disk emulation*: the BIOS presents the image as
+drive 80h, loads its MBR at `0000:7C00`, and every int 13h read the MBR, the
+VBR and the kernel make is serviced out of the file. Nothing that runs can
+tell it from the stick.
+
+The other two El Torito modes were considered and refused. **Floppy
+emulation** carries at most 2.88MB and the payload is ~1.3MB of applications
+*plus* the system, drivers, fonts and the CP/M drive — it does not fit any
+floppy geometry, which is §19.10's fact restated. **No-emulation** hands
+control to the boot image with no int 13h disk behind it at all — the CD
+answers only 2048-byte-sector reads on its own drive number, so it needs a
+CD driver in the kernel, and a driver for a medium the target machine class
+never shipped with is not worth a byte of `KERN_BUDGET`.
+
+The ISO is deterministic the way every image here is (fixed timestamps,
+fixed volume id), lists the boot image and a `README.TXT` beside it as plain
+files, and is built from the usb image byte-for-byte — one image, two
+wrappers, so a defect cannot exist on the CD and not on the stick.
+
+### 80.3 What a CD cannot do, stated rather than hidden
+
+A CD is read-only and the OS is not told so in advance: int 13h write on the
+emulated drive fails at the BIOS, and the failure surfaces exactly where a
+write-protected floppy's does — the operation reports its error when it is
+attempted. What that costs on a live CD: `SYSTEM.CFG` cannot be created or
+rewritten, so Control Panel choices and driver ticks (§51.5) last until
+power-off; saves onto C: refuse, and `DOCS/` is a folder the user can enter
+and not add to. None of it is handled specially, because §47's rule applies —
+the write's refusal is a fact, and it is reported where it happens. A USB
+stick has none of these limits: it persists settings and saves like the
+installed disk it is.
+
+The 720KB and 1.44MB floppy *images* still matter to the same reader — a USB
+floppy drive and a Gotek take them — so the live media are additions to the
+release zip, not replacements for anything in it.

--- a/docs/LIVE-MEDIA.md
+++ b/docs/LIVE-MEDIA.md
@@ -1,0 +1,195 @@
+# Live USB & Live CD — booting os8088 with no floppy drive
+
+os8088 ships as floppy images, and most machines that can still boot
+MS-DOS-era code no longer have a floppy drive. The live media close that
+gap: **one bootable hard-disk image**, carrying the whole operating system
+and **every application** — both word processors, the Z-machine story
+reader, the CP/M emulator, the Commodore 64, all the games and tools —
+written to a USB stick or wrapped in a CD. Booted either way, the machine
+starts straight into the desktop with everything on drive **C:** and about
+30MB free to save into.
+
+| file | what it is |
+|---|---|
+| `os8088-usb.img` | a raw 32MB hard-disk image, written directly to a USB stick |
+| `os8088.iso` | the **same image** wrapped in a bootable CD (El Torito hard-disk emulation) |
+
+They are two wrappers around one set of bytes, so anything that works on
+the stick works on the CD — with one honest difference: a CD is read-only,
+so settings and saved files last until power-off there, while the USB stick
+keeps them like a real hard disk.
+
+## Getting the images
+
+**From a release:** both files are in the release zip on the
+[releases page](https://github.com/jggonz/os8088/releases), when that
+release built them. `SHA256SUMS` in the zip covers them.
+
+**From source:** the live media are an on-demand build — they carry the
+applications written in C, so they need the compiler the shipped floppies
+deliberately do not:
+
+```
+tools/setup-cc.sh     # one-time: fetch and build the C compiler into build/cc
+make runcpm-src       # one-time: fetch the CP/M command processor and master disk
+make live             # build/os8088-usb.img + build/os8088.iso
+```
+
+The build is deterministic: the same source produces byte-identical images,
+so a checksum comparison against a release is meaningful.
+
+## Writing the USB stick
+
+> ⚠️ **Writing the image erases the entire stick.** Everything on it is
+> destroyed. Double-check which device you are writing to — this is the one
+> step where a typo costs somebody their backup drive.
+
+### On a Mac — the guided way (recommended)
+
+```
+make burn
+```
+
+An interactive guide that makes the dangerous step hard to get wrong:
+
+```
+os8088 live media writer (SPEC.md 80)
+
+  1) Write the live USB image to a flash drive
+  2) Burn the live CD
+  q) Quit
+  > 1
+
+  Image: build/os8088-usb.img (33.5MB)
+
+  USB flash drives attached now - CHOOSING ONE ERASES IT COMPLETELY:
+
+    1) disk4      15.5GB  SanDisk Cruzer  (UNTITLED)
+
+  Number to choose, r to rescan, q to go back.
+  > 1
+
+  About to ERASE disk4: SanDisk Cruzer, 15.5GB (UNTITLED).
+  Everything on it is destroyed. This cannot be undone.
+
+  Type the disk's identifier (disk4) to confirm, anything else aborts:
+```
+
+Three things it does that a raw copy command does not:
+
+- **It only lists disks that could be the right answer.** A drive appears
+  only if it is on the USB bus, external, and not the disk macOS is
+  running from. Your internal drive and your Thunderbolt enclosure are not
+  shown-with-a-warning — they are not shown at all.
+- **The erase is confirmed by typing the disk's identifier**, not by
+  pressing `y`. Pressing `y` is muscle memory; typing `disk4` is a
+  decision.
+- **It verifies the write by reading it back.** After writing, it reads
+  the full image length back off the stick and compares SHA-256 checksums.
+  A stick that silently drops bytes — fake-capacity flash is sold every
+  day — looks like a successful write and fails exactly this check.
+
+Only the write itself runs privileged (`sudo` asks once); listing and
+choosing do not. `python3 tools/os88burn.py --scan` lists the attached
+drives and burners without touching anything.
+
+### On a Mac or Linux — by hand
+
+Find the stick, unmount it, write it, eject it. **On macOS:**
+
+```
+diskutil list external physical          # find it - say it is disk4
+diskutil unmountDisk /dev/disk4
+sudo dd if=os8088-usb.img of=/dev/rdisk4 bs=1m
+diskutil eject /dev/disk4
+```
+
+(`rdisk4`, with the `r`, is the raw device — several times faster than
+`disk4`.) **On Linux:**
+
+```
+lsblk -o NAME,SIZE,TRAN,MODEL,MOUNTPOINTS   # find it - say it is /dev/sdb
+sudo umount /dev/sdb?                        # any mounted partitions
+sudo dd if=os8088-usb.img of=/dev/sdb bs=1M conv=fsync status=progress
+```
+
+### On Windows
+
+Use [Rufus](https://rufus.ie/) or
+[balenaEtcher](https://etcher.balena.io/) and give it `os8088-usb.img`.
+In Rufus choose **DD Image mode** if it asks — the image must be written
+raw, byte for byte, not "converted".
+
+## Burning the CD
+
+**On a Mac**, `make burn` again — option 2 appears live when a burner is
+attached and says so when none is. It uses Apple's own `hdiutil burn`,
+which verifies the disc after burning. By hand, the same thing is:
+
+```
+hdiutil burn os8088.iso
+```
+
+**On Windows**, right-click `os8088.iso` → *Burn disc image*. **On
+Linux**, any ISO burner (`wodim -v dev=/dev/sr0 os8088.iso`, or the
+desktop's disc writer). Burn it as an *image*, not as a data disc with one
+file on it.
+
+## Booting it
+
+The live media boot through the **legacy BIOS** path (also called CSM or
+"legacy boot"), the same way DOS did — os8088 is a real-mode 8086 operating
+system, and UEFI-only machines cannot start it.
+
+- **Real hardware:** plug the stick in (or insert the disc), enter the
+  boot menu (commonly F12, F11, F8 or Esc during power-on), and pick the
+  USB drive or the CD. If the stick does not appear, look in BIOS setup
+  for *Legacy boot / CSM* and enable it, and prefer *USB-HDD* mode if the
+  BIOS offers a choice of USB emulation types.
+- **QEMU:**
+
+  ```
+  qemu-system-i386 -drive file=os8088-usb.img,format=raw -boot c \
+    -chardev msmouse,id=m0 -serial chardev:m0
+
+  qemu-system-i386 -cdrom os8088.iso -boot d \
+    -chardev msmouse,id=m0 -serial chardev:m0
+  ```
+
+  The second line of each command is the mouse: os8088 drives a serial
+  mouse, and that is QEMU's way of attaching one.
+- **86Box / VirtualBox / others:** attach `os8088-usb.img` as a hard disk
+  image, or `os8088.iso` as a CD, and boot from it.
+
+What you should see: the boot splash, then the desktop with a **C:** drive
+icon on the right. Open it — `APPS`, `GAMES`, `WORD`, `CWORD`, `RUNCPM`,
+`C64`, `MEDIA` and the rest are all there, and `README.TXT` in the root is
+the on-disk manual. `DOCS/` is an empty folder for your own saves (on the
+USB stick they survive reboots; on the CD, saving politely refuses —
+the disc is read-only).
+
+## If it does not boot
+
+1. **Check the image first.** `shasum -a 256 os8088-usb.img` against the
+   `SHA256SUMS` in the release zip rules out a bad download in one line.
+2. **A black screen or "No boot device"** usually means the machine booted
+   in UEFI mode. Enable Legacy/CSM boot, or use the boot menu entry *not*
+   labelled "UEFI:".
+3. **The stick boots on one machine and not another:** try the BIOS's
+   *USB-HDD* emulation setting, and try a different (smaller, older)
+   stick — some BIOSes refuse large drives on the legacy path.
+4. **It boots but C: is missing or empty:** the write was incomplete.
+   Rewrite the stick; `make burn`'s read-back verify catches this class of
+   failure at write time.
+
+## How it works, for the curious
+
+There is no live-media-specific code in the OS at all. The image is the
+same thing os8088's own hard-disk installer writes to a real drive — a
+master boot record, a boot sector, and one FAT16 partition with the kernel
+laid out where 512 bytes of loader can find it — built at release time
+instead of at install time. The BIOS presents a USB stick (or an El Torito
+emulated CD) through the same interface as a 1980s hard disk, so the
+kernel adopts the partition as C: exactly as it does on a machine it was
+installed onto. SPEC.md §80 is the design record, and §52.10 the hard-disk
+boot chain it reuses.

--- a/tools/os88burn.py
+++ b/tools/os88burn.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""os88burn: put the live media on real media, on a Mac (SPEC.md 80.4).
+
+    python3 tools/os88burn.py            # the interactive guide
+    python3 tools/os88burn.py --scan     # list drives and burners, change
+                                         # nothing, and exit
+    make burn                            # the same guide
+
+An interactive text-mode guide for the two things a reader does with
+SPEC.md 80's images and cannot do with a copy command: write
+`os8088-usb.img` to a USB flash drive, and burn `os8088.iso` to a CD. It
+exists because the raw alternative is `dd` against a device node, and a
+mistyped device node is somebody's backup drive - so this shows what is
+attached, refuses everything that is not a USB flash drive, and makes the
+one destructive step a deliberate act.
+
+WHAT THE USB HALF WILL AND WILL NOT OFFER. A drive is listed only if
+diskutil says all three of: the bus is USB, the device is external, and it
+is not the disk macOS is running from. Internal disks, Thunderbolt/SATA
+enclosures and the boot disk are not shown at all rather than shown and
+guarded - a list that cannot name the wrong disk beats a warning about it.
+The erase is confirmed by TYPING THE DISK'S IDENTIFIER back, not by
+pressing y: y is muscle memory, and this step is the one place muscle
+memory kills.
+
+HOW THE WRITE RUNS. The wizard itself stays unprivileged - listing,
+choosing and confirming need no rights, so they take none. Only the write
+is escalated: it re-invokes this same file under `sudo` in a hidden
+`--_write` mode that opens the RAW device (`/dev/rdiskN` - the buffered
+node is several times slower), streams the image in 1MB chunks with a
+progress line, and then READS THE WHOLE IMAGE BACK and compares SHA-256s -
+a write that errored is loud, but a stick that silently drops bytes (fake
+capacity flash) is not, and the read-back is the only thing that catches
+it. The stick is ejected afterwards, ready to pull.
+
+THE CD HALF drives Apple's own machinery: `drutil list` says whether a
+burner is attached at all (none attached: the option says so and does
+nothing, SPEC.md 47's shape), and `hdiutil burn` does the burn and its own
+verify pass. It needs no privileges. A failed burn - no blank disc, disc
+too small - offers the retry after the fix rather than starting over.
+
+macOS ONLY, and it says so elsewhere: everything here is diskutil,
+drutil and hdiutil. On Linux the same job is `lsblk` + `dd` +
+`wodim`, and a guide that pretended to cover both would test as neither.
+
+The images come out of `make live` (or an unpacked release zip - the
+guide takes a path). Nothing here builds anything.
+"""
+import argparse
+import hashlib
+import os
+import plistlib
+import subprocess
+import sys
+
+CHUNK = 1 << 20                       # 1MB writes: big enough to stream a
+                                      # USB2 stick at bus speed, small
+                                      # enough for a live progress line
+MBR_SIG = b"\x55\xaa"
+
+
+def fail(msg):
+    sys.stderr.write("os88burn: error: %s\n" % msg)
+    sys.exit(1)
+
+
+def run(args):
+    """One external command, captured; None if it would not run at all."""
+    try:
+        return subprocess.run(args, capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+
+
+def mb(n):
+    return "%.1fMB" % (n / 1e6) if n < 1e9 else "%.1fGB" % (n / 1e9)
+
+
+# -----------------------------------------------------------------------------
+# what is attached
+# -----------------------------------------------------------------------------
+
+def boot_whole_disk():
+    """The whole disk '/' lives on - the one disk this tool must never
+    list, even though it CAN be external: a Mac booted from a USB drive
+    reports that drive as USB and external, and it is still the last
+    thing anybody wants erased."""
+    r = run(["diskutil", "info", "-plist", "/"])
+    if not r or r.returncode != 0:
+        return None
+    return plistlib.loads(r.stdout.encode()).get("ParentWholeDisk")
+
+
+def usb_drives():
+    """Every attached USB flash drive, as dicts. The three-way filter is
+    the module docstring's contract: USB bus, external, not the boot
+    disk. Anything that fails it is not shown at all."""
+    r = run(["diskutil", "list", "-plist", "external", "physical"])
+    if not r or r.returncode != 0:
+        fail("diskutil would not list disks - is this a Mac?")
+    wholes = plistlib.loads(r.stdout.encode()).get("WholeDisks", [])
+    boot = boot_whole_disk()
+    out = []
+    for dev in wholes:
+        r = run(["diskutil", "info", "-plist", dev])
+        if not r or r.returncode != 0:
+            continue
+        info = plistlib.loads(r.stdout.encode())
+        if info.get("BusProtocol") != "USB":
+            continue
+        if info.get("Internal"):
+            continue
+        if dev == boot:
+            continue
+        vr = run(["diskutil", "list", "-plist", dev])
+        vols = []
+        if vr and vr.returncode == 0:
+            for d in plistlib.loads(vr.stdout.encode()) \
+                    .get("AllDisksAndPartitions", []):
+                for p in d.get("Partitions", []):
+                    if p.get("VolumeName"):
+                        vols.append(p["VolumeName"])
+        out.append({"dev": dev,
+                    "size": info.get("TotalSize", 0),
+                    "name": (info.get("MediaName") or "").strip(),
+                    "vols": vols})
+    return out
+
+
+def burners():
+    """The attached CD/DVD burners, as name strings. `drutil list` prints
+    its column header whether or not a device follows it, so the header
+    line is skipped by shape rather than counted on."""
+    r = run(["drutil", "list"])
+    if not r or r.returncode != 0:
+        return []
+    out = []
+    for line in r.stdout.splitlines():
+        s = line.strip()
+        if not s or s.startswith("Vendor"):
+            continue
+        out.append(" ".join(s.split()))
+    return out
+
+
+# -----------------------------------------------------------------------------
+# what is being written
+# -----------------------------------------------------------------------------
+
+def check_usb_image(path):
+    """The same refusal os88iso.py makes (SPEC.md 80.2): a USB image is a
+    partitioned hard-disk image with an active type-04h entry, and
+    anything else written raw to a stick is a stick that does not boot -
+    better refused here, where the message can say why."""
+    with open(path, "rb") as f:
+        head = f.read(512)
+    if len(head) < 512 or head[510:512] != MBR_SIG:
+        fail("%s has no MBR signature - the live USB image is "
+             "os8088-usb.img, from `make live` (SPEC.md 80.1)" % path)
+    for i in range(4):
+        e = head[446 + i * 16:446 + i * 16 + 16]
+        if e and e[0] == 0x80 and e[4] == 0x04:
+            return
+    fail("%s has no active FAT16 partition entry - not the live USB "
+         "image" % path)
+
+
+def check_iso(path):
+    with open(path, "rb") as f:
+        f.seek(0x8000)
+        vd = f.read(6)
+    if vd[1:6] != b"CD001":
+        fail("%s is not an ISO9660 image - the live CD is os8088.iso, "
+             "from `make live` (SPEC.md 80.2)" % path)
+
+
+def find_image(given, default_name, checker, what):
+    """Resolve the image to write: --image/--iso, the build/ default, or
+    a path the user types (an unpacked release zip has these same
+    files)."""
+    if given:
+        if not os.path.isfile(given):
+            fail("%s: no such file" % given)
+        checker(given)
+        return given
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    cand = os.path.join(root, "build", default_name)
+    if os.path.isfile(cand):
+        checker(cand)
+        return cand
+    print()
+    print("  build/%s is not built. `make live` builds it (it needs the" %
+          default_name)
+    print("  C toolchain and `make runcpm-src` first - SPEC.md 80), or")
+    print("  point at one from an unpacked release zip.")
+    while True:
+        p = ask("  path to %s (or q to go back): " % what)
+        if p in ("q", ""):
+            return None
+        p = os.path.expanduser(p)
+        if not os.path.isfile(p):
+            print("  %s: no such file" % p)
+            continue
+        checker(p)
+        return p
+
+
+# -----------------------------------------------------------------------------
+# the two halves
+# -----------------------------------------------------------------------------
+
+def ask(prompt):
+    try:
+        return input(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print("Nothing was written.")
+        sys.exit(0)
+
+
+def usb_flow(image):
+    image = find_image(image, "os8088-usb.img", check_usb_image,
+                       "the live USB image")
+    if not image:
+        return
+    size = os.path.getsize(image)
+    print()
+    print("  Image: %s (%s)" % (image, mb(size)))
+
+    while True:
+        drives = usb_drives()
+        print()
+        if not drives:
+            print("  No USB flash drives are attached.")
+            print("  Plug one in, then r to rescan, or q to go back.")
+        else:
+            print("  USB flash drives attached now - CHOOSING ONE ERASES "
+                  "IT COMPLETELY:")
+            print()
+            for i, d in enumerate(drives, 1):
+                vols = ", ".join(d["vols"]) or "no mounted volumes"
+                print("    %d) %-8s %8s  %s  (%s)"
+                      % (i, d["dev"], mb(d["size"]), d["name"] or "?", vols))
+            print()
+            print("  Number to choose, r to rescan, q to go back.")
+        c = ask("  > ").lower()
+        if c == "q":
+            return
+        if c == "r" or not c:
+            continue
+        if not c.isdigit() or not 1 <= int(c) <= len(drives):
+            print("  ? %r" % c)
+            continue
+        d = drives[int(c) - 1]
+        if d["size"] < size:
+            print("  %s is %s - smaller than the image. Pick another."
+                  % (d["dev"], mb(d["size"])))
+            continue
+        break
+
+    print()
+    print("  About to ERASE %s: %s, %s (%s)."
+          % (d["dev"], d["name"] or "?", mb(d["size"]),
+             ", ".join(d["vols"]) or "no mounted volumes"))
+    print("  Everything on it is destroyed. This cannot be undone.")
+    print()
+    got = ask("  Type the disk's identifier (%s) to confirm, anything "
+              "else aborts: " % d["dev"])
+    if got != d["dev"]:
+        print("  Not confirmed. Nothing was written.")
+        return
+
+    r = run(["diskutil", "unmountDisk", "/dev/" + d["dev"]])
+    if not r or r.returncode != 0:
+        fail("could not unmount %s: %s"
+             % (d["dev"], (r.stderr or r.stdout).strip() if r else "?"))
+    print("  Unmounted %s." % d["dev"])
+    print()
+    print("  Writing needs administrator rights for the raw device; sudo")
+    print("  may ask for your password now.")
+    rc = subprocess.call(["sudo", sys.executable,
+                          os.path.abspath(__file__),
+                          "--_write", image, "/dev/r" + d["dev"]])
+    if rc != 0:
+        fail("the write did not complete; the stick's contents are "
+             "undefined - rerun this tool to try again")
+    run(["diskutil", "eject", "/dev/" + d["dev"]])
+    print()
+    print("  Done. %s is ejected - pull it out, plug it into the target"
+          % d["dev"])
+    print("  machine, and boot it in legacy BIOS mode (SPEC.md 80.1).")
+
+
+def write_and_verify(image, dev):
+    """The privileged half, running under sudo: stream, fsync, read the
+    whole image length back off the device, compare digests."""
+    size = os.path.getsize(image)
+    want = hashlib.sha256()
+    try:
+        out = os.open(dev, os.O_WRONLY)
+    except OSError as e:
+        fail("cannot open %s: %s" % (dev, e))
+    done = 0
+    with open(image, "rb") as src:
+        while True:
+            chunk = src.read(CHUNK)
+            if not chunk:
+                break
+            want.update(chunk)
+            while chunk:                     # a raw device may take less
+                try:                         # than asked; an error mid-way
+                    n = os.write(out, chunk)  # deserves a sentence, not a
+                except OSError as e:         # traceback
+                    print()
+                    fail("write failed %s in: %s - the stick's contents "
+                         "are undefined" % (mb(done), e))
+                chunk = chunk[n:]
+                done += n
+            sys.stdout.write("\r  writing  %s / %s (%d%%)"
+                             % (mb(done), mb(size), done * 100 // size))
+            sys.stdout.flush()
+    os.fsync(out)
+    os.close(out)
+    print()
+    got = hashlib.sha256()
+    done = 0
+    with open(dev, "rb", buffering=0) as back:
+        while done < size:
+            chunk = back.read(min(CHUNK, size - done))
+            if not chunk:
+                break
+            got.update(chunk)
+            done += len(chunk)
+            sys.stdout.write("\r  verifying %s / %s (%d%%)"
+                             % (mb(done), mb(size), done * 100 // size))
+            sys.stdout.flush()
+    print()
+    if done < size or got.digest() != want.digest():
+        fail("READ-BACK MISMATCH: the stick did not keep what was "
+             "written. Suspect the stick (fake-capacity flash fails "
+             "exactly this way) before suspecting the image.")
+    print("  Verified: %d bytes, SHA-256 match." % size)
+    return 0
+
+
+def cd_flow(iso):
+    devs = burners()
+    if not devs:
+        print()
+        print("  No CD/DVD burner is attached to this Mac, so there is")
+        print("  nothing to burn with. Attach one and rerun.")
+        return
+    iso = find_image(iso, "os8088.iso", check_iso, "the live CD image")
+    if not iso:
+        return
+    print()
+    print("  Burner: %s" % devs[0])
+    print("  Image:  %s (%s)" % (iso, mb(os.path.getsize(iso))))
+    print()
+    print("  Insert a blank CD-R (or CD-RW) in the burner.")
+    while True:
+        if ask("  Enter to burn, q to go back: ").lower() == "q":
+            return
+        print()
+        # hdiutil does the burn and its own verify pass; its output is
+        # the progress display, so it keeps the terminal.
+        rc = subprocess.call(["hdiutil", "burn", iso])
+        if rc == 0:
+            print()
+            print("  Done. The disc boots a legacy-BIOS machine set to")
+            print("  boot from CD (SPEC.md 80.2); being a CD it is")
+            print("  read-only - settings last until power-off (80.3).")
+            return
+        print()
+        print("  The burn did not complete (no blank disc, or the disc")
+        print("  was refused). Fix that and try again, or q to go back.")
+
+
+# -----------------------------------------------------------------------------
+
+def scan():
+    drives = usb_drives()
+    print("USB flash drives:")
+    if not drives:
+        print("  (none attached)")
+    for d in drives:
+        vols = ", ".join(d["vols"]) or "no mounted volumes"
+        print("  %-8s %8s  %s  (%s)"
+              % (d["dev"], mb(d["size"]), d["name"] or "?", vols))
+    devs = burners()
+    print("CD/DVD burners:")
+    if not devs:
+        print("  (none attached)")
+    for b in devs:
+        print("  %s" % b)
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scan", action="store_true",
+                    help="list attached USB flash drives and burners, "
+                         "change nothing, exit")
+    ap.add_argument("--image", metavar="IMG",
+                    help="the live USB image (default: build/os8088-usb.img)")
+    ap.add_argument("--iso", metavar="ISO",
+                    help="the live CD image (default: build/os8088.iso)")
+    ap.add_argument("--_write", nargs=2, metavar=("IMG", "DEV"),
+                    help=argparse.SUPPRESS)      # the sudo half, internal
+    a = ap.parse_args()
+
+    if a._write:
+        return write_and_verify(*a._write)
+    if sys.platform != "darwin":
+        fail("this is the macOS guide (diskutil/drutil/hdiutil); on "
+             "Linux use lsblk to find the stick and dd to write it")
+    if a.scan:
+        return scan()
+
+    print()
+    print("os8088 live media writer (SPEC.md 80)")
+    while True:
+        nburn = len(burners())
+        print()
+        print("  1) Write the live USB image to a flash drive")
+        if nburn:
+            print("  2) Burn the live CD")
+        else:
+            print("  2) Burn the live CD - no burner attached, so this "
+                  "will only say so")
+        print("  q) Quit")
+        c = ask("  > ").lower()
+        if c == "1":
+            usb_flow(a.image)
+        elif c == "2":
+            cd_flow(a.iso)
+        elif c in ("q", ""):
+            print("Nothing more to do.")
+            return 0
+        else:
+            print("  ? %r" % c)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/os88disk.py
+++ b/tools/os88disk.py
@@ -3,6 +3,8 @@
 
     python3 tools/os88disk.py -o OUT.img --size {1440,720,360}
                              [--folder PATH ...] [[DIR[/DIR...]:]PKG.o88 ...]
+    python3 tools/os88disk.py -o OUT.img --hdd --mbr MBR.bin
+                             --boot BOOTHD.bin --kernel KERNEL.bin [...]
     python3 tools/os88disk.py --verify IMG
     python3 tools/os88disk.py --verify-hdd HDD.img
 
@@ -27,6 +29,20 @@ geometry lived here so the kernel's FAT16 path had a positive test; it went
 when DSK_FAT_SECS fell to 10 sectors, which is below the 16 a FAT has to
 have to be FAT16 at all, so mount rule 10 (SPEC.md 18.2) now turns every
 FAT16 volume away and there is nothing left to test with.
+
+--hdd (SPEC.md 80.1) builds a bootable HARD-DISK image instead of a floppy:
+boot/mbr.asm's 446 bytes and one active partition entry at LBA 0,
+boot/boothd.asm as the volume boot record with this volume's BPB over its
+first 62 bytes and the kernel sector count in the pinned word at offset 508
+(SPEC.md 52.10.2), and a FAT16 volume laid out by the same code as every
+floppy - KERNEL.SYS first and contiguous, the folder tree, the attribute
+rules and the warm ASSOC.DAT are all the one implementation. It is what
+SPEC.md 52.10.4's installer writes, made at build time: the live-USB image,
+and the boot image inside the live CD (SPEC.md 80.2). The geometry is fixed
+(16 heads x 63 spt x 65 cylinders, partition base 63) and the partition
+entry's CHS and LBA columns describe the same sectors under it, because a
+BIOS booting a USB stick derives its virtual geometry from that table.
+--verify-hdd checks the result exactly as it checks an installer's disk.
 
 Boot-sector stub (offset 62): fixed hand-assembled bytes that print
 "Not a bootable disk. Press any key." via int 10h AH=0Eh teletype, wait
@@ -71,6 +87,23 @@ GEOMETRY = {
     720: (9, 2, 1440, 2, 3, 112, 0xF9),
     360: (9, 2, 720, 2, 2, 112, 0xFD),
 }
+
+# --hdd (SPEC.md 80.1): ONE fixed hard-disk shape, not a knob. 65 cylinders
+# puts the partition at 65,457 sectors - just under the kernel's
+# 65,535-sector volume ceiling (SPEC.md 52.10.3) and under 32MB, so the
+# partition type is 04h. The base is one track, the era convention
+# drivers/hdd/part.inc follows. 16x63 is for the consumer the floppies never
+# had: a BIOS booting a USB stick or an El Torito hard disk derives its
+# virtual geometry from the partition table's own CHS fields, so the entry
+# is written CHS/LBA-consistent under exactly this shape.
+HDD_SPT, HDD_HEADS, HDD_CYLS = 63, 16, 65
+HDD_BASE = HDD_SPT                       # the MBR's own track
+HDD_TOT = HDD_SPT * HDD_HEADS * HDD_CYLS # 65,520 sectors, the whole image
+HDD_PSECS = HDD_TOT - HDD_BASE           # 65,457 - the partition
+HDD_ROOT_ENT = 512                       # what drivers/hdd/fmt.inc formats
+HDD_LABEL = b"OS8088LIVE "
+BOOTHD_KSECS = 508                       # boot/boothd.asm's pinned patch word
+HP_TBL = 446                             # the partition table's offset
 
 # Hand-assembled A.4 stub (verified against nasm; see module docstring):
 #   xor ax,ax / mov ds,ax / mov si,0x7C59
@@ -346,12 +379,19 @@ def dirent(name11: bytes, attr: int, clus: int, size: int) -> bytes:
 
 
 def boot_sector(spt, heads, tot, spc, fatsz, root_ent, media,
-                lay: Layout, code: bytes = None, label: bytes = None) -> bytes:
-    """One BPB, two uses. `code` is os8088's own 512-byte boot sector: its
-    first three bytes are already EB 3C 90 and bytes 62.. are its loader, so
-    the BPB is written into the hole between them and everything else is left
-    exactly as nasm assembled it. Without `code` the sector carries the
-    not-bootable stub instead."""
+                lay: Layout, code: bytes = None, label: bytes = None,
+                hidden: int = 0, drvnum: int = 0, ksecs: int = 0) -> bytes:
+    """One BPB, three uses. `code` is os8088's own 512-byte boot sector -
+    boot/boot.asm's on a floppy, boot/boothd.asm's under --hdd: either way
+    its first three bytes are already EB 3C 90 and bytes 62.. are its
+    loader, so the BPB is written into the hole between them and everything
+    else is left exactly as nasm assembled it. Without `code` the sector
+    carries the not-bootable stub instead.
+
+    `hidden`/`drvnum`/`ksecs` are the hard-disk volume boot record's three
+    extras (SPEC.md 52.10.2): the partition base boothd.asm adds to every
+    LBA, BS_DrvNum 80h, and the kernel sector count in the pinned word at
+    offset 508 that the installer would otherwise patch."""
     bs = bytearray(code if code else SECTOR)
     if code:
         if len(code) != SECTOR:
@@ -371,15 +411,50 @@ def boot_sector(spt, heads, tot, spc, fatsz, root_ent, media,
     struct.pack_into("<H", bs, 22, fatsz)       # BPB_FATSz16
     struct.pack_into("<H", bs, 24, spt)         # BPB_SecPerTrk
     struct.pack_into("<H", bs, 26, heads)       # BPB_NumHeads
-    # BPB_HiddSec, BPB_TotSec32 stay 0; BS_DrvNum 0; BS_Reserved1 0.
+    # On a floppy BPB_HiddSec, BS_DrvNum and BPB_TotSec32 stay 0.
+    struct.pack_into("<I", bs, 28, hidden)      # BPB_HiddSec
+    bs[36] = drvnum                             # BS_DrvNum
     bs[38] = 0x29                               # BS_BootSig
     struct.pack_into("<I", bs, 39, VOL_ID)      # BS_VolID
     bs[43:54] = label or VOL_LABEL              # BS_VolLab
     bs[54:62] = b"FAT12   " if lay.fat12 else b"FAT16   "
     if not code:
         bs[62:62 + len(BOOT_STUB)] = BOOT_STUB
+    if ksecs:
+        struct.pack_into("<H", bs, BOOTHD_KSECS, ksecs)
     bs[510:512] = b"\x55\xAA"
     return bytes(bs)
+
+
+def hdd_layout(tot: int) -> Layout:
+    """The FAT16 layout for `tot` sectors: the smallest cluster that keeps
+    the count inside FAT16's range - the shape drivers/hdd/fmt.inc's own
+    capacity table produces, and the one tools/os88hdd.py builds for the
+    installer's test fixture (SPEC.md 52.10)."""
+    root_secs = (HDD_ROOT_ENT * 32 + SECTOR - 1) // SECTOR
+    for spc in (4, 8, 16, 32, 64):
+        fatsz = 1
+        nclus = 0
+        for _ in range(64):                     # converges in two or three
+            data = tot - 1 - 2 * fatsz - root_secs
+            nclus = data // spc
+            need = ((nclus + 2) * 2 + SECTOR - 1) // SECTOR
+            if need == fatsz:
+                break
+            fatsz = need
+        if 4085 <= nclus < 65525:
+            return Layout(spc, 1, 2, HDD_ROOT_ENT, tot, fatsz)
+    fail(f"no FAT16 layout fits {tot} sectors")
+
+
+def hdd_chs(lba: int) -> bytes:
+    """LBA as the 3-byte CHS field of a partition entry, under the fixed
+    --hdd geometry. Never clamped: 65 cylinders is far inside CHS range,
+    and the two columns agreeing IS the contract (SPEC.md 80.1) - a BIOS
+    booting this image derives its virtual geometry from these fields."""
+    c, r = divmod(lba, HDD_SPT * HDD_HEADS)
+    h, s = divmod(r, HDD_SPT)
+    return bytes([h, ((s + 1) & 0x3F) | ((c >> 2) & 0xC0), c & 0xFF])
 
 
 def read_data_file(path: str) -> bytes:
@@ -455,7 +530,20 @@ def read_blob(path: str, what: str) -> bytes:
 
 
 def build(args) -> int:
-    spt, heads, tot, spc, fatsz, root_ent, media = GEOMETRY[args.size]
+    mbr = b""
+    if args.hdd:
+        # A hard-disk image (SPEC.md 80.1) is a SYSTEM disk by construction:
+        # its whole point is booting, so the three parts of the chain are
+        # required rather than optional the way --boot/--kernel are.
+        if not (args.boot and args.kernel and args.mbr):
+            fail("--hdd needs --mbr (mbr.bin), --boot (boothd.bin) "
+                 "and --kernel")
+        mbr = read_blob(args.mbr, "MBR boot code")
+        if len(mbr) != HP_TBL:
+            fail(f"{args.mbr} is {len(mbr)} bytes, not {HP_TBL}")
+        spt, heads, tot, media = HDD_SPT, HDD_HEADS, HDD_PSECS, 0xF8
+    else:
+        spt, heads, tot, spc, fatsz, root_ent, media = GEOMETRY[args.size]
 
     # --- the system disk (SPEC.md 19.3) --------------------------------------
     # The kernel is an ordinary FILE, KERNEL.SYS, allocated FIRST and
@@ -480,7 +568,12 @@ def build(args) -> int:
         kern = read_blob(args.kernel, "kernel")
         ksecs = (len(kern) + SECTOR - 1) // SECTOR
         label = SYS_LABEL
-    lay = Layout(spc, 1, 2, root_ent, tot, fatsz)
+    if args.hdd:
+        label = HDD_LABEL
+        lay = hdd_layout(tot)
+        spc, fatsz, root_ent = lay.spc, lay.fatsz, lay.root_ent
+    else:
+        lay = Layout(spc, 1, 2, root_ent, tot, fatsz)
 
     # Group by folder, keeping first-appearance order. Names are checked for
     # duplicates PER DIRECTORY: two folders may each hold a MINES.O88.
@@ -708,11 +801,33 @@ def build(args) -> int:
         slot += 1
 
     image = bytearray(boot_sector(spt, heads, tot, spc, fatsz, root_ent,
-                                  media, lay, boot, label))
+                                  media, lay, boot, label,
+                                  hidden=HDD_BASE if args.hdd else 0,
+                                  drvnum=0x80 if args.hdd else 0,
+                                  ksecs=ksecs if args.hdd else 0))
     image += fat.buf + fat.buf                   # FAT2 = FAT1
     image += root
     image += data_area
     assert len(image) == tot * SECTOR
+
+    if args.hdd:
+        # The MBR sector in front of the volume: boot/mbr.asm's 446 bytes,
+        # one active entry whose CHS and LBA columns agree (SPEC.md 80.1),
+        # type 04h - the partition is under 32MB by construction - and the
+        # rest of the MBR's track left zero, which is where the era left it.
+        sec0 = bytearray(SECTOR)
+        sec0[0:HP_TBL] = mbr
+        ent = bytearray(16)
+        ent[0] = 0x80                            # active
+        ent[1:4] = hdd_chs(HDD_BASE)
+        ent[4] = 0x04                            # FAT16 under 32MB
+        ent[5:8] = hdd_chs(HDD_BASE + HDD_PSECS - 1)
+        struct.pack_into("<I", ent, 8, HDD_BASE)
+        struct.pack_into("<I", ent, 12, HDD_PSECS)
+        sec0[HP_TBL:HP_TBL + 16] = ent
+        sec0[510:512] = b"\x55\xAA"
+        image = bytes(sec0) + bytes((HDD_BASE - 1) * SECTOR) + bytes(image)
+        assert len(image) == HDD_TOT * SECTOR
 
     try:
         with open(args.output, "wb") as f:
@@ -720,7 +835,10 @@ def build(args) -> int:
     except OSError as e:
         fail(f"cannot write {args.output}: {e}")
 
-    print(f"os88disk: {args.output} ({args.size}KB, {spt} spt, "
+    geom = (f"{HDD_CYLS}/{HDD_HEADS}/{HDD_SPT} hdd, partition at LBA "
+            f"{HDD_BASE} for {HDD_PSECS} sectors" if args.hdd
+            else f"{args.size}KB, {spt} spt")
+    print(f"os88disk: {args.output} ({geom}, "
           f"{lay.type_name}) {len(files)} file(s)"
           + (f" in {len(dirs)} folder(s)" if dirs else "")
           + f", {need}/{lay.nclus} clusters"
@@ -1115,6 +1233,15 @@ def main() -> int:
     ap.add_argument("--size", type=int, choices=(1440, 720, 360),
                     help="disk size in KB: 1440 (18 spt), 720 or 360 (9 spt; "
                          "80 and 40 cylinders)")
+    ap.add_argument("--hdd", action="store_true",
+                    help="build a bootable HARD-DISK image instead of a "
+                         "floppy (SPEC.md 80.1): MBR + partition table, "
+                         "boothd.bin as the volume boot record, one FAT16 "
+                         "partition. Needs --mbr, --boot and --kernel; "
+                         "excludes --size")
+    ap.add_argument("--mbr", metavar="MBR.bin",
+                    help="with --hdd: boot/mbr.asm's 446 bytes of MBR boot "
+                         "code (build/mbr.bin)")
     ap.add_argument("--scramble", action="store_true",
                     help="fragment cluster chains round-robin (test only)")
     ap.add_argument("--verify-hdd", metavar="IMG",
@@ -1157,16 +1284,18 @@ def main() -> int:
 
     if args.verify_hdd:
         if args.output or args.size or args.scramble or args.packages \
-                or args.folder or args.dir_slots or args.verify:
+                or args.folder or args.dir_slots or args.verify or args.hdd:
             ap.error("--verify-hdd takes no other arguments")
         return verify_hdd(args.verify_hdd)
     if args.verify:
         if args.output or args.size or args.scramble or args.packages \
-                or args.folder or args.dir_slots:
+                or args.folder or args.dir_slots or args.hdd:
             ap.error("--verify takes no other arguments")
         return verify(args.verify)
-    if not args.output or not args.size:
-        ap.error("-o and --size are required to build")
+    if args.size and args.hdd:
+        ap.error("--size and --hdd are mutually exclusive")
+    if not args.output or not (args.size or args.hdd):
+        ap.error("-o and --size (or --hdd) are required to build")
     return build(args)
 
 

--- a/tools/os88iso.py
+++ b/tools/os88iso.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""os88iso: wrap the live hard-disk image in a bootable CD (SPEC.md 80.2).
+
+    python3 tools/os88iso.py -o OUT.iso --boot-image os8088-usb.img
+                             [--file NAME=PATH ...]
+
+The output is an ISO9660 volume with an El Torito boot catalog whose one
+entry is media type 4 - HARD DISK EMULATION: the BIOS presents the image as
+int 13h drive 80h, loads its MBR at 0000:7C00, and every read the MBR, the
+volume boot record and the kernel make is serviced out of the file. Nothing
+that runs can tell the CD from the USB stick the same image is written to,
+which is the point - one image, two wrappers (SPEC.md 80.2).
+
+The boot image must therefore BE a partitioned hard-disk image - what
+`os88disk.py --hdd` builds - and this refuses anything without an MBR
+signature and an active type-04h entry, because El Torito hard-disk
+emulation is defined over exactly that shape and a BIOS derives the
+emulated geometry from that table.
+
+The image also appears in the ISO's root directory as an ordinary file
+(OS8088HD.IMG), beside whatever --file adds - so a host that mounts the CD
+can copy the raw image off it and write a stick without a second download.
+
+Deliberately NOT here, so this stays reviewable and deterministic:
+- No Rock Ridge, no Joliet: 8.3 upper-case names are what this project's
+  own volumes use, and every file this carries is one already.
+- No directories: the handful of files ride in the root.
+- No isohybrid MBR on the ISO itself: the raw image for a USB stick is
+  os8088-usb.img, carried INSIDE this ISO and in the release zip beside it,
+  so overloading the ISO to be both would be a second copy of the boot
+  chain to keep in step (SPEC.md 80.2).
+
+Everything is fixed - timestamps, volume id, layout order - so the same
+inputs produce the same bytes, exactly like every disk image here.
+"""
+import argparse
+import os
+import struct
+import sys
+
+LBS = 2048                       # ISO9660 logical block
+VOLUME_ID = b"OS8088"
+BOOT_NAME = "OS8088HD.IMG"
+# One fixed timestamp for every field, os88disk.py's FIXED_DATE restated:
+# 2026-01-01 00:00:00, zone 0.
+YMDHMS = (2026, 1, 1, 0, 0, 0)
+
+
+def fail(msg):
+    sys.stderr.write("os88iso: error: %s\n" % msg)
+    sys.exit(1)
+
+
+def both16(n):
+    return struct.pack("<H", n) + struct.pack(">H", n)
+
+
+def both32(n):
+    return struct.pack("<I", n) + struct.pack(">I", n)
+
+
+def dir_date():
+    y, mo, d, h, mi, s = YMDHMS
+    return bytes([y - 1900, mo, d, h, mi, s, 0])
+
+
+def vol_date():
+    return b"%04d%02d%02d%02d%02d%02d00" % YMDHMS + b"\x00"
+
+
+def dirent(name, extent, size, is_dir):
+    """One directory record. `name` is bytes: b'\\x00' and b'\\x01' are the
+    '.' and '..' links, anything else an 8.3;1 file identifier."""
+    rec = bytearray()
+    rec += b"\x00"                               # length, patched below
+    rec += b"\x00"                               # extended attr length
+    rec += both32(extent)
+    rec += both32(size)
+    rec += dir_date()
+    rec += bytes([2 if is_dir else 0])           # flags
+    rec += b"\x00\x00"                           # unit size, gap
+    rec += both16(1)                             # volume sequence number
+    rec += bytes([len(name)]) + name
+    if len(rec) & 1:
+        rec += b"\x00"                           # pad to even length
+    rec[0] = len(rec)
+    return bytes(rec)
+
+
+def name_iso(name):
+    """Validate an 8.3 name and return its ISO file identifier."""
+    up = name.upper()
+    stem, _, ext = up.partition(".")
+    if not 1 <= len(stem) <= 8 or not ext or len(ext) > 3:
+        fail("'%s' is not an 8.3 NAME.EXT" % name)
+    ok = set(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+    if any(c not in ok for c in (stem + ext).encode("ascii", "replace")):
+        fail("'%s' has characters outside A-Z 0-9 _" % name)
+    return (up + ";1").encode()
+
+
+def check_boot_image(img):
+    """El Torito hard-disk emulation is defined over a partitioned image:
+    an MBR whose active entry the BIOS reads the emulated geometry from.
+    Refuse anything else here, where the message can say what is wrong -
+    booted, the same defect is a machine that hangs with a dark screen."""
+    if len(img) < 512 or img[510:512] != b"\x55\xaa":
+        fail("boot image has no MBR signature - os88disk.py --hdd builds "
+             "the image this wraps (SPEC.md 80.1)")
+    for i in range(4):
+        e = img[446 + i * 16:446 + i * 16 + 16]
+        if e[0] == 0x80:
+            if e[4] != 0x04:
+                fail("active partition is type 0x%02X, not the 04h "
+                     "(FAT16 under 32MB) SPEC.md 80.1 pins" % e[4])
+            return
+    fail("boot image has no active partition entry")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-o", "--output", required=True)
+    ap.add_argument("--boot-image", required=True,
+                    help="the os88disk.py --hdd image; El Torito boots it "
+                         "as an emulated hard disk and it is listed in the "
+                         "root as %s" % BOOT_NAME)
+    ap.add_argument("--file", action="append", default=[], metavar="NAME=PATH",
+                    help="another file for the root directory (repeatable), "
+                         "e.g. README.TXT=build/readme.txt")
+    a = ap.parse_args()
+
+    boot = open(a.boot_image, "rb").read()
+    check_boot_image(boot)
+
+    files = []                                   # (iso id, bytes, is_boot)
+    for spec in a.file:
+        nm, sep, path = spec.partition("=")
+        if not sep:
+            fail("--file wants NAME=PATH, not %r" % spec)
+        files.append((name_iso(nm), open(path, "rb").read(), False))
+    files.append((name_iso(BOOT_NAME), boot, True))
+    files.sort(key=lambda f: f[0])               # ISO9660 orders the record
+
+    # --- layout, in whole logical blocks -------------------------------------
+    # 0..15 system area, 16 PVD, 17 boot record, 18 terminator, 19 boot
+    # catalog, 20/21 the two path tables, 22 the root directory, then the
+    # file extents in record order.
+    pvd_lba, brvd_lba, term_lba = 16, 17, 18
+    cat_lba, ptl_lba, ptm_lba, root_lba = 19, 20, 21, 22
+    next_lba = 23
+    extents = []
+    for _, body, _ in files:
+        extents.append(next_lba)
+        next_lba += (len(body) + LBS - 1) // LBS
+    total = next_lba
+
+    root = b""
+    root += dirent(b"\x00", root_lba, LBS, True)
+    root += dirent(b"\x01", root_lba, LBS, True)
+    for (fid, body, _), ext in zip(files, extents):
+        root += dirent(fid, ext, len(body), False)
+    if len(root) > LBS:
+        fail("more root entries than one directory sector holds")
+    root = root.ljust(LBS, b"\x00")
+
+    # --- the two path tables: one record each, the root ----------------------
+    ptl = bytes([1, 0]) + struct.pack("<I", root_lba) + \
+        struct.pack("<H", 1) + b"\x00\x00"
+    ptm = bytes([1, 0]) + struct.pack(">I", root_lba) + \
+        struct.pack(">H", 1) + b"\x00\x00"
+    pt_size = len(ptl)
+
+    # --- the primary volume descriptor ---------------------------------------
+    pvd = bytearray(LBS)
+    pvd[0] = 1
+    pvd[1:6] = b"CD001"
+    pvd[6] = 1
+    pvd[8:40] = b" " * 32                        # system id
+    pvd[40:72] = VOLUME_ID.ljust(32)             # volume id
+    pvd[80:88] = both32(total)                   # volume space size
+    pvd[120:124] = both16(1)                     # volume set size
+    pvd[124:128] = both16(1)                     # volume sequence number
+    pvd[128:132] = both16(LBS)                   # logical block size
+    pvd[132:140] = both32(pt_size)               # path table size
+    struct.pack_into("<I", pvd, 140, ptl_lba)    # L path table
+    struct.pack_into(">I", pvd, 148, ptm_lba)    # M path table
+    pvd[156:190] = dirent(b"\x00", root_lba, LBS, True)
+    pvd[190:318] = b" " * 128                    # volume set id
+    pvd[318:446] = b"OS8088".ljust(128)          # publisher
+    pvd[446:574] = b"TOOLS/OS88ISO.PY".ljust(128)  # data preparer
+    pvd[574:702] = b"OS8088".ljust(128)          # application
+    pvd[702:739] = b" " * 37                     # copyright file id
+    pvd[739:776] = b" " * 37                     # abstract file id
+    pvd[776:813] = b" " * 37                     # bibliographic file id
+    pvd[813:830] = vol_date()                    # created
+    pvd[830:847] = vol_date()                    # modified
+    pvd[847:864] = b"0" * 16 + b"\x00"           # expires: never
+    pvd[864:881] = vol_date()                    # effective
+    pvd[881] = 1                                 # file structure version
+
+    # --- the El Torito boot record and catalog (SPEC.md 80.2) ----------------
+    brvd = bytearray(LBS)
+    brvd[0] = 0
+    brvd[1:6] = b"CD001"
+    brvd[6] = 1
+    brvd[7:39] = b"EL TORITO SPECIFICATION".ljust(32, b"\x00")
+    struct.pack_into("<I", brvd, 0x47, cat_lba)
+
+    term = bytearray(LBS)
+    term[0] = 255
+    term[1:6] = b"CD001"
+    term[6] = 1
+
+    val = bytearray(32)
+    val[0] = 1                                   # validation entry
+    val[1] = 0                                   # platform: 80x86
+    val[4:28] = b"os8088".ljust(24, b"\x00")
+    val[30:32] = b"\x55\xaa"
+    ck = -sum(struct.unpack("<16H", bytes(val))) & 0xFFFF
+    struct.pack_into("<H", val, 28, ck)
+    boot_lba = extents[[i for i, f in enumerate(files) if f[2]][0]]
+    ent = bytearray(32)
+    ent[0] = 0x88                                # bootable
+    ent[1] = 0x04                                # media: HARD DISK emulation
+    struct.pack_into("<H", ent, 2, 0)            # load segment: default 7C0h
+    ent[4] = 0x04                                # system type = the partition
+                                                 # type byte, as the spec asks
+    struct.pack_into("<H", ent, 6, 1)            # load the MBR's one sector
+    struct.pack_into("<I", ent, 8, boot_lba)
+    cat = (bytes(val) + bytes(ent)).ljust(LBS, b"\x00")
+
+    # --- write ---------------------------------------------------------------
+    out = bytearray(total * LBS)
+
+    def put(lba, blob):
+        out[lba * LBS:lba * LBS + len(blob)] = blob
+
+    put(pvd_lba, pvd)
+    put(brvd_lba, brvd)
+    put(term_lba, term)
+    put(cat_lba, cat)
+    put(ptl_lba, ptl)
+    put(ptm_lba, ptm)
+    put(root_lba, root)
+    for (_, body, _), ext in zip(files, extents):
+        put(ext, body)
+
+    with open(a.output, "wb") as f:
+        f.write(out)
+    print("os88iso: %s  %d sectors (%.1fMB), %d file(s), boot image %s at "
+          "LBA %d, hard-disk emulation"
+          % (a.output, total, total * LBS / 1e6, len(files),
+             BOOT_NAME, boot_lba))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two new on-demand release artifacts carrying the whole OS and every application, for machines with no floppy drive:

- **`make usb`** -> `build/os8088-usb.img` (32MB raw): a bootable hard-disk image, written raw to a USB stick and booted in legacy BIOS mode.
- **`make iso`** -> `build/os8088.iso`: the **same image** wrapped in an El Torito hard-disk-emulation live CD. `make live` builds both.

The release zip now carries both when they were built, with a "LIVE USB AND LIVE CD" section in its README (the `dd` and QEMU commands), and the release skill builds and boot-tests them.

## How

No new boot code. Both media reuse the field-verified SPEC.md 52.10 hard-disk boot chain: `boot/mbr.asm` -> `boot/boothd.asm` as the VBR -> one FAT16 partition with `KERNEL.SYS` first and contiguous, which the kernel adopts as C: before any driver loads (52.10.3). A machine booted from the stick is an *installed* machine as far as every line of the OS is concerned.

- `tools/os88disk.py --hdd` builds the image, sharing the floppy builder's whole middle (folder tree, attribute rules, warm ASSOC.DAT, `--deep-folders`/`--dir-slots`) rather than duplicating it, and the recipe checks the result with the existing `--verify-hdd`. Geometry is fixed at 16 heads x 63 spt x 65 cylinders - 65,457 partition sectors, just under the kernel's 65,535-sector volume ceiling - with CHS/LBA-consistent partition entries, because a BIOS booting a USB stick or an emulated CD derives its virtual geometry from that table.
- `tools/os88iso.py` (new, ~250 lines) writes a deterministic ISO9660 volume + El Torito boot catalog, hard-disk emulation only; it refuses a boot image without an MBR and an active type-04h entry. The raw image and README ride the ISO as plain files, so a host that mounts the CD can copy the stick image off it.
- Payload is derived, not listed: the system disk's arguments plus `ALLAPPSARGS`, with the RunCPM drive-A selection taken exactly as `allapps` takes it, so the two everything-payloads cannot drift. On demand for allapps' reason (needs the C toolchain and `make runcpm-src`).
- SPEC.md 80 (written before the code) is the contract, including what a CD honestly cannot do: settings and saves last until power-off there (80.3).

## Verification

- Booted **both** wrappers in QEMU (`-boot c` and `-cdrom ... -boot d`): desktop up, C: icon present, Disk window lists all 11 root entries with 31MB free, folder navigation works, Minesweeper launches off C:'s GAMES folder with its cached icon.
- `--verify-hdd` passes on the built image (147 files, FATs agree, no loops/cross-links).
- macOS `hdiutil attach` mounts the ISO; the embedded `OS8088HD.IMG` is byte-identical to the USB image.
- Both images rebuild **byte-for-byte** (delete + rebuild, sha256 match).
- `make` and `make test-fast` green (14/14 rows, doc gate included).
- Test zip packed and round-tripped: SHA256SUMS verify, README renders the live section only when the images are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174maNLRwuJK5QUZhgw6FaT