### PR TITLE
Weave: vm/xt-weave and vm/386-weave, wave 7's two machines landed early

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ vm/386-runcpm/nvr/
 vm/386-c64/nvr/
 vm/xt-c64/nvr/
 vm/286-c64/nvr/
+vm/xt-weave/nvr/
+vm/386-weave/nvr/
 
 # Page snapshots the Playwright MCP server drops in the working directory
 .playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ exactly like the feature being broken.
 `286-sound`,
 `386sx`, `386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`, `xt-word`,
 `386-word`, `386-c-word`, `xt-runcpm`, `286-runcpm`, `386-runcpm`, `xt-c64`,
-`286-c64`, `386-c64`;
+`286-c64`, `386-c64`, `xt-weave`, `386-weave`;
 plus `marty` (MartyPC). `xt-multimon` is the
 **two-card** XT — a CGA and a Hercules, a monitor window each — and the only
 86Box machine that can show §39.12–§39.19's extended desktop; it boots Single,
@@ -214,8 +214,12 @@ machines (§68.5), `386-c-word` is the C word processor's (§73.12) and
 `xt-runcpm`/`286-runcpm`/`386-runcpm` the CP/M emulator's, one per floppy
 geometry because the three disks carry different software and the machines
 run at different speeds — which for a CP/M game IS the play speed (§74.5,
-§74.6) — the eight that put a dedicated
-floppy in B: instead of the apps disk. `make zdisk` builds the story disk
+§74.6) — `xt-c64`/`286-c64`/`386-c64` the C64 emulator's (C64-SPEC §14.3,
+one per geometry for that same reason), and `xt-weave`/`386-weave` the Weave
+runtime's (WEAVE-SPEC §13.1) — the thirteen that put a dedicated
+floppy in B: instead of the apps disk. `xt-weave` takes the **360KB** Weave
+disk rather than a 3.5" one — it fits in 33 of 354 clusters — so it is where
+that geometry of it is booted at all. `make zdisk` builds the story disk
 (`tools/getstories.py` fetches the stories, which are never committed), `make
 worddisk` the Word disk, `make cworddisk` the CWORD disk — which carries
 `WELCOME.RTF`, the same welcome document the Word disk carries as a `.DOC`,

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,24 @@ VM286C64 := $(CURDIR)/vm/286-c64
 VMXTC64 := $(CURDIR)/vm/xt-c64
 VM286C64 := $(CURDIR)/vm/286-c64
 
+# The WEAVE machines (WEAVE-SPEC §13.1, wave 7's row landed early
+# because a runtime nobody can boot on a period machine is a runtime nobody
+# has looked at): the Word pairing again - an XT with the Weave disk in B:, a
+# 386 with the 1.44MB one - and no sound card on either: WEAVE-SPEC §8.4's
+# floor voice is `tone` on the SPEAKER, which every machine here has, and
+# `playSound` has no clip carriage in v1, so a card would test nothing yet.
+#
+# THE XT IS 640KB AND THAT IS THE POINT OF PICKING IT. WEAVE-SPEC §1.4's
+# ladder: a 256KB XT holds EXACTLY ONE Weave app and the second launch
+# refuses before any I/O, a 640KB machine holds four or five. This machine is
+# for running the family; the 256KB refusal is the `xt` target's row in
+# WEAVE-SPEC §13.1 wave 7, and it needs WEAVE on a disk that machine sees,
+# which is that wave's ALLAPPSFILES work and not this. `mem_size = 256` in
+# vm/xt-weave/86box.cfg is the one line that swaps the question if you want
+# to look at the refusal by hand before then.
+VMXTWEAVE := $(CURDIR)/vm/xt-weave
+VM386WEAVE := $(CURDIR)/vm/386-weave
+
 # VIDEO=cga|herc|vga forces the adapter instead of probing for it (SPEC.md
 # 39.1). The shipped images are always built without it, so they auto-detect;
 # this exists because QEMU emulates no CGA and no Hercules card, and forcing
@@ -1231,7 +1249,7 @@ KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc boot/boot2.asm
         xt-runcpm 286-runcpm \
         allapps usb iso live burn rcbandbench \
         c64 c64disk c64rom c64bandbench c64cputest c64memtest 386-c64 xt-c64 286-c64 \
-        weave weavedisk \
+        weave weavedisk xt-weave 386-weave \
         checkdocs test-fast test-full test-soak clean clean-cc clean-marty distclean
 
 # `all` deliberately does NOT build anything under tests/ (see the bench block
@@ -3684,6 +3702,51 @@ $(BUILD)/weave720.img: $(WEAVEDISK) tools/os88disk.py
 $(BUILD)/weave360.img: $(WEAVEDISK) tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 360 $(WEAVEDISK)
 	@python3 tools/os88disk.py --verify $@
