### PR TITLE
Weave wave 1 fix pass: 21 defects in the contract and its host reference

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37296,8 +37296,8 @@ criteria in §17 record which apps it affects.
 
 ### 39.8 The package ABI
 
-`OSAPI_VIDEO` (slot **0x00B4**; the table is 44 slots since the §20.6
-worker-task pair) — no inputs;
+`OSAPI_VIDEO` (slot **0x0158**; the table publishes 143 slots today) — no
+inputs;
 out AX = width, BX = height, CX = the first row the dock owns (so the usable
 desktop is rows `MBAR_H`..CX-1), DL = `vid_kind`, DH = bits per pixel (4 or
 1). Callable from any context, lock held or not — the first slot for which

--- a/apps/frotz/zio.inc
+++ b/apps/frotz/zio.inc
@@ -2486,9 +2486,19 @@ zi_m_scrfull: db 'Transcript full - it stops here.', 0
 ;
 ; The association path (SPEC.md 54.7) hands over a name and a LOCATOR, while
 ; the file dialog hands over a name AND the size - and the size is what
-; SPEC.md 61.4's refusal is decided from, before any disk I/O. So this looks
-; the size up the only way a package can: OSAPI_FILE_FIND walks the mount
-; snapshot, which is in RAM, so the walk costs no motor time either.
+; SPEC.md 61.4's refusal is decided from, before the file itself is read. So
+; this looks the size up the only way a package can: OSAPI_FILE_FIND.
+;
+; IT IS NOT FREE, and an earlier version of this comment said it was ("walks
+; the mount snapshot, which is in RAM, so the walk costs no motor time").
+; There is no such snapshot: names resolve through the RAW DIRECTORY SECTORS
+; and so does OSAPI_FILE_FIND (apps/os88api.inc's slot text), which re-seeks
+; from the ordinal and so "costs a directory re-read per entry"
+; (kernel/disk.inc, dsk_find_x). The refusal rule stands anyway - a directory
+; is at most a few hundred entries and the walk is a handful of sector reads
+; against a document read of tens of KB - but it is a cheaper read, not a
+; free one, and the file-dialog route is the only one that gets the size for
+; nothing.
 ;
 ; It walks the directory we are STANDING IN, so the locator frotz.asm banked
 ; is spent first. Nothing here searches for the file - the whole of opening a

--- a/docs/WEAVE-SPEC.md
+++ b/docs/WEAVE-SPEC.md
@@ -209,7 +209,7 @@ draw and arm/fire natively but no bytecode runs, and the pane is labelled
 | +8 | 2 | flags | §2.2.1 |
 | +10 | 1 | vm KB | VM claim ask, 16–32 (§4.7) |
 | +11 | 1 | grid KB | grid claim ask, 0 or 8–26 (§5.6) |
-| +12 | 1 | section count | 1–9, one row per section present |
+| +12 | 1 | section count | **5–9**, one row per section present. Five is the floor and not one: §2.4 makes UISTREAM, PROPS, CODE and ATOMS mandatory in every bundle and ICON always present, so those five rows are named by the format itself and a bundle carrying fewer refuses (§10.4) |
 | +13 | 1 | entry card | card index (1-based) shown at open |
 | +14 | 1 | canvas KB | canvas claim ask, 0 or 2–8 (§6.10) |
 | +15 | 1 | reserved | 0 |
@@ -1503,8 +1503,96 @@ component creation** (§9.9), which is what keeps layout §7's single walk.
 Layout runs on the 8×8 cell grid of the window's **content area**, whose
 truth is the live screen (`[vid_w]`/`[vid_h]`/`[vid_stride]` — never the
 VGA reference constants; SPEC.md §39). Let `CW` = content width in cells
-(content_px_w / 8, floor), `CH` = content height in rows of 8 px.
-Positions are cell-grid coordinates, converted to pixels only at paint.
+and `CH` = content height in rows of 8 px, both floored and both derived in
+§7.1.2 — the floor is not the only thing that comes off `CW`. Positions are
+cell-grid coordinates, converted to pixels only at paint.
+
+**Cell (0,0) IS the content origin.** WEAVE adds no inset of its own; a
+component that wants breathing room asks for a `spacer` (§6.3). That is a
+decision, not an omission — §7.1.2 is what it buys.
+
+#### 7.1.1 The three adapters' `CW × CH`, and the arithmetic behind them
+
+**WEAVE's window chrome is the browser's** (SPEC.md §71): an ordinary
+resizable window, no toolbar and no status strip of its own, opened at
+SPEC.md §11.95's **standard rect** — the whole desktop band. Everything the
+three adapters differ by falls out of that one rect, so the numbers below
+are derived and checkable rather than measured:
+
+```
+frame:   x = 0                       y = MBAR_H
+         w = [vid_w]                 h = [vid_dock_y0] - MBAR_H - 1
+content: width  = w - 1              (a window spanning the screen has no
+                                      LEFT border, SPEC.md 11.95.2, so
+                                      wm_geom answers w-1 and not w-2)
+         height = h - (TITLE_H + 1)   (wm_geom, SPEC.md 11)
+```
+
+`MBAR_H` is 20 and `TITLE_H` 18 (`apps/os88api.inc`), `DOCK_H` is 24
+(`kernel/dock.inc`) and `[vid_dock_y0]` is `[vid_h] - DOCK_H`
+(`kernel/viddet.inc`). The four subtractions on the height collapse to a
+constant — `24 + 20 + 1 + 19 = 64` — so for every adapter:
+
+```
+CW = floor(([vid_w] - 1)  / 8)
+CH = floor(([vid_h] - 64) / 8)
+```
+
+| adapter | screen | content px | `CW × CH` | wasted |
+|---|---|---|---|---|
+| CGA | 640×200 | 639 × 136 | **79 × 17** | 7 px × 0 px |
+| Hercules | 720×348 | 719 × 284 | **89 × 35** | 7 px × 4 px |
+| VGA mode 12h | 640×480 | 639 × 416 | **79 × 52** | 7 px × 0 px |
+
+These are the grids `weavesim --render` prints and the 8086 must reproduce
+exactly (§12). They are the **opening** grid and not a constant: a window
+the user has resized re-runs the walk at whatever `CW × CH` it then has
+(§7.4), and §7.4's 32×12 floor is what the family refuses to go below.
+Nothing else in this document may hard-code 79, 89, 17, 35 or 52 — an
+implementation that reads the numbers instead of the screen is wrong on two
+adapters of three the moment either constant moves (SPEC.md §39).
+
+#### 7.1.2 The content origin is rounded UP to a multiple of 8
+
+**Binding, and it is a shipped defect class rather than a theory.**
+`OSAPI_FONT_RUN`'s single-store fast path — the one that writes each cell
+old-to-final in ONE store, so a run is never momentarily blank — requires
+the pen on a multiple of 8 (SPEC.md §6.1). The walk emits cell coordinates
+and converts to pixels only at paint, so cell column `c` is drawn at
+`origin_x + 8c`: if `origin_x` is not ≡ 0 (mod 8) then **no component in
+the family ever takes the fast path, at any window position, on any
+adapter**, and every one of them draws the erase-then-letter pair instead
+(PERFORMANCE.md Part 1).
+
+That is exactly what happened to the line editor. `apps/os88line.inc` took
+its pen from a content edge plus its caller's small inset — the browser's
+is content+3, so the pen sat at content+6 — and `WF_SNAP` (SPEC.md §11.94)
+makes the content origin 8-aligned, which pinned the pen at 6 mod 8 for
+every window position on every adapter. Measured on a cycle-accurate
+5150/CGA with PERFORMANCE.md Part 3.1's instrument, a 26-character URL:
+**one keystroke flashed 246 transient pixels** over ~18 cells, and a
+backspace 437 over ~21.
+
+So, at **layout** time and not at paint:
+
+```
+origin_x = (content_left + 7) & ~7      ; UP. Down would put the pen inside
+                                        ; the frame (os88line_pen's reason)
+origin_y = content_top                  ; y is NOT aligned - font_run's
+                                        ; requirement is on x alone
+CW       = (content_left + content_w - origin_x) / 8
+CH       = content_h / 8
+```
+
+Three instructions, and the whole family is on the fast path by
+construction. The round costs up to 7 px of width, which `CW` has already
+taken off — the `os88line_cols` pattern, so nothing downstream of the walk
+learns about it. On §7.1.1's standard rect `content_left` is 0 and the
+round is a no-op, which is the point: it is the **general** case it exists
+for — a window the user resized, one that opted out with `WF_NOSNAP`, a
+secondary display where x = 0 is not a screen edge (SPEC.md §39.17.2), and
+the window too wide to snap that SPEC.md §11.94 leaves unsnapped rather
+than illegal.
 
 ### 7.2 The walk — normative and deterministic
 
@@ -1518,11 +1606,22 @@ for each component C (hidden components still take part — hiding does not
   w = C.w if C.w > 0 else natural width (§7.3), clamped to CW
   if C has CF_BREAK, or x > 0 and x + w > CW:
       close the current row; x = 0
+      (closing an EMPTY row is a NO-OP: no row is emitted. A CF_BREAK on a
+       card's first component, and a second CF_BREAK straight after one, are
+       both already at the start of a new row and must not produce a
+       zero-component row - a row has no height without a component in it,
+       and an implementation that emits one has no max() to take)
   place C at column x in the current row; x += w + 1   (one gutter cell)
-close the last row
+close the last row (the same no-op rule: an empty last row emits nothing)
 for each row:
   row height = max component natural/declared height in the row
-  align: slack = CW - (sum of widths + gutters);
+  align: slack = CW - (sum of widths + (n - 1))
+         (n = the row's component count. A row of n components carries n-1
+          gutters, NOT n: the gutter `x += w + 1` left after the last
+          component is the space before a component that went to the next
+          row, and is not part of this one. Slack is never negative - every
+          width is clamped to CW and a row closes before a component would
+          overflow it)
          ALIGN of the row's FIRST component: left -> 0 shift,
          center -> shift floor(slack/2), right -> shift slack
 row tops stack from row 0 downward, one blank pixel row (not cell) between
@@ -1541,8 +1640,8 @@ implementation — `weavesim --render` prints the cell rectangles and the
 
 | component | natural w (cells) | natural h (rows) |
 |---|---|---|
-| `label` | text length | 1 |
-| `text` | CW (full row) | wrapped row count at its width |
+| `label` | max(1, text length) | 1 |
+| `text` | CW (full row) | max(1, wrapped row count at its width) |
 | `rule` | CW | 1 |
 | `box` | declared (required) | declared |
 | `spacer` | declared | 1 |
@@ -1550,13 +1649,63 @@ implementation — `weavesim --render` prints the cell rectangles and the
 | `button` | label length + 2 | 2 |
 | `check`/`radio` | label length + 2 | 2 |
 | `input` | cols + 2 | 2 |
-| `list` | longest item + 3 (scroll bar) | rows |
+| `list` | max(1, longest item) + 3 (scroll bar) | rows |
 | `grid` | CW | CH − consumed rows above, min 6 |
 | `canvas` | w px / 8 | h px / 8 |
 
-`text` wrapping is greedy word wrap at cell granularity: break at spaces;
-a word longer than the width hard-breaks. Identical rule in weavesim and
-the 8086 — the wrap is part of the layout contract.
+The **floor of 1** in three of those rows is not defensive rounding. A
+component with no content still occupies one cell, so that it can be seen,
+hit, and given content later from script. Without the floor an empty
+`label` is 0 cells wide and §7.2's `x += w + 1` collapses it into its
+neighbour's gutter — a component present in the display list, invisible on
+the glass, and reachable by `.text` from WJS with nowhere to draw the
+answer. The same reasoning gives `text` a height of at least one row and a
+`list` of empty items a width of `1 + 3`.
+
+`text` wrapping is greedy word wrap at cell granularity: break at spaces; a
+word longer than the width hard-breaks. **The algorithm is normative here
+rather than by reference** — `tools/htmsim.py`'s `wrap()` is its one host
+implementation and the 8086 implements from this text, never from that
+source. In: the component's text folded to ASCII (§3.1) and split at
+whitespace into `words` in document order, and `width` = the component's
+width in cells, at least 1. Out: a list of lines, whose count is the
+natural height in the table above.
+
+```
+pending = ""                                ; the line being collected
+1. for each `word`, in document order:
+   a. while len(word) > width:              ; too long for ANY line: break it
+        i.   if pending is not empty: emit pending; pending = ""
+        ii.  emit the first `width` characters of word
+        iii. word = what is left of word
+   b. if pending is empty:
+          pending = word
+      else if len(pending) + 1 + len(word) <= width:
+          pending = pending + " " + word
+      else:
+          emit pending; pending = word
+2. if pending is not empty: emit pending
+```
+
+Three things the sentence above does not pin and an implementer would
+otherwise have to guess:
+
+- **On a hard break the pending line is emitted FIRST** (1.a.i), before the
+  over-long word's leading `width` characters. The word starts a line of
+  its own; it never continues the line already in hand, however much room
+  that line had left.
+- **The remainder becomes the new pending line** (1.a.iii feeding 1.b), not
+  a line of its own — so the tail of a hard-broken word goes on collecting
+  the words after it.
+- **The remainder may be EMPTY**, when the word's length was an exact
+  multiple of `width`. An empty `pending` is overwritten by the next word
+  at 1.b and emits nothing at step 2, so such a word adds no blank line.
+
+The separator written between two words on a line is one space, one cell
+wide, whatever whitespace stood there in the source (§3.1 collapses it) —
+and `len(pending) + 1 + len(word)` is the whole of the fit test. Identical
+rule in weavesim and the 8086: the wrap is part of the layout contract, and
+`--render` diffs it.
 
 ### 7.4 Resize, minimums, clipping
 
@@ -1771,14 +1920,31 @@ land here.
 
 ### 10.4 Malformed bundle
 
-Bad magic, version ≠ 1, size word ≠ directory size, section out of
-bounds, unknown section type, unknown ctype, reserved bits set, atom id
-out of range:
+Bad magic, version ≠ 1, size word ≠ directory size, section count under
+5 (§2.2), section out of bounds, unknown section type, unknown ctype,
+reserved bits set, atom id out of range, **a required property absent**,
+**a property outside §3.3's range**:
 
-> `<NAME>.WAB is not a Weave bundle (: <field>).`
+> `<NAME>.WAB is not a Weave bundle (<field>).`
 
 with the field named. The runtime never guesses past a bad header — every
 byte off a disk is hostile (SPEC.md §19).
+
+The last two are the ones a reader is likeliest to skip, because the packer
+already refuses them at pack (§10.5, §11.3) — and a `.WAB` on a disk need
+never have been through a packer. **A required property absent is
+malformed, never defaulted**: §3.3 requires `group` on a `radio`,
+`cols`/`rows` on a `grid`, `w`/`h` on a `box`, `w` on a `spacer` and
+`w`/`h` on a `canvas`, and §7.3 reads `box`'s, `spacer`'s and `canvas`'s
+straight out of the record as their natural size — so a bundle missing one
+lays the card out around a number nobody wrote. The field is
+`required property`. **A property outside its range is malformed too**:
+§3.3 bounds a `meter`'s `max` at 1–32000, an `input`'s `cols` at 2–60, a
+`list`'s `rows` at 1–40, a `grid`'s `cols` at 1–26 and `rows` at 1–256
+with cols×rows ≤ 6,140 (§5.6), a `canvas`'s `w` at 64–320 and a multiple
+of 8 and its `h` at 32–160. The field is `property range`. Both are
+checked as the PROPS blocks are read (§2.6), before any of them reaches
+the walk.
 
 ### 10.5 Pack-time refusals — the sentences name the platform fact
 

--- a/docs/WEAVE-SPEC.md
+++ b/docs/WEAVE-SPEC.md
@@ -2163,23 +2163,25 @@ after any change to §6 or to the model. Field figures land on the 5150
 and supersede modelled ones row by row (§12.4).
 
 | component | interaction | gfx calls | modelled cost |
-|---|---|---|---|
-| label | `.text` set (20 cells) | 1 | ~19 ms |
+| label | .text set (20 cells) | 1 | ~19 ms |
 | text | repaint (per wrapped row, 40 cells) | 1/row | ~37 ms/row |
 | rule / box / spacer | card paint | 1 / 1 / 0 | ~0.8 ms |
-| meter | `.value` delta | 1 | ~0.8–1 ms |
-| button | press+release | ~2 + label | ~1.5–9 ms |
-| check / radio | toggle (one glyph) | 1 | 35–50 ms (field) |
+| meter | .value delta | 1 | ~0.8-1 ms |
+| button | press+release | ~2 + label | ~1.5-9 ms |
+| check / radio | toggle (one glyph) | 1 | 35-50 ms (field) |
 | input | keystroke | ~2 cells | ~1.8 ms |
 | list | selection move | 2 (XOR) | ~1.6 ms |
-| list | scroll one line | 2 | ~83–90 ms |
-| grid | edit one cell (compose+blit 1 row) | 1 | ~3–5 ms |
+| list | scroll one line | 2 | ~83-90 ms |
+| grid | edit one cell (compose+blit 1 row) | 1 | ~3-5 ms |
 | grid | selection move (2 XOR rects) | 2 | ~1.5 ms |
 | grid | 79-cell row compose+blit | 1 | ~14.5 ms |
 | grid | full 20-row page | 20 | ~291 ms |
-| canvas | frame, 2 sprites (dirty bands) | 2–4 | ~2–5 ms |
-| card | switch (full-card repaint, text-heavy CGA card) | ~1/row | ~0.3–1.2 s |
-| alert | raise + dismiss | ~8 | ~30–40 ms |
+| canvas | frame, 2 sprites (dirty bands) | 2-4 | ~2-5 ms |
+| card | switch (full-card repaint, text-heavy CGA card) | ~1/row | ~0.3-1.2 s |
+| card | first paint, fully lettered CGA 640x200 (17 rows x 79 cells) | 17 | ~1.25 s |
+| card | first paint, fully lettered Hercules 720x348 (35 rows x 89 cells) | 35 | ~2.85 s |
+| card | first paint, fully lettered VGA 640x480 (52 rows x 79 cells) | 52 | ~2.59 s |
+| alert | raise + dismiss | ~8 | ~30-40 ms |
 
 A change that moves a row of this table upward is a regression against a
 documented number, not a neutral refactor — PERFORMANCE.md Part 5's

--- a/tests/unit/t_wab.py
+++ b/tests/unit/t_wab.py
@@ -44,6 +44,32 @@ The former AMBIGUITY sites below now enforce the pinned readings:
       in CODE, an <input>, or a <grid> (its formula bar is a library-wired
       input, S6.9).  Enforced both directions.
 
+STILL AMBIGUOUS, and read leniently here rather than guessed at:
+
+  A9. What `<canvas walls="TB">` COMPILES to.  S3.3 types the attribute
+      as a string, a subset of `TBLR`, and pins no encoding; the packed
+      bundles carry a PK_INT edge mask.  Both readings are admitted -
+      a mask is bounded by S3.4's four edge codes (0..15), a pooled
+      string by the TBLR subset - because a second reader that picks one
+      and refuses the other is asserting a fact the spec does not state.
+      Naming it here is the point: the spec should pin it, and until it
+      does neither implementation can be called wrong.
+
+  A10. S2.2 tabulates `section count` as 1-9 while S2.4 makes four
+      sections mandatory and ICON always present.  Read here as 5-9,
+      the only range the rest of the format can produce; S2.2's own
+      figure is the one that should move.
+
+WHAT S3.3 SAYS AND THIS FILE NOW ENFORCES.  S2.6 hands the reader the
+attribute table as a validation duty - "which names are legal on which
+component is S3.3's table; a reader treats an unknown pairing as a
+malformed bundle" - so S33_PROPS below is that table transcribed: the
+legal pairings per element, the kind each attribute compiles to, and the
+range each is bounded by.  S33_REQUIRED is its `required` column.  These
+are not ornaments on a well-formed file: `meter max = 0` divides by zero
+drawing the bar, a `radio` with no `group` has nothing to be exclusive
+against, and an out-of-range `cols` lays a component out past the card.
+
 DETERMINISM.  S2.14 rule 1: no timestamps, no host paths, nothing
 environmental.  Every field S2.2-S2.13 defines is structural, so there is no
 field this file must wave through unvalidated as "environmental" - byte
@@ -88,10 +114,95 @@ WK_EVENTS = set(range(48, 61))                            # onclick..onalert
 ATOM_ITEMS, ATOM_MENUS = 61, 62
 ATOM_ROWS, ATOM_COLS, ATOM_CARD = 15, 16, 20
 ATOM_FRAME, ATOM_START = 11, 40
+ATOM_TEXT, ATOM_VALUE, ATOM_LABEL, ATOM_CHECKED = 1, 2, 3, 5
+ATOM_X, ATOM_Y, ATOM_SHOWN, ATOM_MAX = 7, 8, 12, 14
+ATOM_GROUP, ATOM_WALLS, ATOM_TICK = 19, 23, 24
+ATOM_ONCLICK, ATOM_ONCHANGE, ATOM_ONKEY, ATOM_ONSELECT = 48, 49, 50, 51
+ATOM_ONEDIT, ATOM_ONCALC, ATOM_ONCOLLIDE = 52, 53, 54
+ATOM_ONWALL, ATOM_ONSCORE, ATOM_ONTICK = 55, 56, 57
 WK_ASSIGNED = WK_PROPS | WK_METHODS | WK_EVENTS | {ATOM_ITEMS, ATOM_MENUS}
 
 # S2.6 - property record kinds.
 PK_INT, PK_ATOM, PK_BLOB, PK_FUNC, PK_SPRITE = range(5)
+
+# S3.3 - the attribute table, element by element, as a bundle carries it:
+# which property atoms may appear in a component's block, the kind each
+# attribute compiles to, and the range S3.3 bounds it by (None = unbounded
+# there).  S2.6 makes the pairing binding in as many words - "which names
+# are legal on which component is S3.3's table; a reader treats an unknown
+# pairing as a malformed bundle" - and a range is not decoration either:
+# `meter max = 0` is a divide by zero on the runtime, and an `input` claiming
+# 61 columns lays out past the widest card the flow walk can give it.
+# Content-derived props are here too (S3.2's "children allowed: text"):
+# `label`/`text` carry their content as `text`, the three controls as `label`.
+S33_PROPS = {
+    CT_LABEL:  {ATOM_TEXT: (PK_ATOM, None, None)},
+    CT_TEXT:   {ATOM_TEXT: (PK_ATOM, None, None)},
+    CT_RULE:   {},
+    CT_BOX:    {},                                        # w,h live in the record
+    CT_SPACER: {},
+    CT_METER:  {ATOM_VALUE: (PK_INT, 0, 32000),           # and <= max, below
+                ATOM_MAX: (PK_INT, 1, 32000)},
+    CT_BUTTON: {ATOM_LABEL: (PK_ATOM, None, None),
+                ATOM_ONCLICK: (PK_FUNC, None, None)},
+    CT_CHECK:  {ATOM_LABEL: (PK_ATOM, None, None),
+                ATOM_CHECKED: (PK_INT, 0, 1),
+                ATOM_ONCHANGE: (PK_FUNC, None, None)},
+    CT_RADIO:  {ATOM_LABEL: (PK_ATOM, None, None),
+                ATOM_GROUP: (PK_ATOM, None, None),
+                ATOM_CHECKED: (PK_INT, 0, 1),
+                ATOM_ONCHANGE: (PK_FUNC, None, None)},
+    CT_INPUT:  {ATOM_TEXT: (PK_ATOM, None, None),
+                ATOM_COLS: (PK_INT, 2, 60),
+                ATOM_ONCHANGE: (PK_FUNC, None, None),
+                ATOM_ONKEY: (PK_FUNC, None, None)},
+    CT_LIST:   {ATOM_ITEMS: (PK_BLOB, None, None),
+                ATOM_ROWS: (PK_INT, 1, 40),
+                ATOM_ONSELECT: (PK_FUNC, None, None)},
+    CT_GRID:   {ATOM_COLS: (PK_INT, 1, 26),
+                ATOM_ROWS: (PK_INT, 1, 256),
+                ATOM_ONSELECT: (PK_FUNC, None, None),
+                ATOM_ONEDIT: (PK_FUNC, None, None),
+                ATOM_ONCALC: (PK_FUNC, None, None)},
+    CT_CANVAS: {ATOM_WALLS: (PK_INT, 0, 15),              # or PK_ATOM - see below
+                ATOM_TICK: (PK_INT, 0, 255),
+                ATOM_ONKEY: (PK_FUNC, None, None),
+                ATOM_ONCOLLIDE: (PK_FUNC, None, None),
+                ATOM_ONWALL: (PK_FUNC, None, None),
+                ATOM_ONSCORE: (PK_FUNC, None, None),
+                ATOM_ONTICK: (PK_FUNC, None, None)},
+    CT_SPRITE: {ATOM_FRAME: (PK_SPRITE, None, None),      # S3.3: `img` compiles here
+                ATOM_X: (PK_INT, None, None),             # signed px
+                ATOM_Y: (PK_INT, None, None),
+                ATOM_SHOWN: (PK_INT, 0, 1)},
+}
+assert len(S33_PROPS) == 14                               # S2.5.1's fourteen ctypes
+
+# S3.3's `required` column, for the attributes that survive into a block.
+# (`app name` is the header field, `card id` is the card index, `canvas w/h`
+# and `box`/`spacer` sizes are REC_COMP bytes, `menu title` and `item
+# oncommand` are the MENUS blob - each checked where it lands.)
+S33_REQUIRED = {
+    CT_RADIO: (ATOM_GROUP,),      # one checked per group; absent = no group
+    CT_GRID: (ATOM_COLS, ATOM_ROWS),
+    CT_SPRITE: (ATOM_FRAME,),     # S3.3: `img` is required on <sprite>
+}
+
+CT_NAMES = {CT_LABEL: "label", CT_TEXT: "text", CT_RULE: "rule",
+            CT_BOX: "box", CT_SPACER: "spacer", CT_METER: "meter",
+            CT_BUTTON: "button", CT_CHECK: "check", CT_RADIO: "radio",
+            CT_INPUT: "input", CT_LIST: "list", CT_GRID: "grid",
+            CT_CANVAS: "canvas", CT_SPRITE: "sprite"}
+ATOM_NAMES = {ATOM_TEXT: "text", ATOM_VALUE: "value", ATOM_LABEL: "label",
+              ATOM_CHECKED: "checked", ATOM_X: "x", ATOM_Y: "y",
+              ATOM_FRAME: "frame", ATOM_SHOWN: "shown", ATOM_MAX: "max",
+              ATOM_ROWS: "rows", ATOM_COLS: "cols", ATOM_GROUP: "group",
+              ATOM_WALLS: "walls", ATOM_TICK: "tick", ATOM_ITEMS: "ITEMS",
+              ATOM_ONCLICK: "onclick", ATOM_ONCHANGE: "onchange",
+              ATOM_ONKEY: "onkey", ATOM_ONSELECT: "onselect",
+              ATOM_ONEDIT: "onedit", ATOM_ONCALC: "oncalc",
+              ATOM_ONCOLLIDE: "oncollide", ATOM_ONWALL: "onwall",
+              ATOM_ONSCORE: "onscore", ATOM_ONTICK: "ontick"}
 
 # S4.5 - the 38 WVM opcodes and each one's total encoded length.
 OP_HALT, OP_RET = 0x00, 0x1D
@@ -133,6 +244,11 @@ def word(b, o):
     return struct.unpack_from("<H", b, o)[0]
 
 
+def signed(v):
+    """S2.6: a property record's value is a SIGNED word for PK_INT."""
+    return v - 0x10000 if v >= 0x8000 else v
+
+
 def align16(n):
     return (n + 15) & ~15
 
@@ -152,6 +268,7 @@ class Bundle:
         self.entry_card = 0
         self.vm_kb = self.grid_kb = self.canvas_kb = 0
         self.atom_count = 0        # app atoms in the pool
+        self.atom_text = {}        # atom id -> its pooled string
         self.comp_ids = set()      # every REC_COMP comp_id
         self.ctypes = {}           # comp_id -> ctype
         self.prop_ref = {}         # comp_id -> PROPS block offset (not 0xFFFF)
@@ -194,7 +311,11 @@ def check_header(w):
     check(w.grid_kb == 0 or 8 <= w.grid_kb <= 26,
           "%s: grid KB ask 0 or 8..26" % n, "S2.2/S5.6", got=w.grid_kb)
     nsec = b[12]
-    check(1 <= nsec <= 9, "%s: section count in 1..9" % n, "S2.2", got=nsec)
+    check(5 <= nsec <= 9, "%s: section count in 5..9" % n,
+          "S2.2 tabulates the byte as 1-9, but S2.4 leaves no bundle with "
+          "fewer than five sections: UISTREAM, PROPS, CODE and ATOMS are "
+          "mandatory in every bundle and ICON is always present. A count "
+          "below five is a header the format cannot produce", got=nsec)
     w.entry_card = b[13]
     check(1 <= w.entry_card <= 8, "%s: entry card in 1..8" % n,
           "S2.2: 1-based card index; S3.2 allows 1-8 cards", got=w.entry_card)
@@ -309,6 +430,7 @@ def check_atoms(w):
               "nothing outside them survives to a bundle", got=body)
         eq(s[off + 1 + L], 0, "%s: atom %d NUL-terminated" % (n, 64 + i),
            "S2.7: length byte and NUL must agree - a reader may use either")
+        w.atom_text[64 + i] = bytes(body)
         pos = off + 1 + L + 1
     eq(pos if count else 2, len(s), "%s: ATOMS length is exactly the pool" % n,
        "S2.7: no trailing bytes - the section length is part of the format")
@@ -360,6 +482,79 @@ def walk_prop_block(w, off, owner):
                "S2.6.1/S2.6.2")
         out.append((name, kind, value))
         off += 4
+
+
+def check_comp_props(w, cid, ctype, recs):
+    """S3.3 - one component's block against the attribute table: every
+    pairing legal on that element, every kind the one S3.3 compiles to,
+    every value inside the range the table pins, and every attribute S3.3
+    marks required actually present.
+
+    S2.6 hands this to the reader in as many words - an unknown pairing IS
+    a malformed bundle - and the ranges are what the runtime trusts: a
+    `meter` whose `max` is 0 divides by zero drawing its bar, and a `radio`
+    with no `group` has nothing to be exclusive against (S6.6).
+    """
+    n, el = w.name, CT_NAMES.get(ctype, "ctype 0x%02X" % ctype)
+    table = S33_PROPS.get(ctype, {})
+    seen = {}
+    for name, kind, value in recs:
+        aname = ATOM_NAMES.get(name, "atom %d" % name)
+        if name == ATOM_WALLS and ctype == CT_CANVAS and kind == PK_ATOM:
+            # AMBIGUITY (A9): S3.3 types `walls` as a string, a subset of
+            # `TBLR`, and does not say what it compiles to.  The demo
+            # bundles carry a PK_INT edge mask; a pooled string is the
+            # other defensible reading, so both are admitted and each is
+            # bounded on its own terms.  S3.4's edge codes (0 T, 1 B,
+            # 2 L, 3 R) are what bound the mask.
+            seen[name] = value
+            txt = w.atom_text.get(value, b"")
+            check(set(txt) <= set(b"TBLR"),
+                  "%s: %s comp %d walls string is a subset of TBLR" % (n, el, cid),
+                  "S3.3: `walls` is a subset of TBLR; missing edges are open",
+                  got=txt)
+            continue
+        if not check(name in table,
+                     "%s: %s comp %d carries `%s`, which S3.3 does not give a "
+                     "<%s>" % (n, el, cid, aname, el),
+                     "S2.6: which names are legal on which component is "
+                     "S3.3's table, and a reader treats an unknown pairing "
+                     "as a malformed bundle - the runtime would hand the "
+                     "value to a library component that has no such field",
+                     got="atom %d on <%s>" % (name, el)):
+            continue
+        want_kind, lo, hi = table[name]
+        eq(kind, want_kind, "%s: %s comp %d `%s` kind" % (n, el, cid, aname),
+           "S3.3/S2.6: the attribute's compiled kind - 0 PK_INT, 1 PK_ATOM, "
+           "2 PK_BLOB, 3 PK_FUNC, 4 PK_SPRITE")
+        if lo is not None and kind == PK_INT:
+            check(lo <= signed(value) <= hi,
+                  "%s: %s comp %d `%s` in %d..%d" % (n, el, cid, aname, lo, hi),
+                  "S3.3: the range this attribute is pinned to - a value "
+                  "outside it is refused at pack, so a bundle carrying one "
+                  "was not written by a conforming packer",
+                  got=signed(value), want="%d..%d" % (lo, hi))
+        seen[name] = value
+    for req in S33_REQUIRED.get(ctype, ()):
+        check(req in seen, "%s: %s comp %d carries the required `%s`"
+              % (n, el, cid, ATOM_NAMES.get(req, req)),
+              "S3.3 marks this attribute required on <%s>: absent is "
+              "malformed, not defaulted - there is no default for it to "
+              "take" % el, got=sorted(seen))
+    if ctype == CT_METER:
+        # S3.3: `value` is 0..max, `max` defaults to 100 when absent.
+        mx = signed(seen[ATOM_MAX]) if ATOM_MAX in seen else 100
+        val = signed(seen[ATOM_VALUE]) if ATOM_VALUE in seen else 0
+        check(0 <= val <= mx, "%s: meter comp %d value within 0..max"
+              % (n, cid), "S3.3/S6.4: `value` is 0..max and the library "
+              "clamps to it; a packed value outside means the two "
+              "implementations disagree about the clamp",
+              got=val, want="0..%d" % mx)
+    if ctype == CT_CANVAS and ATOM_ONTICK in seen:
+        check(signed(seen.get(ATOM_TICK, 0)) >= 1,
+              "%s: canvas comp %d binds ontick and carries tick >= 1" % (n, cid),
+              "S3.3: `ontick` requires `tick` >= 1 - tick 0 is no ontick "
+              "(S6.10 step 7 never fires), so a bound handler is dead code")
 
 
 def check_uistream(w):
@@ -428,6 +623,20 @@ def check_uistream(w):
                       "S3.3: w cells 0-160; 0 = natural", got=cw)
                 check(ch <= 40, "%s: rec %d h <= 40 rows" % (n, i),
                       "S3.3: h rows 0-40", got=ch)
