### PR TITLE
functional-check: a skill that verifies a change on the glass before it merges

### DIFF
--- a/.claude/skills/functional-check/LESSONS.md
+++ b/.claude/skills/functional-check/LESSONS.md
@@ -1,0 +1,111 @@
+# What the waves 3-7 functional pass cost to learn
+
+Read before step 3 of [`SKILL.md`](SKILL.md). Every item happened during the
+functional check and merge of PRs #124-#128 (2026-08-31), on a real screen,
+and every one first produced a WRONG conclusion - the conclusion is listed,
+because recognizing it is how the trap is caught the second time.
+
+## Driving the UI
+
+- **Two `mouse.py click` invocations are never a double-click.** Process
+  startup puts the presses outside the kernel's 9-tick window every time.
+  Wrong conclusion drawn: "the icon doesn't open". Fix: position with `to`,
+  then both presses down one `qmp.py` connection with `sleep 0.08/0.12`
+  between events.
+- **A modal alert explains three mysteries at once.** After a menu command,
+  `^R` did nothing, the menu bar showed one menu instead of three, and a
+  crop looked mid-redraw. Wrong conclusions: "Reload is broken", "the bar
+  repaint is broken". The truth, visible only in a FULL screenshot: the
+  command's handler had raised `alert()`, and a modal alert owns the menu
+  bar and swallows every event until OK. Take the full shot first.
+- **Stillness can be the contract.** PONG's frames were byte-identical
+  before Serve - correct, because nothing moves until the loop starts
+  (§9.3: no per-frame work without motion). And after a goal the paddle
+  ignored keys - correct, because `onGoal` calls `field.stop()` and the
+  key poll is a step OF the running loop. Wrong conclusion both times:
+  "canvas/input is dead". Read the demo's own handlers before judging.
+- **Key-state pollers need held keys.** QEMU's default `sendkey` tap can
+  fall between an 18.2Hz poll's frames; `sendkey z 800` holds it. And a
+  fast backspace sequence lost one keystroke silently - the committed value
+  was `35` where `5` was intended. Verify the on-screen text (the caret
+  shows every arrival), never the send.
+- **Click coordinates rot.** The B: window's rows shifted when the file
+  count changed between waves; a reopened window sits somewhere new; a
+  caret jump scrolls the pane under a remembered coordinate. Single-click,
+  screenshot the selection, then act in place. A backspace sent after a
+  caret JUMP deleted a newline at column 1 and joined two lines - wrong
+  conclusion: "the editor corrupted the file".
+- **Some contracts need reading before driving.** The grid's formula bar is
+  LOADED by a cell click but ARMED only by a click in the bar itself
+  (§6.9.4) - typing after a cell click goes nowhere. Wrong conclusion:
+  "the bar is broken". When input seems ignored, check what the spec says
+  arms it.
+- **Mouse cursor photobombs.** The XOR cursor sits exactly where you were
+  working; move it away before the evidence shot.
+
+## The harness
+
+- **A too-early screenshot photographs the previous world.** `make test`
+  can rebuild for a minute before QEMU exists; connection-refused
+  tracebacks or a stale desktop follow. Poll for `build/qmp.sock` answering
+  `info status`, then give the desktop 5s to paint.
+- **MartyPC's staged config is a COPY.** `tools/martypc/configs/*.toml` is
+  appended into `build/martypc/run/configs/machines/ibm5150.toml` by
+  `tools/martypc/build.sh` at build time. Editing the tracked file changes
+  nothing until re-staged, and a row asking for a machine only the tracked
+  file has dies with `martypc_headless exited at once (rc=1)`. Wrong
+  conclusion: "the new test is broken". Re-stage: copy the pristine
+  `build/martypc/src/install/.../ibm5150.toml` and append the tracked file
+  (never `cp` it beside - duplicate machine names refuse the whole config,
+  and so does a duplicate `conventional.size` key from a mangled merge).
+- **The suite runner failing when the direct run passes** usually means the
+  runner's preflight (the symbol map, a knob, the staged config), not the
+  test. `python3 tests/<row>.py` directly, and read
+  `build/martypc/run/martypc.log`'s last lines - the answer is there.
+- **`kernresident`-shaped harness bugs hide behind adapter choice.** The
+  debug server's nonblocking socket dropped any reply bigger than the send
+  buffer: deterministic on VGA's 1.8MB `fbuf`, a once-a-week flake on CGA's
+  768KB. A failure that is adapter-shaped may be SIZE-shaped (#129).
+
+## Merging a stack
+
+- **GitHub closes, it does not retarget.** Deleting a merged branch that is
+  still the BASE of the next open PR closes that PR; a closed PR whose base
+  is gone cannot be reopened until the branch is pushed back
+  (`git push origin <sha>:refs/heads/<name>`, reopen, retarget, delete
+  again). Retarget first, delete second - and never delete an unmerged
+  PR's HEAD branch at all.
+- **Mergeability is asynchronous.** `gh pr merge` seconds after the
+  conflict-resolving push was refused with "merge conflicts" that no longer
+  existed. Re-check `--json mergeable`, wait, retry once.
+- **Squash merges make cousins of identical content.** After squashing PR
+  N, branch N+1 shares no commits with main; the 3-way base falls back to
+  the fork point and every file both touched "conflicts" - most resolve to
+  one side wholesale. Classify per file first: if main's copy equals the
+  previous branch tip's, the newer branch's side is the whole answer; only
+  files main genuinely moved (another team's work landing, a set-number
+  collision, a shared-SDK growth) need hand-merging. `git diff main
+  <last-branch>` empty after the final merge is the proof the gated tree is
+  what shipped.
+- **A number in prose is part of the diff.** Main's drift changed the cell
+  grid (79->80 columns), renumbered a PERFORMANCE.md Set, and grew every
+  package by ~105 bytes through a shared include - each invalidated
+  figures quoted in specs, tests' docstrings, Makefile comments and the
+  suite registry. After any merge, grep the branch's own documents for the
+  numbers the merge moved.
+
+## The working tree is somebody's home
+
+- **Capture `git diff` of any pre-existing dirty file before starting.**
+  Three subagents swept the user's uncommitted `vm/386-weave/86box.cfg`
+  into commits with `git add -A`/`-u`; a fourth destroyed it outright with
+  `git reset --hard`. It was restored only because the exact diff had been
+  captured at session start. Name every path you stage; never reset or
+  checkout over paths you do not own.
+- **A bare `git stash pop` in this repo is a trap** (the stash stack
+  carries years of other work): a pop that "kept the entry" half-applied an
+  old c64 stash into the index and left a UU conflict a later builder
+  tripped over. If state must be parked, prefer a scratch clone or
+  `git worktree`; if a stash was popped wrong, the entry is still in the
+  stack - `git reset --hard HEAD` discards only the half-application (but
+  see the previous item first: know what else is dirty).

--- a/.claude/skills/functional-check/SKILL.md
+++ b/.claude/skills/functional-check/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: functional-check
+description: Functionally verify a change on the glass before it merges - boot the built OS in QEMU, drive the actual UI the change proposes (mouse, keys, menus) over QMP, screenshot the evidence for every user-visible claim, and report per-claim pass/fail. Use when the user asks to functionally check, exercise, or "click through" a branch, PR, or the working tree - or to merge PRs as they pass such a check. Runs the change's own registered gates first; the driving pass is what the gates cannot see.
+---
+
+# Functional check
+
+A change's tests prove what the tests ask. This skill proves the thing the
+user was promised: the button fires, the cell recalculates, the pane draws
+the picture. It boots what `make` built, drives the real UI over QMP, and
+keeps a screenshot for every claim - so the merge decision rests on what was
+seen, not on what a description said.
+
+It exists because the Weave waves 3-7 merge train (PRs #124-#128) was checked
+exactly this way, and the checking found what no gate had: a modal alert
+explaining a "dead" `^R`, a key poll that only reads during play, and a
+half-broken machine config that killed every MartyPC row at launch. Every
+trap below fired on a real screen during that work. **Read [LESSONS.md](LESSONS.md)
+before driving anything** - it is the trap list, and each entry names the
+wrong conclusion the trap produces.
+
+## Step 0 - scope: what are the claims?
+
+Establish what work is under check and what it CLAIMS, before booting
+anything:
+
+- **A PR number**: `gh pr view <N>` - the body's claims are the checklist.
+  Check out the head branch. If main has moved since the branch forked,
+  merge `origin/main` into it FIRST and re-run its gates - a functional
+  check of a tree that will not exist after merge proves nothing
+  (docs/UPSTREAM.md; the wave merges each collided with main's own drift).
+- **A branch or the working tree**: the checklist is the diff -
+  `git diff --stat main...` plus commit messages. Turn it into concrete,
+  user-visible sentences ("clicking X does Y") before starting.
+
+Write the checklist down. The report at the end is this list with evidence
+attached, and anything that cannot be exercised is REPORTED as not
+exercised, never silently skipped.
+
+## Step 1 - the change's own gates first
+
+Cheapest evidence first, and it catches a broken tree before a long
+interactive session does:
+
+```
+make                       # fast tier rides it; checkdocs too
+make test-full             # the pre-merge gate, inside its 600s budget
+python3 tools/os88test.py soak -k '<subject>*'   # the rows the change owns
+```
+
+`make` **after every commit** and before any emulator row - the About box's
+build number is the commit count, so a commit invalidates `build/kernel.bin`
+for the symbol reader and every row dies saying the map describes a
+different kernel (CLAUDE.md, Testing traps).
+
+A soak row that fails on a loaded box with a navigation-shaped error (drive
+B's window never opened; two presses 9 ticks apart) is retried STANDALONE
+before it is believed - the flake is documented, and one retry
+distinguishes it from a defect. Never loosen a shared retry to make a row
+greener.
+
+## Step 2 - boot what was built
+
+```
+pkill -f "[q]emu-system"        # a stale QEMU answers on the old kernel;
+                                # the pattern must not appear in the killing
+                                # command itself (CLAUDE.md, Testing)
+make <the-disk-target>          # weavedisk, zdisk, worddisk, ... whatever
+                                # the change ships on
+make test TESTAPPS=build/<x>.img &
+```
+
+Then WAIT for the socket - `make test` may rebuild for a long time first,
+and a screenshot taken too early photographs the previous world or nothing:
+
+```
+for i in $(seq 1 40); do
+  [ -S build/qmp.sock ] && python3 tools/qmp.py build/qmp.sock 'info status' \
+      >/dev/null 2>&1 && break
+  sleep 2
+done
+sleep 5     # let the desktop finish its first paint
+```
+
+## Step 3 - drive it
+
+The three drivers, and the idioms that actually work (each learned the hard
+way - LESSONS.md has the failure that taught it):
+
+- **Move / click**: `python3 tools/mouse.py build/qmp.sock to|click X Y`.
+  `--screen WxH` must match the adapter (§39).
+- **Double-click**: two `mouse.py click` invocations are two processes and
+  ALWAYS miss the window. Position first, then both presses down ONE QMP
+  connection:
+
+  ```
+  python3 tools/mouse.py build/qmp.sock to X Y
+  python3 tools/qmp.py build/qmp.sock 'mouse_button 1' 'sleep 0.08' \
+      'mouse_button 0' 'sleep 0.12' 'mouse_button 1' 'sleep 0.08' \
+      'mouse_button 0'
+  ```
+
+- **Menus**: `down` on the title, `to` the item, `up` on it. Screenshot the
+  open menu once per session to learn the real item coordinates before
+  selecting blind.
+- **Keys**: `python3 tools/qmp.py build/qmp.sock 'sendkey <key>'`. A
+  key-STATE consumer (`OSAPI_KEY_DOWN` pollers - games) needs a held key:
+  `sendkey z 800` holds for 800ms; the default tap can fall between polls.
+  Rapid sequences lose keystrokes - pace them, and verify the on-screen
+  text rather than trusting the send.
+- **Screenshot**: `python3 tools/shot.py build/qmp.sock out.png
+  [--crop X,Y,W,H] [--zoom N]`. **Crop and zoom before concluding a click
+  was lost** - a small change is invisible in a full-screen dump. Move the
+  mouse away first; the cursor sits exactly where you were working.
+- **Verify the target before acting on it**: single-click, screenshot the
+  selection, THEN double-click in place. Rows move when file counts change;
+  windows move when reopened.
+- **Read the whole screen when anything is odd.** A menu bar that "lost its
+  menus", input that "stopped working" - take a FULL screenshot before
+  theorizing: a modal alert owns the bar and swallows every event, and it
+  may have been raised by the previous action's handler.
+- **Prove animation with arithmetic, not eyeballs**: two shots N seconds
+  apart, diff the pixels (PIL), report the changed-pixel count and bbox.
+  Identical frames are CORRECT for an idle canvas - know what the contract
+  says before calling stillness a bug.
+
+Exercise every checklist claim, happy path AND one refusal per surface the
+change added (the refusal sentence is part of the contract - §10-style
+sentences are quoted in the report verbatim). When an oracle exists
+(`weavesim --render`, `dfrotz`, a golden number in the PR body), check the
+glass against it, not against the change's own opinion of itself.
+
+## Step 4 - report
+
+A table: claim | what was driven | what the glass showed | verdict, with
+the screenshot paths. Then, plainly: anything NOT exercised and why, any
+flake seen and how it was disambiguated, and any defect found - a defect in
+the change blocks the merge; a defect found in code the change does not own
+is reported separately (and fixed in its own commit/PR if small, the wave
+precedent).
+
+## Step 5 - merging on pass (only when asked)
+
+Merging is not part of the check; do it only when the user asked for
+check-then-merge. The house style is squash (`gh pr merge N --squash`;
+`--admin` only when the user said to use admin privileges). For a STACK,
+per PR, in order:
+
+1. Merge the bottom PR. GitHub's mergeability answer is computed ASYNC - a
+   refusal seconds after a push may be stale; re-check, sleep, retry once
+   before believing it.
+2. **Retarget the next PR's base to main BEFORE deleting the merged
+   branch** - `gh pr edit <next> --base main`, then delete. Deleting a
+   branch that is still the base of an open PR CLOSES that PR, and a closed
+   PR whose base branch is gone cannot be reopened until the branch is
+   pushed back.
+3. Never delete an unmerged PR's head branch - that closes it too.
+4. Merge `origin/main` into the next branch, resolve (squash merges mean
+   the histories share no commits - identical content auto-resolves, and a
+   conflict means one side is genuinely newer; classify per file against
+   the previous branch's tip before touching anything), re-run step 1's
+   gates, re-run the functional pass for THAT change, merge, repeat.
+5. After the last merge: `git diff main <last-branch>` must be EMPTY - the
+   proof that what merged is what was gated - then `make && make test-full`
+   on main, and leave the checkout on main.
+
+Throughout: never `git add -A`/`-u`/`.` (name the paths), never
+`git reset --hard` or `git stash pop` in a tree with anyone else's dirty
+files or stash stack (capture `git diff` of any pre-existing dirty file
+before starting, so it can be restored byte-for-byte), and leave the user's
+uncommitted files exactly as found.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,12 @@ fork** — fetch it, merge `main` into it, review it, fix it, push the fixes
 back to their branch, comment — is `.claude/skills/review-fork-pr`
 (`/review-fork-pr <PR#>`), whose `LESSONS.md` is what seven of those reviews
 learned. `docs/UPSTREAM.md` is the same cycle seen from the fork's side and
-binds both.
+binds both. Verifying a change **on the glass** before it merges — boot the
+build in QEMU, drive the UI it claims over QMP, screenshot the evidence per
+claim, then (when asked) merge a stacked series in order — is
+`.claude/skills/functional-check` (`/functional-check [PR#|branch]`), whose
+`LESSONS.md` is what checking and merging the Weave waves (#124–#128)
+learned.
 
 ## Hard rules (§1 — these break silently if violated)
 


### PR DESCRIPTION
The Weave waves (#124–#128) were merged only after each was functionally exercised in QEMU — the button pressed, the cell recalculated, the pane photographed — and that pass caught what no registered gate had: a modal alert explaining a "dead" ^R, a key poll that only reads during play, a mangled machine config that killed every MartyPC row at launch. This writes the procedure down as `.claude/skills/functional-check` so any future branch, PR, or working tree gets the same treatment on request.

**SKILL.md** — the procedure: scope the change's claims; run its own gates first (`make`, `test-full`, its soak rows, with the make-after-commit rule); boot the built disk and wait for the socket; drive the UI with the idioms that actually work (the one-QMP-connection double-click, menu drag, held keys for `OSAPI_KEY_DOWN` pollers, crop+zoom before concluding, single-click-verify before double-click, full screenshot before theorizing); report per-claim with screenshot paths; and — only when the user asked — merge a stacked series in order with the retarget-before-delete rule and the final `git diff main <branch>` emptiness proof.

**LESSONS.md** — the trap list from the waves pass, each entry with the wrong conclusion it produced first: the modal-alert triple mystery, stillness-as-contract, coordinate rot, the async mergeability refusal, GitHub closing (not retargeting) stacked PRs, squash-cousin conflicts and how to classify them, prose numbers as part of the diff, and the two working-tree rules this session paid for (capture the diff of any dirty user file before starting; never bare `git stash pop` here).

**CLAUDE.md** — one sentence in the skills roster, beside `port-to-os8088` and `review-fork-pr`.

No code paths change; `make` (fast tier 30/30, checkdocs 0 problems) is green with only these three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qCvvgaUoNrz39t6m5Lijf