+
+# The two WEAVE machines (WEAVE-SPEC §13.1), with the Weave disk in B: instead
+# of the apps disk - Frotz's precedent and Word's, for their reason: an app
+# whose documents live on its own disk is best launched from that disk, and a
+# .WAB IS the document here (WEAVE-SPEC §1.5 launches the runtime by
+# double-clicking one).
+#
+#   xt-weave   An IBM XT at 4.77MHz with the FULL 640KB, booting the 360KB
+#              system floppy with build/weave360.img in B: - TWO 5.25" drives,
+#              no fdd_02_type override, which is where this differs from
+#              xt-word: the Word disk did not fit 360KB and this one uses 33
+#              of 354 clusters. So this is the only target that boots
+#              build/weave360.img - QEMU is driven with the 720KB and 1.44MB
+#              images (CLAUDE.md's three geometries) - and the 360KB FAT is
+#              the one a real XT reads.
+#
+#              640KB rather than 256KB is deliberate and is argued at
+#              $(VMXTWEAVE)'s definition above.
+#
+#   386-weave  The comfortable target the same code also has to be right on:
+#              a 386DX/25 with TWO 1.44MB drives, B: = build/weave.img.
+#              AT-class, so the first launch stops at the BIOS setup wanting
+#              a CMOS - pick EXIT FOR BOOT once and 86Box writes
+#              vm/386-weave/nvr/ for every later boot.
+#
+# Each config is a copy of the corresponding Word machine - one that has been
+# BOOTED - with fdd_02_fn and the uuid changed and nothing else, the rule
+# vm/386-c-word records: 86Box does not reject an unrecognised key, it
+# substitutes a default and rewrites the config on exit, so a hand-written
+# profile is a machine whose clock nobody chose.
+#
+# Both call $(UNPROTECT) for the standing reason: 86Box re-adds wp:// to its
+# floppy paths on exit, which turns every guest write into FERR_WPROT - and
+# from wave 3 that is every saveState (WEAVE-SPEC §8.3), reading as a Weave bug
+# rather than an emulator setting.
+#
+# ON DEMAND, like every C target: `all` does not build build/weave.o88, so
+# these depend on the disk and the disk needs SmallerC (tools/setup-cc.sh).
+xt-weave: $(IMG360) $(BUILD)/weave360.img
+	@$(UNPROTECT) $(VMXTWEAVE)/86box.cfg
+	$(BOX) -P $(VMXTWEAVE) -N
+
+386-weave: $(IMG) $(BUILD)/weave.img
+	@$(UNPROTECT) $(VM386WEAVE)/86box.cfg
+	$(BOX) -P $(VM386WEAVE) -N
 
 # =============================================================================
 # FROTZ and its story floppy (SPEC.md 61) - ON DEMAND: `make zdisk`

--- a/docs/WEAVE-SPEC.md
+++ b/docs/WEAVE-SPEC.md
@@ -2151,6 +2151,17 @@ of which the load-bearing one was §7.1.1's Hercules grid, wrong at 89×36
 because it had been inherited from the browser's viewport rather than
 derived.
 
+**`vm/xt-weave` and `vm/386-weave` came forward out of wave 7** — a 640KB
+IBM XT at 4.77MHz with `build/weave360.img` in B: and a 386DX/25 with
+`build/weave.img` — because a runtime whose whole subject is what fits and
+what refuses on a period machine (§1.4) needs that machine available from
+the wave it becomes bootable, not from the wave that packages it. Nothing
+else in wave 7 moved with them: the `xt` target's 256KB one-app refusal is
+still that wave's row, because it needs WEAVE on a disk the `xt` machine
+sees, which is the ALLAPPSFILES work. Both machines are manual evidence —
+`make xt-weave` launches 86Box and cannot assert that anything booted, so
+no gate in this family rests on either.
+
 The rest, each gated before the next begins:
 
 | wave | ships | the gate |
@@ -2160,7 +2171,7 @@ The rest, each gated before the next begins:
 | 4 | `<grid>`: cell store, `wband.inc` benched against Set 68's numbers (`make weavebandbench`), per-row damage, formula bar, `wfx.inc` + resident formula compiler, sliced recalc | `weavegrid` (recalc vs model + tpdraw identity), `weavegfx` |
 | 5 | `<canvas>`/`<sprite>`: `wspr.inc` mask composition, dirty-band emit, worker loop, AABB, KEY_DOWN input, worker tones, ontick budget enforcement | `weavegame` (wirefps/wireflick); **commission the field run** — 5150 fps and the XT ops/s reading that converts §4.12 to measurement |
 | 6 | Loom: `lm_` editor transplant, project folder + file switcher, LOOM.OVL compilers + packer, Pack, Preview, templates, APPDATA prefs, W_ONCLOSE/ASAVE close guard | `weavepack` byte-identity on all templates and demos, in the OS |
-| 7 | distribution: `make weavedisk` in three geometries with cluster-fit refusal + `--verify`, writable `PROJECTS/` folder, CATALOG.TXT, `BUNDLES=` knob; `vm/xt-weave` + `vm/386-weave`; ALLAPPSFILES rows (one `WEAVE/` folder — package + overlay + bundles share it, SPEC.md §19.10); the 256KB one-app refusal exercised on the `xt` target | the release checklist |
+| 7 | distribution: `make weavedisk` in three geometries with cluster-fit refusal + `--verify`, writable `PROJECTS/` folder, CATALOG.TXT, `BUNDLES=` knob; ALLAPPSFILES rows (one `WEAVE/` folder — package + overlay + bundles share it, SPEC.md §19.10); the 256KB one-app refusal exercised on the `xt` target | the release checklist |
 
 Wave order within a wave follows the size line: `os88pkg.py`'s resident
 count is printed and recorded every wave, 55,000 is the overlay-split