+            # S3.3's two sizes that are REQUIRED rather than natural: a
+            # `box` is a frame and a `spacer` is a width, so 0 (= natural,
+            # S7.3) is not a reading either one has.
+            if ctype == CT_BOX:
+                check(cw >= 2, "%s: rec %d box w >= 2" % (n, i),
+                      "S3.3: <box> `w`,`h` required, >= 2x1 - a frame "
+                      "narrower than its two verticals is not a frame",
+                      got=cw)
+                check(ch >= 1, "%s: rec %d box h >= 1" % (n, i),
+                      "S3.3: <box> `w`,`h` required, >= 2x1", got=ch)
+            elif ctype == CT_SPACER:
+                check(cw >= 1, "%s: rec %d spacer w >= 1" % (n, i),
+                      "S3.3: <spacer> `w` required - a spacer draws nothing "
+                      "(S6.3), so its width is the whole of it", got=cw)
             check(style & 0xF0 == 0, "%s: rec %d style bits 4-7 zero" % (n, i),
                   "S2.5.2: a set bit refuses at load", got=hex(style))
             check((style >> 2) & 3 != 3, "%s: rec %d ALIGN != 3" % (n, i),
@@ -661,16 +870,13 @@ def check_props(w):
                    "%s: comp %d PK_SPRITE record named `frame`" % (n, cid),
                    "S3.3: no `img` atom exists; the record doubles as the "
                    "frame property's initial value")
