### PR TITLE
MartyPC debug server: drain large replies on a nonblocking socket

### DIFF
--- a/tools/martypc/debug_server.rs
+++ b/tools/martypc/debug_server.rs
@@ -492,11 +492,41 @@ impl DebugServer {
     }
 
     fn send(&mut self, value: &Value) {
+        // The stream is NONBLOCKING (poll_socket set it so, for the read
+        // side), and `write_all` on a nonblocking socket returns
+        // `WouldBlock` the moment the kernel send buffer fills - it does
+        // not wait for the client to drain. Any reply larger than that
+        // buffer then dies PART-WRITTEN and the client is dropped, which
+        // the caller sees as a truncated JSON line followed by EOF. `fbuf`
+        // on a VGA card is a ~1.8MB line (640x480 rgb24, hex), so it lost
+        // its connection at ~330KB every single time, while CGA's 768KB
+        // usually squeaked through on the drain race - a bug that looks
+        // like a flake on one adapter and is deterministic on another.
+        // So: write in a loop and treat WouldBlock as "let the client
+        // catch up", never as an error. Only a real error, or a peer that
+        // closed (Ok(0)), drops the client.
         if let Some(reader) = self.client.as_mut() {
             let mut out = value.to_string();
             out.push('\n');
-            if reader.get_mut().write_all(out.as_bytes()).is_err() {
-                self.client = None;
+            let stream = reader.get_mut();
+            let bytes = out.as_bytes();
+            let mut off = 0usize;
+            while off < bytes.len() {
+                match stream.write(&bytes[off..]) {
+                    Ok(0) => {
+                        self.client = None;
+                        return;
+                    }
+                    Ok(n) => off += n,
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                    Err(_) => {
+                        self.client = None;
+                        return;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The debug server's stream is nonblocking, and `send()` used `write_all` — which answers `WouldBlock` when the kernel send buffer fills, so any reply larger than the buffer died part-written and dropped the client: a truncated JSON line, then EOF.

Exposed by #121's `kernresident` row on `os8088_xt_vga`: VGA's `fbuf` reply is a ~1.8MB hex line and lost its connection at ~330KB every run. CGA's 768KB usually won the drain race, so the bug read as an adapter-specific flake. The write is now a loop that sleeps 1 ms on `WouldBlock` and drops the client only on a real error or a closed peer.

Verified: `kernresident` ok 13.9 s (was a JSON decode error at 0.7 s), and `make test-full` on main **36/36 in 267.8 s** with the rebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qCvvgaUoNrz39t6m5Lijf