### PR TITLE
kernel: OSAPI_JSLOT's jump must be STRICT near - main does not assemble

### DIFF
--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -2289,7 +2289,14 @@ dbg_reg_at:                     ; 0060:000E - THE DEBUG REGISTRY (SPEC.md 57)
 %endmacro
 
 %macro OSAPI_JSLOT 1                ; a cell that defers to a longer stub
-    jmp near %1                     ; E9 rel16 = 3 bytes
+    ; STRICT, and the whole slot depends on it. Without it NASM shortens the
+    ; jump to EB rel8 whenever the target is within 127 bytes - which
+    ; api_icon_draw became - and the slot emits 2 + 5 = SEVEN bytes. The
+    ; padding here is a fixed `times 5`, so it cannot absorb the difference:
+    ; every slot after the shortened one slides down a byte and answers at the
+    ; wrong address. That is the whole reason the length assertion below
+    ; exists, and it is what caught this.
+    jmp strict near %1              ; E9 rel16 = 3 bytes, always
     times 5 db 0
 %endmacro
 


### PR DESCRIPTION
## What

`main` does not assemble. One word fixes it.

```
kernel/kernel.asm:3317: error: os8088 API jump table must be exactly 153 8-byte slots
```

## Why

The table has exactly **153 entries** and both slot macros are eight bytes by
construction, so the count is right. The **length** is wrong: 1,223 bytes — one
short, and not even a multiple of eight.

`OSAPI_JSLOT` is `jmp near %1` plus a fixed `times 5 db 0`, and its own comment
says why that adds to eight: *"E9 rel16 = 3 bytes"*. NASM shortens the jump to
`EB rel8` anyway when the target is within 127 bytes, and `near` alone does not
stop it — `strict` does. `api_icon_draw` came within range in #116, so its slot
assembled as **seven** bytes. The listing names it outright:

```
2292 000004B8 EB33            <1>  jmp near %1
2293 000004BA 00<rep 5h>      <1>  times 5 db 0
```

The padding is a fixed count, so it cannot absorb the difference. Every slot
after the shortened one slides down a byte and answers at the wrong address —
`gfx_blitp` at `0x04C0` would have been reached at `0x04BF`. That is exactly
what the length assertion is there to catch, and it caught it.

## Scope

Bisected to **f3a41d1 (#116)**; `4f415e7` — the previous `main` — still builds.
Reproduced at every commit from #116 to `37db5c2`, on a clean checkout with
none of my own work in the tree.

## SPEC

No section moves. This restores the behaviour §20.1's ABI already specifies —
a fixed 8-byte slot at a fixed offset — rather than changing it.

## Verification

```
git checkout 37db5c2 && make build/kernel-full.bin     # fails, as above
git checkout <this branch> && make -j4                 # builds
python3 tools/os88test.py full                         # 25 passed, 0 failed
```

Measured by replacing the assertion with the `times` idiom, which reports the
delta rather than just failing: `TIMES value -1 is negative`, i.e. 1,223 bytes
against 153 x 8 = 1,224.

No screenshots: there is nothing visual here, and before the fix nothing boots
to photograph.