--- a/vm/386-weave/86box.cfg
+++ b/vm/386-weave/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 8680f1ee-fccc-4309-b93a-5be9fd137fae
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = i386dx
+cpu_multi = 1
+cpu_speed = 25000000
+cpu_use_dynarec = 0
+machine = micronics386
+mem_size = 2048
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088.img
+fdd_01_type = 35_2hd
+fdd_02_fn = ../../build/weave.img
+fdd_02_type = 35_2hd
+fdd_host_buffering = 1

--- a/vm/xt-weave/86box.cfg
+++ b/vm/xt-weave/86box.cfg
@@ -1,0 +1,32 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = f132ad9e-87bb-5c35-9db6-420ac3b9dbf1
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 8088
+cpu_multi = 1
+cpu_speed = 4772728
+cpu_use_dynarec = 0
+machine = ibmxt86
+mem_size = 640
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_pc_xt
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-360.img
+fdd_02_fn = ../../build/weave360.img
+fdd_host_buffering = 1


### PR DESCRIPTION
`make xt-weave` and `make 386-weave` — the two 86Box machines WEAVE-SPEC §13.1
had in wave 7's distribution row. Wave 2 made `WEAVE.O88` bootable, so they came
forward: a runtime whose whole subject is what fits and what refuses on a period
machine (WEAVE-SPEC §1.4) needs that machine available from the wave it becomes
bootable, not from the wave that packages it.

| target | machine | A: | B: |
|---|---|---|---|
| `xt-weave` | IBM XT, 8088 @ 4.77 MHz, **640KB**, two 5.25" drives | `os8088-360.img` | `weave360.img` |
| `386-weave` | Micronics 386DX/25, 2MB, two 1.44MB drives | `os8088.img` | `weave.img` |

Nothing else in wave 7 moved with them. The `xt` target's 256KB one-app refusal
is still that wave's row: it needs WEAVE on a disk the `xt` machine sees, which
is the ALLAPPSFILES work.

## The two decisions

**640KB and not 256KB.** WEAVE-SPEC §1.4's ladder: a 256KB XT holds exactly ONE
Weave app and the second launch refuses before any I/O; 640KB holds four or five.
These machines are for running the family. `mem_size = 256` in
`vm/xt-weave/86box.cfg` is the one line that swaps the question for anyone who
wants to look at the refusal by hand before wave 7 makes it a row.

**The 360KB disk in B:,** which is where this differs from `xt-word` — that
machine takes a 720KB disk because the Word disk did not fit 360KB. The Weave
disk uses 33 of 354 clusters, so the XT gets two period 5.25" drives, no
`fdd_02_type` override, and this becomes the only target that boots
`build/weave360.img` — the geometry a real XT reads and QEMU is not driven with.

## The configs

Each is a copy of the corresponding Word machine — one that has **been booted** —
with `fdd_02_fn` and the `uuid` changed and nothing else, the rule
`vm/386-c-word` records: 86Box does not reject an unrecognised key, it
substitutes that key's default and rewrites the config on exit, so a hand-written
profile is a machine whose clock nobody chose. Both targets call `$(UNPROTECT)`
for the standing reason — 86Box re-adds `wp://` to its floppy paths on the way
out, and from wave 3 that turns every `saveState` (WEAVE-SPEC §8.3) into
`FERR_WPROT`, reading as a Weave bug rather than an emulator setting. No sound
card on either: WEAVE-SPEC §8.4's floor voice is `tone` on the speaker, which
every machine here has, and `playSound` has no clip carriage in v1.

On demand like every C target — `all` does not build `build/weave.o88` — so both
depend on the disk and the disk needs SmallerC (`tools/setup-cc.sh`).

## Evidence

These targets are **manual**, as every 86Box target in this tree is: `make
xt-weave` launches the emulator and cannot assert that anything booted, and no
gate rests on either. What is checked is the disk under them, booted headless in
QEMU with `build/weave360.img` in B: — the Locator lists all five files (30K
used, 321K free) with the `.WAB` association icon resolved, and double-clicking
`FORM.WAB` launches WEAVE and draws the Weave Greeter.

`make` green, `checkdocs` clean, fast tier 21/21. `weavesmoke` needs MartyPC and
skips in this environment.

## Docs

`docs/WEAVE-SPEC.md` §13.1 — struck both machines from wave 7's row and recorded
them as landing early, with the reason and with what did *not* move. `CLAUDE.md`'s
machine paragraph gains both targets; its dedicated-floppy count had drifted (the
C64 trio was listed among the machines but left out of the "eight"), so it is now
thirteen with both families named. `.gitignore` gains the two `nvr/` directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCWJZWzk4tC4NWGYmKK9MJ