+        check_comp_props(w, cid, w.ctypes[cid], recs)
         if w.ctypes[cid] == CT_GRID:
             got = {nm: v for nm, k, v in recs if k == PK_INT}
-            if check(ATOM_ROWS in got and ATOM_COLS in got,
-                     "%s: grid block carries rows and cols" % n,
-                     "S3.3: cols and rows are required on <grid>", got=list(got)):
+            # Presence and the 1..26 / 1..256 ranges are S33_PROPS' and
+            # S33_REQUIRED's; what is left here is the pair's arithmetic.
+            if ATOM_ROWS in got and ATOM_COLS in got:
                 w.grid_rows, w.grid_cols = got[ATOM_ROWS], got[ATOM_COLS]
-                check(1 <= w.grid_cols <= 26, "%s: grid cols 1..26" % n,
-                      "S3.3", got=w.grid_cols)
-                check(1 <= w.grid_rows <= 256, "%s: grid rows 1..256" % n,
-                      "S3.3", got=w.grid_rows)
                 check(w.grid_rows * w.grid_cols <= 6140,
                       "%s: rows x cols <= 6140" % n,
                       "S5.6: the cell store plus its pool must fit a 26KB claim",
@@ -733,6 +939,11 @@ def check_menus_blob(w, off):
         title, nitems = s[pos], s[pos + 1]
         check(w.atom_ok(title), "%s: menu %d title atom assigned" % (n, m),
               got=title)
+        check(len(w.atom_text.get(title, b"")) <= 8,
+              "%s: menu %d title <= 8 chars" % (n, m),
+              "S3.3: <menu> `title` <= 8 chars - the kernel's bar is drawn "
+              "from these and a longer one runs into the next menu",
+              got=w.atom_text.get(title))
         check(1 <= nitems <= 8, "%s: menu %d item count 1..8" % (n, m),
               "S2.6.2", got=nitems)
         pos += 2
@@ -743,6 +954,10 @@ def check_menus_blob(w, off):
             label, fn = s[pos + 2 * it], s[pos + 2 * it + 1]
             check(w.atom_ok(label), "%s: menu %d item %d label atom" % (n, m, it),
                   got=label)
+            check(len(w.atom_text.get(label, b"")) <= 24,
+                  "%s: menu %d item %d label <= 24 glyphs" % (n, m, it),
+                  "S3.3: <item> content is the label, <= 24 glyphs",
+                  got=w.atom_text.get(label))
             check(fn == 0xFF or fn < len(w.funcs),
                   "%s: menu %d item %d oncommand index" % (n, m, it),
                   "S2.6.2: a function index, or 0xFF for none (present, inert)",

--- a/tools/os88marty.py
+++ b/tools/os88marty.py
@@ -648,22 +648,65 @@ def _png(path, w, h, raw, colour_type):
 # sentence saying which of the above it was.
 # =============================================================================
 
+def _keep_pid(cmd):
+    """Does this command line belong to the EMULATOR, not to a shell or a
+    client that merely names it? The one rule both platforms below share."""
+    if "martypc_headless" not in cmd:
+        return False
+    if "pgrep" in cmd or "pkill" in cmd:
+        return False
+    parts = cmd.split()
+    return bool(parts) and parts[0].endswith("martypc_headless")
+
+
 def _marty_pids():
-    """Every running martypc_headless, by PID, without pgrep's self-match."""
+    """Every running martypc_headless, by PID, without pgrep's self-match.
+
+    TWO READERS, because /proc IS NOT PORTABLE AND DARWIN HAS NONE. This
+    harness ran on Linux only until a macOS box tried it and every marty row
+    died in launch() with FileNotFoundError('/proc') before starting anything
+    - which reads as the emulator being broken rather than as the process
+    lister being Linux-only, and macOS is a supported dev platform here
+    (tools/setup-macos.sh). The Darwin branch reads the same two fields from
+    `ps` and applies the same _keep_pid rule, so BOTH still kill by PID rather
+    than by pattern - which is the discipline the banner above insists on and
+    the whole reason this function exists instead of a pkill.
+    """
     import os
+    import subprocess
     out = []
-    for ent in os.listdir("/proc"):
-        if not ent.isdigit():
-            continue
-        try:
-            with open("/proc/%s/cmdline" % ent, "rb") as f:
-                cmd = f.read().replace(b"\0", b" ").decode("utf-8", "replace")
-        except OSError:
-            continue
-        # the EXECUTABLE, not any shell or client that merely names it
-        if "martypc_headless" in cmd and "pgrep" not in cmd and "pkill" not in cmd:
-            if cmd.split()[0].endswith("martypc_headless"):
+    if os.path.isdir("/proc"):
+        for ent in os.listdir("/proc"):
+            if not ent.isdigit():
+                continue
+            try:
+                with open("/proc/%s/cmdline" % ent, "rb") as f:
+                    cmd = f.read().replace(b"\0", b" ").decode("utf-8",
+                                                               "replace")
+            except OSError:
+                continue
+            if _keep_pid(cmd):
                 out.append(int(ent))
+        return out
+
+    # Darwin (and any other /proc-less unix): `ps` is the only process table.
+    # -A every process, -o with trailing `=` to suppress the headers, so each
+    # line is "<pid> <argv joined>" and nothing has to be parsed around a
+    # column title that localises.
+    try:
+        ps = subprocess.run(["ps", "-Ao", "pid=,args="],
+                            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return out
+    for line in ps.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pid, _, cmd = line.partition(" ")
+        if not pid.isdigit():
+            continue
+        if _keep_pid(cmd.strip()):
+            out.append(int(pid))
     return out
 
 

--- a/tools/weavesim.py
+++ b/tools/weavesim.py
@@ -58,12 +58,16 @@ GLYPH_TOGGLE_MS = (35, 50)  # os88ui_glyph toggle, 44-64 set bits, field 5150
 LIST_SCROLL_MS = (83, 90)   # PERFORMANCE.md Part 5's scroll-one-line contract
 KEYSTROKE_MS = 1.8          # the Note Pad contract (SPEC.md 27.2), ~2 cells
 
-# Content areas per adapter: the browser's maximized-window figures
-# (tools/htmsim.py), same chrome arithmetic; cell_us is Part 2's per-adapter
-# glyph cost. The walk itself only needs cw/ch (WEAVE-SPEC 7.1).
+# Content areas per adapter, derived in WEAVE-SPEC 7.1.1 from the platform's
+# own constants - CW = floor(([vid_w]-1)/8), CH = floor(([vid_h]-64)/8) over
+# SPEC.md 11.95's standard rect. NOT htmsim's viewport: the browser is not
+# maximized on Hercules (it takes 90% of the band), and copying its figure
+# is where this table's herc ch=36 came from - four content pixels that do
+# not exist, and a row the 8086 would have been told to lay out on.
+# cell_us is Part 2's per-adapter glyph cost; the walk needs only cw/ch.
 ADAPTERS = {
     "cga":  dict(name="CGA 640x200",      cell_us=918.0, cw=79, ch=17),
-    "herc": dict(name="Hercules 720x348", cell_us=905.0, cw=89, ch=36),
+    "herc": dict(name="Hercules 720x348", cell_us=905.0, cw=89, ch=35),
     "vga":  dict(name="VGA 640x480",      cell_us=620.0, cw=79, ch=52),
 }
 GEOM_ALIAS = {"640x200": "cga", "720x348": "herc", "640x480": "vga"}
@@ -217,7 +221,7 @@ class PackError(Exception):
 class BundleError(Exception):
     """A malformed bundle, refused with the field named (WEAVE-SPEC 10.4)."""
     def __init__(self, name, field):
-        super().__init__("%s is not a Weave bundle (: %s)." % (name, field))
+        super().__init__("%s is not a Weave bundle (%s)." % (name, field))
         self.field = field
 
 
@@ -2639,6 +2643,12 @@ class CompRec:
 
 
 class Bundle:
+    """The reader.  WEAVE-SPEC 2.1: every byte read off a disk is hostile,
+    so nothing here believes an offset it has not bounds-checked, and a
+    malformed bundle refuses with the field named (WEAVE-SPEC 10.4) rather
+    than raising - on the 8086 the same byte is a wild read, a bad divide
+    or a claim sized from a lie, and there is no traceback to catch."""
+
     def __init__(self, data, name):
         self.data, self.name = data, name
         e = lambda field: (_ for _ in ()).throw(BundleError(name, field))
@@ -2654,50 +2664,129 @@ class Bundle:
         self.flags = flags
         self.vm_kb, self.grid_kb, nsec, self.entry, self.canvas_kb, rsvd \
             = data[10:16]
-        if rsvd or not 1 <= nsec <= 9 or not 16 <= self.vm_kb <= 32:
+        if rsvd:
             e("header")
+        # The three claim-KB bytes ARE WEAVE-SPEC 10.1's memory refusal:
+        # the whole ask is computed from the directory entry plus these,
+        # BEFORE any I/O, so an out-of-range one is a lie the heap would
+        # believe.  All three are ranged, not just the VM's.
+        if not 16 <= self.vm_kb <= 32:
+            e("vm KB")
+        if self.grid_kb and not 8 <= self.grid_kb <= 26:
+            e("grid KB")
+        if self.canvas_kb and not 2 <= self.canvas_kb <= 8:
+            e("canvas KB")
+        # 2.4: UISTREAM, PROPS, CODE and ATOMS are mandatory and ICON is
+        # always present, so five rows is the floor and nine the ceiling.
+        if not 5 <= nsec <= 9:
+            e("section count")
+        if not 1 <= self.entry <= 8:
+            e("entry card")
         nm = data[16:32]
         z = nm.find(b"\0")
-        if z < 0 or any(b for b in nm[z:]):
+        if z <= 0 or any(b for b in nm[z:]):
+            e("app name")
+        if any(not 0x20 <= b <= 0x7E for b in nm[:z]):
             e("app name")
         self.app_name = nm[:z].decode("ascii")
         self.sections = {}
-        prev = 0
+        if 32 + 8 * nsec > total:
+            e("section table")
+        prev, end = 0, 32 + 8 * nsec
         for k in range(nsec):
             typ, z2, ofs, ln, extra = struct.unpack_from("<BBHHH", data,
                                                          32 + 8 * k)
             if typ <= prev or typ > 9 or z2:
                 e("section table")
-            if ofs % 16 or ofs + ln > total:
+            # 2.3: the first section begins at align16(32 + 8*count) and
+            # each next at align16(previous offset + length) - sections
+            # abut, so a gap or an overlap is a different file.
+            if ofs != align16(end) or ofs + ln > total:
                 e("section table")
-            prev = typ
+            if any(data[end:ofs]):      # 2.1: padding bytes are 0x00
+                e("section padding")
+            prev, end = typ, ofs + ln
             self.sections[typ] = (data[ofs:ofs + ln], extra)
+        if end != total:                # 2.3: no tail padding, ever
+            e("total size")
         for typ in (SEC_UISTREAM, SEC_PROPS, SEC_CODE, SEC_ATOMS):
             if typ not in self.sections:
                 e("section table")
+        # 2.4: ICON always - the packer supplies a default when the
+        # project has none, so an absent one is a truncated bundle.
+        if SEC_ICON not in self.sections \
+                or len(self.sections[SEC_ICON][0]) != 64:
+            e("ICON")
+        self._check_couplings(e)
+        # Parse order is dependency order: the atom pool, the sprite
+        # table and the function table are what a property record's value
+        # is bounds-checked against, so they are read first.
         self._parse_atoms(e)
-        self._parse_props(e)
-        self._parse_uistream(e)
-        self._parse_code(e)
-        self._parse_fx(e)
         self._parse_sprites(e)
-        self.icon = self.sections.get(SEC_ICON, (b"", 0))[0]
+        self._parse_code(e)
+        self._parse_uistream(e)
+        self._parse_props(e)
+        self._parse_fx(e)
+        self._check_comp_props(e)
+        self.icon = self.sections[SEC_ICON][0]
         src, wml_len = self.sections.get(SEC_SOURCE, (b"", 0))
+        if src and wml_len > len(src):
+            e("SOURCE")
         self.source = (src[:wml_len], src[wml_len:]) if src else None
 
+    def _check_couplings(self, e):
+        """2.2.1/2.4 - which sections ride which flag bits.  The packer
+        computes the flags word; a bundle whose flags disagree with its own
+        section table makes the load-time capability test (10.2) lie."""
+        grid = bool(self.flags & WABF_GRID)
+        if (SEC_FXCODE in self.sections) != grid:
+            e("flags")
+        if (SEC_CELLS in self.sections) != grid:
+            e("flags")
+        if (self.grid_kb > 0) != grid:
+            e("flags")
+        if (self.canvas_kb > 0) != bool(self.flags & WABF_CANVAS):
+            e("flags")
+        if (SEC_SOURCE in self.sections) != bool(self.flags & WABF_SOURCE):
+            e("flags")
+        if SEC_SPRITES in self.sections \
+                and not self.flags & WABF_CANVAS:
+            e("flags")
+
     def _parse_atoms(self, e):
+        """2.7 - the pool walked end to end: the count word must leave
+        room for its own offset table, every offset and length must stay
+        inside the section, and every body byte must be one the cell font
+        has a glyph for."""
         b, _ = self.sections[SEC_ATOMS]
+        if len(b) < 2:
+            e("atom pool")
         n = struct.unpack_from("<H", b, 0)[0]
         if n > APP_ATOM_MAX:
             e("atom id")
+        if 2 + 2 * n > len(b):
+            e("atom pool")
         self.atom_strings = []
+        pos = 2 + 2 * n
         for k in range(n):
             ofs = struct.unpack_from("<H", b, 2 + 2 * k)[0]
+            # Offsets ascend in id order and strings pack without gaps.
+            if ofs != pos or ofs >= len(b):
+                e("atom pool")
             ln = b[ofs]
+            if ln < 1 or ofs + 1 + ln + 1 > len(b):
+                e("atom pool")
             s = b[ofs + 1:ofs + 1 + ln]
             if b[ofs + 1 + ln] != 0:
                 e("atom pool")
+            # 2.7/3.1: folded to 0x20..0x7E.  A decode() here would raise
+            # instead of refusing - and the 8086 has no decode at all.
+            if any(not 0x20 <= c <= 0x7E for c in s):
+                e("atom pool")
             self.atom_strings.append(s.decode("ascii"))
+            pos = ofs + 1 + ln + 1
+        if pos != len(b):
+            e("atom pool")
 
     def atom_str(self, aid):
         if APP_ATOM0 <= aid < APP_ATOM0 + len(self.atom_strings):
@@ -2705,6 +2794,10 @@ class Bundle:
         if aid in WK_NAME:
             return WK_NAME[aid]
         raise BundleError(self.name, "atom id")
+
+    def _atom_ok(self, aid):
+        return aid in WK_NAME or \
+            APP_ATOM0 <= aid < APP_ATOM0 + len(self.atom_strings)
 
     def _block(self, ofs, e):
         b, _ = self.sections[SEC_PROPS]
@@ -2718,10 +2811,16 @@ class Bundle:
                 return out
             if kind > PK_SPRITE:
                 e("prop kind")
-            if not (atom in WK_NAME
-                    or APP_ATOM0 <= atom < APP_ATOM0
-                    + len(self.atom_strings)):
+            if not self._atom_ok(atom):
                 e("atom id")
+            if kind == PK_ATOM and not self._atom_ok(val):
+                e("atom id")
+            if kind == PK_BLOB and val >= len(b):
+                e("prop blob")
+            if kind == PK_FUNC and val >= len(self.functions):
+                e("function index")
+            if kind == PK_SPRITE and val >= len(self.sprites):
+                e("sprite index")
             if kind == PK_INT and val & 0x8000:
                 val -= 0x10000          # PK_INT is a signed word
             out[atom] = (kind, val)
@@ -2730,9 +2829,66 @@ class Bundle:
     def blob(self, ofs):
         return self.sections[SEC_PROPS][0][ofs:]
 
+    def _items_blob(self, ofs, e):
+        """2.6.1 - count byte then count atom-id bytes.  Walked AT LOAD:
+        a count larger than the blob's remaining bytes is a short list on
+        the model and a wild read on the machine."""
+        b = self.sections[SEC_PROPS][0]
+        if ofs >= len(b):
+            e("prop blob")
+        n = b[ofs]
+        if n > 64 or ofs + 1 + n > len(b):
+            e("list items")
+        for a in b[ofs + 1:ofs + 1 + n]:
+            if not self._atom_ok(a):
+                e("atom id")
+
+    def _menus_blob(self, ofs, e):
+        """2.6.2 - the MENUS blob, walked AT LOAD.  The model reads menus
+        lazily and the 8086 cannot: it must have them before the first
+        OSAPI_MENU_SET, so an unwalked blob is a wild read there and clean
+        here, which no differential can see."""
+        b = self.sections[SEC_PROPS][0]
+        if ofs >= len(b):
+            e("prop blob")
+        nm = b[ofs]
+        if not 1 <= nm <= 5:            # MENU_APPMAX (SPEC.md 12.2)
+            e("menu count")
+        pos = ofs + 1
+        self.menus = []
+        for _ in range(nm):
+            if pos + 2 > len(b):
+                e("menu blob")
+            title, ni = b[pos], b[pos + 1]
+            if not self._atom_ok(title):
+                e("atom id")
+            if not 1 <= ni <= 8:
+                e("menu item count")
+            pos += 2
+            if pos + 2 * ni > len(b):
+                e("menu blob")
+            items = []
+            for it in range(ni):
+                label, fn = b[pos + 2 * it], b[pos + 2 * it + 1]
+                if not self._atom_ok(label):
+                    e("atom id")
+                if fn != 0xFF and fn >= len(self.functions):
+                    e("menu command")
+                items.append((label, fn))
+            self.menus.append((title, items))
+            pos += 2 * ni
+
     def _parse_props(self, e):
         _, app_at = self.sections[SEC_PROPS]
+        if app_at >= len(self.sections[SEC_PROPS][0]):
+            e("app block")
         self.app_props = self._block(app_at, e)
+        self.menus = []
+        for atom, (kind, val) in self.app_props.items():
+            if atom not in (WK["card"], WK["start"], WK["MENUS"]):
+                e("app block")          # 2.6.2: nothing else may appear
+            if atom == WK["MENUS"]:
+                self._menus_blob(val, e)
 
     def _parse_uistream(self, e):
         b, nrec = self.sections[SEC_UISTREAM]
@@ -2741,15 +2897,22 @@ class Bundle:
         self.cards = []
         seen_ids = set()
         comps = None
+        end_seen = False
+        next_id, prev_ct = 1, None
         for k in range(nrec):
             r = b[10 * k:10 * k + 10]
             if r[0] == REC_END:
                 if k != nrec - 1 or any(r[1:]):
                     e("REC_END")
+                end_seen = True
             elif r[0] == REC_CARD:
                 if not 1 <= r[1] <= 8 or r[1] != len(self.cards) + 1:
                     e("card index")
+                # 2.5: bytes +2..+7 are 0 and v1 cards carry no props.
+                if any(r[2:8]) or struct.unpack_from("<H", r, 8)[0] != 0xFFFF:
+                    e("card record")
                 comps = []
+                prev_ct = None
                 self.cards.append(comps)
             elif r[0] == REC_COMP:
                 if comps is None:
@@ -2757,37 +2920,125 @@ class Bundle:
                 cid, ct = r[1], r[2]
                 if ct not in CTYPE_NAME:
                     e("ctype")
-                if cid in seen_ids or not 1 <= cid <= 250:
+                # 2.5/2.14 rule 2: comp_ids are document order, 1-based.
+                if cid in seen_ids or not 1 <= cid <= 250 or cid != next_id:
                     e("comp_id")
                 seen_ids.add(cid)
+                next_id += 1
+                if r[7]:
+                    e("component record")
                 if r[5] & 0xF0:
                     e("style byte")
                 if (r[5] >> 2) & 3 == 3:
                     e("style byte")
                 if r[6] & ~7:
                     e("cflags")
+                self._geometry(CTYPE_NAME[ct], r[3], r[4], prev_ct, e)
                 c = CompRec(cid, ct, r[3], r[4], r[5], r[6])
                 pofs = struct.unpack_from("<H", r, 8)[0]
                 if pofs != 0xFFFF:
+                    if pofs >= len(self.sections[SEC_PROPS][0]):
+                        e("prop block")
                     c.props = self._block(pofs, e)
                 comps.append(c)
+                prev_ct = ct
             else:
                 e("record kind")
+        if not end_seen:
+            e("REC_END")
         if not self.cards or not 1 <= self.entry <= len(self.cards):
             e("entry card")
         self.comps = {c.comp_id: c for comps in self.cards for c in comps}
 
+    def _geometry(self, tag, w, h, prev_ct, e):
+        """2.5/3.3 - the record's w/h bytes, per ctype.  A 0 where the
+        spec says "never 0" is a divide or a negative repeat count on the
+        machine, so it refuses here."""
+        if tag == "sprite":
+            # 2.5: a <sprite> record follows its <canvas> directly.
+            if prev_ct not in (CTYPE["canvas"], CTYPE["sprite"]):
+                e("sprite record")
+            if w or h:                  # its geometry lives in SPRITES
+                e("sprite record")
+            return
+        if tag == "canvas":
+            # w/8 cells (64..320 px) and ceil(h/8) rows (32..160 px).
+            if not 8 <= w <= 40:
+                e("canvas w")
+            if not 4 <= h <= 20:
+                e("canvas h")
+            return
+        if w > 160:
+            e("component w")
+        if h > 40:
+            e("component h")
+        if tag == "box":                # 3.3: w,h required, >= 2x1
+            if w < 2:
+                e("box w")
+            if h < 1:
+                e("box h")
+        elif tag == "spacer":           # 3.3: w required
+            if w < 1:
+                e("spacer w")
+
+    def _check_comp_props(self, e):
+        """3.3's required properties and their bounds - checked by no
+        reader in this tree before now.  Each is something the runtime
+        divides by, sizes a claim from, or dereferences."""
+        for c in self.comps.values():
+            t = c.tag
+            if t == "grid":
+                if WK["cols"] not in c.props:
+                    e("grid cols")
+                if WK["rows"] not in c.props:
+                    e("grid rows")
+                cols = c.props[WK["cols"]][1]
+                rows = c.props[WK["rows"]][1]
+                if not 1 <= cols <= 26:
+                    e("grid cols")
+                if not 1 <= rows <= 256:
+                    e("grid rows")
+                # 5.6: the cell store plus its pool must fit a 26KB claim
+                # - and the header's grid KB was sized from these numbers.
+                if rows * cols > 6140:
+                    e("grid size")
+            elif t == "radio":
+                if WK["group"] not in c.props:
+                    e("radio group")
+            elif t == "meter":
+                if WK["max"] in c.props \
+                        and not 1 <= c.props[WK["max"]][1] <= 32000:
+                    e("meter max")
+            elif t == "list" and WK["ITEMS"] in c.props:
+                self._items_blob(c.props[WK["ITEMS"]][1], e)
+
     def _parse_code(self, e):
         b, _ = self.sections[SEC_CODE]
+        if len(b) < 2:
+            e("function table")
         nf, ng = b[0], b[1]
         if nf > 128 or ng > 128:
             e("function table")
         self.nglobals = ng
         self.functions = []
+        body_at = 2 + 4 * nf
+        if body_at > len(b):
+            e("function table")
+        if nf == 0:
+            # 2.8: a scriptless bundle's body is exactly one HALT byte.
+            if b[body_at:] != bytes([OP["HALT"]]):
+                e("function table")
+        prev = body_at
         for k in range(nf):
             ofs, nargs, nloc = struct.unpack_from("<HBB", b, 2 + 4 * k)
-            if ofs > len(b) or nargs > 8 or nloc > 16 or nloc < nargs:
+            # 2.8: functions are packed back to back from 2+4F, each a
+            # contiguous run - so every offset bounds the previous body.
+            bad = (ofs != prev) if k == 0 else (ofs <= prev)
+            if bad:
                 e("function table")
+            if ofs >= len(b) or nargs > 8 or nloc > 16 or nloc < nargs:
+                e("function table")
+            prev = ofs
             self.functions.append((ofs, nargs, nloc))
         self.code = b
 
@@ -2795,10 +3046,19 @@ class Bundle:
         self.formulas, self.cells = [], []
         if SEC_FXCODE in self.sections:
             b, nf = self.sections[SEC_FXCODE]
-            if struct.unpack_from("<H", b, 0)[0] != nf:
+            if len(b) < 2 or struct.unpack_from("<H", b, 0)[0] != nf:
                 e("formula count")
+            if 2 + 2 * nf > len(b):
+                e("formula count")
+            prev = 2 + 2 * nf
             for k in range(nf):
                 ofs = struct.unpack_from("<H", b, 2 + 2 * k)[0]
+                bad = (ofs != prev) if k == 0 else (ofs <= prev)
+                if bad:
+                    e("formula table")
+                if ofs >= len(b):
+                    e("formula table")
+                prev = ofs
                 self.formulas.append(b[ofs:])
         if SEC_CELLS in self.sections:
             b, nc = self.sections[SEC_CELLS]
@@ -2808,11 +3068,20 @@ class Bundle:
                 r, c, kind, z = b[8 * k:8 * k + 4]
                 if z or kind not in (1, 2, 3):
                     e("cell record")
+                if c > 25:
+                    e("cell record")
                 if kind == 1:
                     payload = struct.unpack_from("<i", b, 8 * k + 4)[0]
                 else:
                     payload = struct.unpack_from("<I", b, 8 * k + 4)[0] \
                         & 0xFFFF
+                    if kind == 2 and not self._atom_ok(payload):
+                        e("cell record")
+                    # 2.9/2.10: CELLS reference formulas by INDEX into
+                    # the FXCODE table - past its end is a wild read at
+                    # the first recalc, which is at open.
+                    if kind == 3 and payload >= len(self.formulas):
+                        e("cell record")
                 self.cells.append((r, c, kind, payload))
 
     def _parse_sprites(self, e):
@@ -2820,7 +3089,9 @@ class Bundle:
         if SEC_SPRITES not in self.sections:
             return
         b, ns = self.sections[SEC_SPRITES]
-        if b[0] != ns or b[1]:
+        if len(b) < 2 or b[0] != ns or b[1] or not 1 <= ns <= 16:
+            e("sprite count")
+        if 2 + 8 * ns > len(b):
             e("sprite count")
         for k in range(ns):
             wb, h, nf, z1 = b[2 + 8 * k:2 + 8 * k + 4]
@@ -2828,7 +3099,11 @@ class Bundle:
             if z1 or not 1 <= wb <= 8 or not 1 <= h <= 64 \
                     or not 1 <= nf <= 8:
                 e("sprite descriptor")
+            if struct.unpack_from("<H", b, 2 + 8 * k + 6)[0]:
+                e("sprite descriptor")
             fsz = wb * h
+            if dofs + nf * 2 * fsz > len(b):
+                e("sprite data")
             images, masks = [], []
             for f in range(nf):
                 base = dofs + f * 2 * fsz
@@ -3835,8 +4110,10 @@ def flow_walk(rt, adapter, card=None):
         w = c.w if c.w > 0 else natural_w(rt, c, cw)
         w = min(w, cw)
         if (c.cflags & CF_BREAK) or (x > 0 and x + w > cw):
-            rows.append(cur)
-            cur, x = [], 0
+            if cur:                     # closing an EMPTY row is a no-op
+                rows.append(cur)        # (WEAVE-SPEC 7.2): a CF_BREAK on a
+                cur = []                # card's first component is already
+            x = 0                       # at the start of a row
         cur.append((c, x, w))
         x += w + 1                      # one gutter cell
     if cur:
@@ -3952,6 +4229,20 @@ def render(rt, adapter, card=None, out=print):
 
 
 # --- the cost model (WEAVE-SPEC 14) ------------------------------------------
+def first_paint_us(adapter, comps=None):
+    """What OPENING a card costs, which WEAVE-SPEC 14 priced nowhere: every
+    other row of that table is an INTERACTION, and paint() counts only
+    mutations, so the one spend wave 2's gate actually measures had no
+    number.  One gfx call per painted component plus its cells:
+    sum(CALL_US + cells x cell_us).  With no component list, the worst
+    case - a fully lettered card, one component per content row, every
+    cell of the content area a glyph."""
+    A = ADAPTERS[adapter]
+    if comps is None:
+        comps = [A["cw"]] * A["ch"]
+    return sum(CALL_US + cells * A["cell_us"] for cells in comps)
+
+
 def costs_table(adapter="cga"):
     """WEAVE-SPEC 14's rows, computed from the measured constants. The
     appendix is regenerated FROM this function - the model owns the
@@ -3987,6 +4278,15 @@ def costs_table(adapter="cga"):
          "~%.0f-%.0f ms" % (ms(2 * CALL_US) + 0.5, ms(4 * CALL_US) + 2)),
         ("card", "switch (full-card repaint, text-heavy CGA card)",
          "~1/row", "~0.3-1.2 s"),
+    ]
+    # The first paint, worst case, per adapter - the row wave 2's gate is.
+    for ad in ("cga", "herc", "vga"):
+        A = ADAPTERS[ad]
+        rows.append(("card", "first paint, fully lettered %s (%d rows x "
+                     "%d cells)" % (A["name"], A["ch"], A["cw"]),
+                     "%d" % A["ch"],
+                     "~%.2f s" % (first_paint_us(ad) / 1e6)))
+    rows += [
         ("alert", "raise + dismiss", "~8",
          "~%.0f-%.0f ms" % (ms(8 * CALL_US) + 24, ms(8 * CALL_US) + 34)),
     ]
@@ -4158,6 +4458,15 @@ def cmd_render(path, adapters, card=None):
     else:
         res = pack_project(path)
         rt = Runtime(Bundle(res.data, "x.WAB"), idmap=res.app.idmap)
+    # Card indices are 1-based (WEAVE-SPEC 2.5).  Python's are not: --card 0
+    # rendered the LAST card and --card 9 traced back, so both refuse here
+    # with the range, the way every other out-of-range answer does.
+    if card is not None and not 1 <= card <= len(rt.b.cards):
+        raise SystemExit("--card %d: %s has %d card%s, numbered 1..%d "
+                         "(WEAVE-SPEC 2.5)"
+                         % (card, rt.b.app_name, len(rt.b.cards),
+                            "" if len(rt.b.cards) == 1 else "s",
+                            len(rt.b.cards)))
     for ad in adapters:
         render(rt, ad, card)
         print()
@@ -4485,6 +4794,23 @@ def selfcheck_demos(ck, tmp):
         ck.ok(total >= max(p.y + p.h for p in placed), "%s: total rows "
               "cover the walk" % ad)
 
+    # CF_BREAK on a card's FIRST component, and two in a row: closing an
+    # empty row is a no-op (WEAVE-SPEC 7.2). A row with no component in it
+    # has no height, and the walk once raised on max() of an empty list.
+    brk = os.path.join(tmp, "brk.wml")
+    with open(brk, "w") as f:
+        f.write('<app name="Brk"><card id="main">'
+                '<label br="1">A</label><label br="1">B</label>'
+                '<label>C</label></card></app>\n')
+    resb = pack_project(brk)
+    rtb = Runtime(Bundle(resb.data, "BRK.WAB"), idmap=resb.app.idmap)
+    pl, tot = flow_walk(rtb, "cga")
+    ck.ok(tot == 2, "br: two rows, not three - the leading break emits no "
+          "empty row (got %d)" % tot)
+    ck.ok([(p.x, p.y) for p in pl] == [(0, 0), (0, 1), (2, 1)],
+          "br: A at 0,0; B at 0,1; C at 2,1 (got %s)"
+          % [(p.x, p.y) for p in pl])
+
     # sheet: SUM/AVG/IF over the budget, the WJS truncation seam
     res = pack_project(os.path.join(dd, "sheet.wml"))
     rt = Runtime(Bundle(res.data, "SHEET.WAB"), idmap=res.app.idmap)
@@ -4591,7 +4917,7 @@ def selfcheck_vm(ck, tmp):
         d = bytearray(good)
         mut(d)
         ck.raises(what, BundleError, lambda: Bundle(bytes(d), "X.WAB"),
-                  contains="is not a Weave bundle (: %s)." % field)
+                  contains="is not a Weave bundle (%s)." % field)
     broken(lambda d: d.__setitem__(0, 0x57 + 1), "magic", "bad magic")
     broken(lambda d: d.__setitem__(4, 2), "version", "version != 1")
     broken(lambda d: d.__setitem__(6, d[6] ^ 1), "total size",
@@ -4610,6 +4936,21 @@ def selfcheck_vm(ck, tmp):
     band79 = BAND_CALL_US + 79 * BAND_CELL_US
     ck.ok(abs(band79 - 14527) < 1, "79-cell band row = 14.5 ms (Set 68)")
 
+    # The first paint (WEAVE-SPEC 14's added row): every other row of that
+    # table is an interaction, and paint() counts only mutations, so
+    # nothing priced opening a card - which is exactly wave 2's gate.
+    A = ADAPTERS["cga"]
+    ck.ok(abs(first_paint_us("cga")
+              - A["ch"] * (CALL_US + A["cw"] * A["cell_us"])) < 1,
+          "card first paint: one call plus its cells, per painted "
+          "component, worst case a fully lettered card")
+    ck.ok(first_paint_us("cga", [20, 20])
+          == 2 * CALL_US + 40 * A["cell_us"],
+          "first paint sums over the components it is given")
+    ck.ok(any(c == "card" and "first paint" in i
+              for c, i, _n, _v in costs_table("cga")),
+          "the cost table carries a card first-paint row")
+
     # the generators
     tab = emit_optab()
     ck.ok(tab.count("\n    dw ") == 38, "--emit-optab emits 38 entries")
@@ -4619,10 +4960,266 @@ def selfcheck_vm(ck, tmp):
           "--emit-foldtab: 128 entries from htmsim's one definition")
 
 
+# --- the hostile corpus (WEAVE-SPEC 2.1, 10.4) -------------------------------
+# Every byte read off a disk is hostile.  These build a real packed bundle,
+# break exactly one thing in it, and assert the reader REFUSES with the field
+# named - never a traceback.  Each row is a defect the model once accepted or
+# crashed on; on the 8086 each is a wild read, a bad divide or a claim sized
+# from a lie, so they stay here as a regression suite rather than a one-off.
+def _wab_take(data):
+    """A packed bundle taken apart: [[type, bytearray body, extra], ...]."""
+    out = []
+    for k in range(data[12]):
+        typ, _z, ofs, ln, extra = struct.unpack_from("<BBHHH", data,
+                                                     32 + 8 * k)
+        out.append([typ, bytearray(data[ofs:ofs + ln]), extra])
+    return out
+
+
+def _wab_make(data, secs):
+    """...and put back together, with the section table, the 16-byte
+    padding and the total-size word recomputed (WEAVE-SPEC 2.3).  A corpus
+    bundle must be malformed in exactly ONE place, or the reader refuses
+    the scaffolding instead of the defect under test."""
+    out = bytearray(data[:32])
+    out[12] = len(secs)
+    out += bytearray(8 * len(secs))
+    for i, (typ, body, extra) in enumerate(secs):
+        while len(out) % 16:
+            out.append(0)
+        struct.pack_into("<BBHHH", out, 32 + 8 * i, typ, 0, len(out),
+                         len(body), extra)
+        out += body
+    struct.pack_into("<H", out, 6, len(out))
+    return bytes(out)
+
+
+def _sec(secs, typ):
+    for row in secs:
+        if row[0] == typ:
+            return row
+    raise KeyError(typ)
+
+
+def _find_prop(props, name, start=0, stop=None):
+    """The offset of the first 4-byte property record with this name atom.
+    Blocks run back to back from PROPS+0 and the blobs follow all of them
+    (WEAVE-SPEC 2.14 rule 5), so a 4-byte stride is the record grid."""
+    for i in range(start, (len(props) if stop is None else stop) - 3, 4):
+        if props[i] == name:
+            return i
+    raise KeyError(name)
+
+
+def _find_rec(ui, ctype):
+    for i in range(0, len(ui), 10):
+        if ui[i] == REC_COMP and ui[i + 2] == ctype:
+            return i
+    raise KeyError(ctype)
+
+
+RADIO_WML = ('<app name="Radio"><card id="m">'
+             '<radio id="r" group="pick">One</radio>'
+             '<radio id="r2" group="pick">Two</radio></card></app>')
+LIST_WML = ('<app name="Lister"><card id="m"><list id="l">'
+            '<item>Alpha</item><item>Beta</item></list></card></app>')
+BOX_WML = '<app name="Boxy"><card id="m"><box w="4" h="2"/></card></app>'
+
+
+def selfcheck_hostile(ck, tmp):
+    dd = demo_dir()
+    form = pack_project(os.path.join(dd, "form.wml")).data
+    sheet = pack_project(os.path.join(dd, "sheet.wml")).data
+    pong = pack_project(os.path.join(dd, "pong.wml")).data
+    radio = pack_project(_proj(tmp, RADIO_WML, stem="radio")).data
+    lister = pack_project(_proj(tmp, LIST_WML, stem="lister")).data
+    boxy = pack_project(_proj(tmp, BOX_WML, stem="boxy")).data
+
+    def hostile(base, mut, field, what):
+        secs = _wab_take(base)
+        mut(secs)
+        d = _wab_make(base, secs)
+        ck.raises(what, BundleError, lambda: Bundle(d, "X.WAB"),
+                  contains="is not a Weave bundle (%s)." % field)
+
+    def header(base, mut, field, what):
+        d = bytearray(base)
+        mut(d)
+        ck.raises(what, BundleError, lambda: Bundle(bytes(d), "X.WAB"),
+                  contains="is not a Weave bundle (%s)." % field)
+
+    # UB-1..UB-4: ATOMS.  The pool is a table of offsets into itself -
+    # every one of these was an IndexError or a UnicodeDecodeError.
+    def ub1(secs):
+        a = _sec(secs, SEC_ATOMS)[1]
+        struct.pack_into("<H", a, 2, len(a) + 8)        # atom 64 past the end
+    hostile(form, ub1, "atom pool", "UB-1 atom offset past the section")
+
+    def ub2(secs):
+        a = _sec(secs, SEC_ATOMS)[1]
+        n = struct.unpack_from("<H", a, 0)[0]
+        a[struct.unpack_from("<H", a, 2 + 2 * (n - 1))[0]] = 250
+    hostile(form, ub2, "atom pool", "UB-2 atom length overruns the section")
+
+    def ub3(secs):
+        a = _sec(secs, SEC_ATOMS)[1]
+        a[struct.unpack_from("<H", a, 2)[0] + 1] = 0xE9
+    hostile(form, ub3, "atom pool", "UB-3 non-ASCII byte in an atom body")
+
+    def ub4(secs):
+        struct.pack_into("<H", _sec(secs, SEC_ATOMS)[1], 0, 150)
+    hostile(form, ub4, "atom pool", "UB-4 atom count larger than the pool")
+
+    # UB-5: a sprite record with no canvas before it - the model's own
+    # canvas_cid was still None and the append raised KeyError.
+    def ub5(secs):
+        ui = _sec(secs, SEC_UISTREAM)[1]
+        ui[12], ui[13], ui[14] = CTYPE["sprite"], 0, 0
+    hostile(form, ub5, "sprite record", "UB-5 sprite with no canvas")
+
+    # UB-6/UB-8/UB-16/UB-17: PROPS values that address nothing.
+    def ub6(secs):
+        p, app_at = _sec(secs, SEC_PROPS)[1], _sec(secs, SEC_PROPS)[2]
+        for i in range(0, app_at, 4):
+            if p[i + 1] == PK_SPRITE:
+                struct.pack_into("<H", p, i + 2, 99)
+                return
+        raise KeyError("PK_SPRITE")
+    hostile(pong, ub6, "sprite index", "UB-6 PK_SPRITE past the SPRITES table")
+
+    def ub8(secs):
+        p = _sec(secs, SEC_PROPS)[1]
+        struct.pack_into("<H", p, _find_prop(p, WK["ITEMS"]) + 2, len(p) + 4)
+    hostile(lister, ub8, "prop blob", "UB-8 ITEMS blob offset past PROPS")
+
+    def ub16(secs):
+        p, app_at = _sec(secs, SEC_PROPS)[1], _sec(secs, SEC_PROPS)[2]
+        struct.pack_into("<H", p,
+                         _find_prop(p, WK["MENUS"], app_at) + 2, len(p) + 4)
+    hostile(form, ub16, "prop blob", "UB-16 MENUS blob offset past PROPS")
+
+    def ub17(secs):
+        p = _sec(secs, SEC_PROPS)[1]
+        p[struct.unpack_from("<H", p,
+                             _find_prop(p, WK["ITEMS"]) + 2)[0]] = 60
+    hostile(lister, ub17, "list items", "UB-17 ITEMS count past the blob")
+
+    # UB-7/UB-13..UB-15/UB-20: WEAVE-SPEC 3.3's required properties.
+    def drop_prop(name, start=0):
+        def mut(secs):
+            p = _sec(secs, SEC_PROPS)[1]
+            i = _find_prop(p, name, start)
+            p[i:i + 4] = bytes(4)      # the block now terminates here
+        return mut
+    hostile(radio, drop_prop(WK["group"]), "radio group",
+            "UB-7 radio with no group")
+    hostile(sheet, drop_prop(WK["rows"]), "grid cols",
+            "UB-13 grid with no cols/rows")
+
+    def set_prop(name, val):
+        def mut(secs):
+            p = _sec(secs, SEC_PROPS)[1]
+            struct.pack_into("<H", p, _find_prop(p, name) + 2, val)
+        return mut
+    hostile(sheet, set_prop(WK["rows"], 60000), "grid rows",
+            "UB-14 grid rows = 60000")
+    hostile(sheet, set_prop(WK["cols"], 0), "grid cols",
+            "UB-15 grid cols = 0")
+    hostile(form, set_prop(WK["max"], 0), "meter max",
+            "UB-20 meter max = 0")
+
+    # UB-9/UB-10: a section emptied while its count word still lies.
+    def empty(typ):
+        def mut(secs):
+            _sec(secs, typ)[1] = bytearray()
+        return mut
+    hostile(pong, empty(SEC_SPRITES), "sprite count",
+            "UB-9 empty SPRITES, count 2")
+    hostile(sheet, empty(SEC_FXCODE), "formula count",
+            "UB-10 empty FXCODE, count 4")
+
+    # UB-11: a CELLS record naming a formula that is not in FXCODE.
+    def ub11(secs):
+        c = _sec(secs, SEC_CELLS)[1]
+        for i in range(0, len(c), 8):
+            if c[i + 2] == 3:
+                struct.pack_into("<H", c, i + 4, 99)
+                return
+        raise KeyError("formula cell")
+    hostile(sheet, ub11, "cell record", "UB-11 cell formula index past FXCODE")
+
+    # UB-18/UB-19: a geometry byte WEAVE-SPEC 2.5/3.3 says is never 0 -
+    # a divide, or a negative repeat count, on the machine.
+    def zero_geom(ctype, off):
+        def mut(secs):
+            ui = _sec(secs, SEC_UISTREAM)[1]
+            ui[_find_rec(ui, ctype) + off] = 0
+        return mut
+    hostile(pong, zero_geom(CTYPE["canvas"], 3), "canvas w",
+            "UB-18 canvas w = 0")
+    hostile(pong, zero_geom(CTYPE["canvas"], 4), "canvas h",
+            "UB-18 canvas h = 0")
+    hostile(boxy, zero_geom(CTYPE["box"], 3), "box w", "UB-19 box w = 0")
+    hostile(boxy, zero_geom(CTYPE["box"], 4), "box h", "UB-19 box h = 0")
+
+    # UB-12: the CLI's own 1-based/0-based seam (WEAVE-SPEC 2.5).
+    wab = os.path.join(tmp, "CARDS.WAB")
+    open(wab, "wb").write(form)
+    for n in (0, 9):
+        ck.raises("UB-12 --card %d refuses with the range" % n, SystemExit,
+                  cmd_render, wab, ["cga"], n, contains="numbered 1..")
+
+    # The header's three claim-KB bytes ARE 10.1's memory refusal.
+    header(form, lambda d: d.__setitem__(10, 15), "vm KB", "vm KB below 16")
+    header(form, lambda d: d.__setitem__(11, 4), "grid KB",
+           "grid KB outside 0 or 8..26")
+    header(pong, lambda d: d.__setitem__(14, 9), "canvas KB",
+           "canvas KB outside 0 or 2..8")
+    header(form, lambda d: d.__setitem__(12, 4), "section count",
+           "fewer than the four mandatory sections plus ICON")
+    header(form, lambda d: d.__setitem__(13, 0), "entry card",
+           "entry card 0")
+    header(form, lambda d: d.__setitem__(16, 0), "app name",
+           "an empty app name")
+
+    # 2.3: sections abut at align16, padding is 0x00, the file ends at the
+    # last section's UNPADDED end.
+    header(form, lambda d: d.__setitem__(203, 1), "section padding",
+           "a non-zero inter-section padding byte")
+    padded = bytearray(form) + bytes(16)
+    struct.pack_into("<H", padded, 6, len(padded))   # a consistent lie
+    ck.raises("tail padding after the last section", BundleError,
+              lambda: Bundle(bytes(padded), "X.WAB"),
+              contains="(total size)")
+
+    def shift(secs):
+        _sec(secs, SEC_ICON)[1] = bytearray(63)
+    hostile(form, shift, "ICON", "ICON that is not 64 bytes")
+
+    # 2.5/2.14 rule 2: comp_ids are document order.
+    def outoforder(secs):
+        ui = _sec(secs, SEC_UISTREAM)[1]
+        ui[11] = 7
+    hostile(form, outoforder, "comp_id", "a comp_id out of document order")
+
+    # 2.4/2.2.1: the flag/section couplings, both directions.
+    header(form, lambda d: d.__setitem__(8, d[8] | WABF_SOURCE), "flags",
+           "WABF_SOURCE with no SOURCE section")
+    header(sheet, lambda d: d.__setitem__(8, d[8] & ~WABF_GRID), "flags",
+           "FXCODE and CELLS with WABF_GRID clear")
+
+    # 2.8: the function table bounds its own bodies.
+    def badfn(secs):
+        c = _sec(secs, SEC_CODE)[1]
+        struct.pack_into("<H", c, 2, len(c) + 4)
+    hostile(form, badfn, "function table", "a function offset past CODE")
+
+
 def run_selfcheck(verbose=False):
     ck, tmp = selfcheck(verbose)
     sizes = selfcheck_demos(ck, tmp)
     selfcheck_vm(ck, tmp)
+    selfcheck_hostile(ck, tmp)
     if ck.fails:
         print("selfcheck: %d of %d checks FAILED" % (len(ck.fails),
                                                      ck.count))


### PR DESCRIPTION
Stacked on #118. **Base is `weave-wave1`, not `main`** — this fixes wave 1's own artifacts, and wave 2 stacks on top of it in turn.

Wave 1 shipped the executable spec: `docs/WEAVE-SPEC.md`, `tools/weavesim.py`, `tests/unit/t_wab.py`. Wave 2's 8086 runtime is written **from** that document and diffed **against** that model, so a defect in either propagates straight into assembly. This is the pass that finds them before any 8086 code exists — the `tools/htmsim.py` precedent, which found three real bugs before the browser had a line of it. Twenty-one here.

## The one that matters most: Hercules is 89×35, not 89×36

`weavesim` claimed 89×36. Derived from the platform's own constants — §11.95's standard rect, `[vid_dock_y0] = [vid_h] − DOCK_H`, and `wm_geom`'s content box — the four height subtractions collapse to a constant 64:

```
CW = floor(([vid_w] - 1)  / 8)
CH = floor(([vid_h] - 64) / 8)
```

| adapter | screen | content px | CW × CH |
|---|---|---|---|
| CGA | 640×200 | 639 × 136 | 79 × 17 |
| Hercules | 720×348 | 719 × 284 | **89 × 35** |
| VGA 12h | 640×480 | 639 × 416 | 79 × 52 |

**CGA and VGA come out exact**, which is what validates the derivation rather than making it a rival guess. Hercules has 284 content pixels — 35 rows with 4 spare; 36 needs 288, and no reading of the chrome produces it.

The 36 came from `tools/htmsim.py`: the **browser's** viewport. The browser is not maximized on Hercules, it takes 90% of the band — so the family had inherited a different window's geometry as if it were the platform's. htmsim is right for its own window and is untouched here.

The three demos are unaffected either way, which is why arithmetic found this and no test could. It is not harmless: `<grid>`'s natural height is `CH − y`, so a full-height grid got `h=35` with a bottom row of 36 — one row **below** the content box, on the flagship component (§6.9), whose band composer emits one `gfx_blit1` per row and repaints per row on every edit.

§7.1.1 is new and shows the subtraction, so the numbers are checkable instead of asserted.

## The rest of the contract

- **§7.1.2, new and binding**: the content origin rounds **up** to a multiple of 8. `font_run`'s fast path needs `x & 7 == 0`; `os88line`'s pen sat at 6 mod 8 at every window position on every adapter and never took it — 246 transient pixels per keystroke, measured on a 5150/CGA. Every Weave component would have inherited that.
- **§7.2 had two places an implementer had to guess.** Closing an *empty* row is now a no-op — a leading `br="1"` made `weavesim` raise on `max()` of an empty list. And the slack formula says **n−1** gutters, not n: guess wrong and every centred and right-aligned row moves a cell.
- **§7.3** carries the `text` wrap algorithm itself instead of pointing at another tool's source, and its `label`/`list` natural widths now match the model.
- **§2.2**: section count is **5–9**, not 1–9 — four sections are mandatory and ICON is always present.
- **§10.4** loses a stray colon that rendered as `(: magic)`, and gains the two refusal classes §3.3 requires and nobody checked.

## The model: 20 hostile bundles

§2.1 says every byte off a disk is hostile and §10.4 says a malformed bundle is refused with a named field. Twenty did neither — twelve raised a Python exception (the whole ATOMS reader was unbounded; a `radio` with no `group` raised `KeyError: 19`), eight were accepted silently. A `grid` with `rows=60000` was taken **after** the header's `grid_kb` had already answered §10.1's memory refusal, so the ask was computed from a lie.

All twenty now refuse by name. The parse runs in dependency order so an index is checked against the table it indexes, and **MENUS is walked at load** rather than lazily — the 8086 reads it at load to call `MENU_SET`, so a bad offset was a wild read on the machine and clean on the model: a differential blind to its own subject. The corpus is in `--selfcheck`, not a one-off: **154 → 195 checks**.

## The second reader

§12.2 makes `t_wab` an independent reader sharing no code with any packer, so its checks are written from the document. Four of six cases reported as uncaught were already caught — but **no §3.3 property range or pairing was checked at all** except grid's, though §2.6 makes that the reader's duty in as many words. §3.3's table is now transcribed per ctype. **1900 → 2055 checks**, each seen failing against a hand-mutated bundle before it was kept.

## Also here

- `SPEC.md` §39.8 named `OSAPI_VIDEO` as slot `0x00B4` with "the table is 44 slots". It is `0x0158` and the table publishes 143 — both halves stale, in the one slot §7.1's "the truth is the live screen" depends on.
- **`tools/os88marty.py` — every MartyPC row in the repo died on macOS.** `_marty_pids()` listed `/proc`, which Darwin has not, so every row raised `FileNotFoundError` inside `launch()` before starting anything — reading as a broken emulator rather than a Linux-only process lister. macOS is a supported dev platform (`tools/setup-macos.sh`). Both platforms now share one `_keep_pid()` predicate and both still kill **by PID, not by pattern** — the discipline the function's own banner insists on. Proved end to end: launched `martypc_headless` on a real 360KB floppy, got the live PID, killed it, got none, and confirmed a process merely naming the binary is never matched.
- **`apps/frotz/zio.inc`** said `OSAPI_FILE_FIND` "walks the mount snapshot, which is in RAM, so the walk costs no motor time". There is no such snapshot — names resolve through raw directory sectors and `dsk_find_x` "costs a directory re-read per entry". §61.4's rule stands, but it is a cheaper read, not a free one. Corrected now because Weave copies this idiom line by line for §10.1 and would have inherited the reasoning with the code. `frotz.o88` is byte-identical: comment only.

## Verification

`make` clean · `checkdocs` 0 problems · fast tier 15/15 · `--selfcheck` 195 · `t_wab` 2055 · demo bundles byte-identical (FORM 736, PONG 736, SHEET 848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJYqX3kxTA4YRsrEb9cpag