### PR TITLE
Hibernate: save the whole machine to the hard disk and pick up exactly where you left off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ vm/xt-c64/nvr/
 vm/286-c64/nvr/
 vm/xt-weave/nvr/
 vm/386-weave/nvr/
+vm/xt-mfm/nvr/
 
 # Page snapshots the Playwright MCP server drops in the working directory
 .playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,8 @@ sees an up-to-date `kernel.bin`, boots the previous configuration, and it reads
 exactly like the feature being broken.
 
 86Box targets for period hardware, one per `vm/` directory: `xt`, `xt-640`,
+`xt-mfm` (a 20MB ST-225 on a Xebec MFM controller — the machine to install
+and hibernate on; `build/mfm20.img` is created blank and kept),
 `xt-cga`, `xt-hercules`, `xt-ega`, `xt-multimon`, `xt-sound`,
 `xt-sound-1.44`, `286`,
 `286-sound`,
@@ -345,6 +347,17 @@ learned.
   one 64KB window because offsets are 16 bits. They are relieved by different
   mechanisms. **Raising either is a decision to take with whoever asked for the
   feature, not a build fix.**
+- **Before spending a resident byte, ask whether the feature is an ON-DEMAND
+  MODULE** (§2.8, `kernel/mod.inc`, docs/ONDEMAND-PLAN.md §1's test): kernel
+  code that ships as a file (`CTRL.DRV`, `FORMAT.DRV`, `CLONE.DRV`) and is
+  read into a heap claim when the feature is asked for, freed when it is
+  done. A feature qualifies when the system disk is already required to use
+  it, or can be required without interrupting what the user was doing. When
+  it qualifies, the resident part is the menu item, the greying predicate and
+  the thunks; everything else goes in the module. Only a feature that fails
+  the test may grow `.text`/`.cold`, and moving code to `.cold` or the boot
+  overlay relieves `KERN_CODE_MAX` but not `KERN_BUDGET` — a module relieves
+  both. Check `tools/kernsize.py` before and after: a byte costs a byte.
 - **A heap claim can MOVE, and the default is that it may not** (§66). A record
   is born `MC_RLOC` = 0, PINNED; `OSAPI_MEM_MOVABLE` opts one in and takes a
   relocation **proc**, not the address of the word naming the block — a holder

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,8 @@ learned.
   feature, not a build fix.**
 - **Before spending a resident byte, ask whether the feature is an ON-DEMAND
   MODULE** (§2.8, `kernel/mod.inc`, docs/ONDEMAND-PLAN.md §1's test): kernel
-  code that ships as a file (`CTRL.DRV`, `FORMAT.DRV`, `CLONE.DRV`) and is
+  code that ships as a file (`CTRL.DRV`, `FORMAT.DRV`, `CLONE.DRV`,
+  `HIBER.DRV`) and is
   read into a heap claim when the feature is asked for, freed when it is
   done. A feature qualifies when the system disk is already required to use
   it, or can be required without interrupting what the user was doing. When

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ endif
 
 VM    := $(CURDIR)/vm/xt
 VM640 := $(CURDIR)/vm/xt640
+VMMFM := $(CURDIR)/vm/xt-mfm
 VMCGA := $(CURDIR)/vm/xt-cga
 VMHERC := $(CURDIR)/vm/xt-hercules
 VMEGA := $(CURDIR)/vm/xt-ega
@@ -1301,7 +1302,7 @@ $(shell mkdir -p $(BUILD); \
         [ -f $(VIDSTAMP) ] || { rm -f $(BUILD)/.video-* $(BUILD)/kernel.bin \
                                       $(BUILD)/kernel-full.bin \
                                       $(BUILD)/ctrl.drv $(BUILD)/format.drv \
-                                      $(BUILD)/clone.drv \
+                                      $(BUILD)/clone.drv $(BUILD)/hiber.drv \
                                       $(BUILD)/boot.bin $(BUILD)/boot360.bin \
                                       $(BUILD)/hdd.bin $(BUILD)/hdd.drv \
                                       $(BUILD)/hddtool.bin $(BUILD)/hddtool.drv \
@@ -1378,7 +1379,7 @@ KERNEL_SRC := kernel/kernel.asm
 # a map that described "a DIFFERENT kernel".
 KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc boot/boot2.asm
 
-.PHONY: small kernsplit all run run-640 run-720 debug test test-snd xt xt-640 xt-cga \
+.PHONY: small kernsplit all run run-640 run-720 debug test test-snd xt xt-640 xt-mfm xt-cga \
         xt-hercules xt-ega xt-multimon 286 386sx 386 386-xms 386-ps2 xt-sound xt-sound-1.44 \
         286-sound 386-sound 486 pentium \
         bench field combo combo144 combo720 stackprobe trklog trkscrl npbench clicktest marty \
@@ -1535,9 +1536,10 @@ $(FONTINC): $(FONTSRC) tools/os88font.py | $(BUILD)
 # (SPEC.md 2.8.2), so shipping the wrong one is refused rather than executed;
 # this is what stops it happening in the first place.
 KMODDIR = $(BUILD)
-KMODS = $(KMODDIR)/ctrl.drv $(KMODDIR)/format.drv $(KMODDIR)/clone.drv
+KMODS = $(KMODDIR)/ctrl.drv $(KMODDIR)/format.drv $(KMODDIR)/clone.drv \
+        $(KMODDIR)/hiber.drv
 KMODARGS = -m 0=$(BUILD)/ctrl.drv -m 1=$(BUILD)/format.drv \
-           -m 2=$(BUILD)/clone.drv
+           -m 2=$(BUILD)/clone.drv -m 3=$(BUILD)/hiber.drv
 
 # THE KERNEL IS ASSEMBLED WHOLE AND THEN CUT UP (SPEC.md 2.8). Everything
 # from .modc onward is an on-demand module: kernel code that ships as a file
@@ -6871,6 +6873,26 @@ xt: $(IMG360) $(APPSIMG360)
 xt-640: $(IMG360) $(APPSIMG360)
 	@$(UNPROTECT) $(VM640)/86box.cfg
 	$(BOX) -P $(VM640) -N
+
+# ...AND A 20MB MFM HARD DISK: an ST-225 (615 cylinders, 4 heads, 17 sectors)
+# on IBM's Fixed Disk Adapter, the Xebec card whose option ROM presents the
+# drive as int 13h unit 80h - SPEC.md 52.1's rung 0, the transport the field
+# machine uses (docs/FIELD-MACHINES.md: an ST-225 on an ST-11M, which 86Box
+# also has as `st506_xt_st11_m`, but that ROM keeps its geometry ON THE DISK
+# and wants its own low-level format first, so the Xebec is the one a blank
+# image boots on). The image is created blank, once, and KEPT: partitioning
+# and formatting it is the OS's job (Control Panel -> Drivers -> tick Hard
+# Drive -> Format), and so is installing to it (SPEC.md 52.10.4) and
+# hibernating to it (SPEC.md 86), which is what this machine is for -
+# hibernate and resume on period hardware, MFM and all. The size is the
+# geometry's exactly, because 86Box refuses a raw image that disagrees.
+MFMIMG := $(BUILD)/mfm20.img
+$(MFMIMG): | $(BUILD)
+	dd if=/dev/zero of=$@ bs=512 count=$$(( 615 * 4 * 17 )) 2>/dev/null
+
+xt-mfm: $(IMG360) $(APPSIMG360) $(MFMIMG)
+	@$(UNPROTECT) $(VMMFM)/86box.cfg
+	$(BOX) -P $(VMMFM) -N
 
 # The two monochrome machines (SPEC.md 39), both 256KB - which is all an
 # ibmxt takes anyway, and the floor os8088 targets. These are the ONLY way to

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ make run-640  # the same, on a 640KB machine
 make run-720  # the same, off the 720KB pair
 make xt       # boot the 360KB image on an emulated IBM PC/XT in 86Box
 make xt-640   # the same XT with a full 640KB of RAM
+make xt-mfm   # ...and a 20MB MFM hard disk on IBM's Fixed Disk Adapter
 make xt-cga   # the same XT with a CGA card instead of VGA
 make xt-hercules  # ...and the same XT with a Hercules card
 make xt-ega   # ...and the same XT with an IBM EGA, at 640x350
@@ -578,7 +579,13 @@ fancy period configuration. Expect the real 4.77MHz experience: repaints
 you can watch. `make xt-640` boots the same setup with a full 640KB of
 RAM (`vm/xt640/86box.cfg`) — on the 1986 XT board revision (`ibmxt86`),
 because the original 1982 planar maxes out at 256KB and 86Box silently
-clamps `mem_size` back to the board's limit.
+clamps `mem_size` back to the board's limit. `make xt-mfm` is that machine
+with a **20MB MFM hard disk** (`vm/xt-mfm/86box.cfg`): an ST-225 on IBM's
+Fixed Disk Adapter, whose option ROM is the int 13h the kernel's hard-disk
+driver calls (SPEC.md 52.1). The image, `build/mfm20.img`, is created blank
+and kept between runs; partition and format it from Control Panel → Drivers
+→ Hard Drive → Format, and from then on it is C: — the machine to install
+to (SPEC.md 52.10) and to hibernate on (SPEC.md 86) at a real 4.77MHz.
 
 `make xt-cga`, `make xt-hercules` and `make xt-ega` are the same 256KB XT
 with the other three adapters os8088 supports (`vm/xt-cga`,
@@ -626,6 +633,7 @@ All targets, at a glance:
 |---|---|---|---|---|---|
 | `xt` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | OTI-067 VGA | — |
 | `xt-640` | XT, 1986 board | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | — |
+| `xt-mfm` | XT, 1986 board + 20MB ST-225 on a Xebec MFM controller | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | — |
 | `xt-cga` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | CGA | — |
 | `xt-hercules` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | Hercules | — |
 | `xt-ega` | IBM PC/XT | 8088 @ 4.77MHz | 256KB | IBM EGA (640x350) | — |

--- a/SPEC.md
+++ b/SPEC.md
@@ -806,8 +806,9 @@ sector nothing: unset, the `%ifdef` is not assembled.
 **A module is `.cold` code that ships as a file instead of as part of the
 kernel image.** It is read into a heap claim when its feature is asked for,
 far-called through a table of entry pointers, and freed when the feature is
-finished. Two exist: `CTRL.DRV`, the Control Panel (§31), and `FORMAT.DRV`,
-the floppy formatter (§18.96).
+finished. Four exist: `CTRL.DRV`, the Control Panel (§31), `FORMAT.DRV`,
+the floppy formatter (§18.96), `CLONE.DRV`, the disk cloner (§18.99), and
+`HIBER.DRV`, hibernate and resume (§86).
 
 **This is the fourth lever on the footprint, and the only one that relieves
 `KERN_BUDGET` without relieving nothing else.** §2.5's overlay is run-once
@@ -2006,6 +2007,7 @@ VIEW_KB       equ 3          ; each window's cache, claimed when it opens
 | `kernel/disk.inc`   | BIOS int 13h floppy transfers (`disk_read`/`disk_write`), FAT12/16 mount + directory + chain walk (§18–19) |
 | `kernel/diskw.inc`  | the FAT write path (§18.4): name parsing, cluster allocation + free, FAT flush, directory entry create/update/delete, the five whole-file operations — prefix `dskw_`; the ONLY caller of `disk_write`. **`.cold`** (§2.6) |
 | `kernel/clone.inc`  | the disk cloner (§18.99): the on-demand `CLONE.DRV` — sector-for-sector copy between any two floppy drives or one drive twice, its XMS/heap planner, its own geometry probe and its status-line prompts — prefix `clo_`; the resident half is one word and one thunk, both **`.cold`**/`.text` (§2.6) |
+| `kernel/hiber.inc`  | hibernate and resume (§86): the on-demand `HIBER.DRV` — the Hibernate window, the image write, the boot-time question, the extent walk, the stub that puts memory back from the text framebuffer and the wake — prefix `hbm_`/`hbs_`; the resident half is the template, the state block, the `.text` thunks a kernel window needs, and in **`.cold`** the boot probe, the greying predicate and the loading thunks (`hb_`/`hbf_`/`hbk_`) |
 | `kernel/loader.inc` | package validation, pool allocation, per-instance load + relocate, launch (§21). **`.cold`** (§2.6) |
 | `kernel/files.inc`  | Disk window: file list UI, selection, open, refresh (§22). **`.cold`** (§2.6), with its strings and dispatch tables toggled back to `.text` |
 | `kernel/filecp.inc` | the file manager's clipboard: Cut, Copy, Paste and the recursive paste engine (§22.3) — prefix `fcp_`. **`.cold`** (§2.6) |
@@ -9105,7 +9107,8 @@ opposed, and no single number satisfies both.
 
 **Worse, the highlight goes AWAY rather than merely lagging.** Separators are
 `MENU_DIS` items (§12.2 — `menu_s_msep`, `fm_s_fsep`), so the System menu is
-About / Control Panel / Task Manager / **rule** / Restart, and `menu_hover`
+About / Control Panel / Task Manager / **rule** / Hibernate... / Restart
+(§86; `kern_small` has no Hibernate), and `menu_hover`
 answers `0xFFFF` for the whole of that fourth cell. Six presses in the middle
 of a menu that highlight nothing at all do not read as slowness; they read as
 the menu having stopped working.
@@ -27944,6 +27947,13 @@ The first consumer is the hard disk installer's Restart button (§52.10.6),
 which is the case that needed it: the user has just written a bootable
 volume and the next thing they want is to boot it.
 
+**The same byte carries three more values** (§86): `UI_RBQ_HIBER`,
+`UI_RBQ_RESUME` and `UI_RBQ_ASK`, spent at the same top-of-pass site for the
+same reason — a hibernate detaches drivers and a resume waits on their
+workers, neither of which can be done from the callback that decided it.
+Unlike a restart these can RETURN: on a refusal, a Discard, or once the
+question is on the screen. A restart already posted wins over any of them.
+
 #### 20.10.1 …and `AL` says whether it may touch a disk
 
 `AL` = 0 is the System menu's restart, which calls `cp_flush_close` on the
@@ -36322,7 +36332,8 @@ row keeps 0.
 Pinned caps: About 1 (stateless), Timer 10
 (stride 16 — 8 of state and 8 of §14.1's TMR_SHOWN), Bounce 10 (stride 8),
 **Files 4 (stride `FS_SIZE`, pool `fm_pool`)**,
-TaskMgr 1 (one sampler), Control Panel 1 (no per-instance state, §31). The
+TaskMgr 1 (one sampler), Control Panel 1 (no per-instance state, §31),
+Hibernate 1 (stateless, painted by its module, §86.1). The
 Files cap is 4 because each window claims its own `VIEW_KB` cache (§2.3); `KD_CAP`, `VIEW_SLOTS` and the `fm_pool` size are one
 number wearing three hats and must move together. The
 per-kind caps deliberately over-subscribe INST_MAX now that Timer and
@@ -55972,6 +55983,13 @@ DSV_BLK      in  AL = 0 read / 1 write
 DSV_CPNAME   -> a NUL page name in ITS segment (0 = no page)
 DSV_CPPAINT  near proc: DI = pane left, DX = pane top
 DSV_CPCLICK  near proc: the same, plus CX/BX = the click
+DSV_GEOM     in  AH = the DRIVER's own volume handle
+             out CF = 0: DL = the int 13h drive, CX:BX = the partition's
+                 first LBA, SI = sectors per track, DI = heads - the
+                 TRANSPORT FACTS, for a caller that must reach the volume's
+                 sectors with every driver detached (§86.5's resume stub);
+                 CF = 1: no such volume, or one the ROM does not reach
+                 (§52.1's rung 1). 0 = never, which reads as CF = 1
 ```
 
 **`DX:BX` and not `ES:BX`, deliberately.** The buffer is in `LOW_SEG`, the FAT
@@ -83101,3 +83119,303 @@ the `VID_*` kind `fsx_caps` hands back in DL, which `tk_adapter` already asks
 for and re-asks on a resize, so a window dragged to the other card of a
 two-card machine (§39.18.2) re-answers it rather than carrying VGA's palette
 onto a Hercules.
+
+## 86. Hibernate — the machine to a file on the hard disk, and back (`kernel/hiber.inc`, `HIBER.DRV`)
+
+**What it is.** `Hibernate...` is the System menu's item above `Restart`
+(§12.1). It writes everything in conventional memory to `HIBERNAT.IMG` in the
+root of the hard disk the machine booted from — or of the first hard disk
+there is, when the boot was a floppy — then stops the machine with a
+text-mode sentence saying it is safe to switch off. Nothing is asked but a
+confirmation. The next boot finds that file by itself and asks, on the
+desktop, whether to **Resume** it or **Discard** it and start normally. A
+resume puts every byte back where it was and returns into the UI task's loop
+exactly where the hibernate left it: the windows, the running packages, their
+tasks and the clipboard are all as they were.
+
+**What it is not.** Not a suspend: nothing is kept powered. Not a snapshot of
+the hardware: the drivers that own hardware are detached before the image is
+written and loaded again after it is restored (§86.4). And not a feature of
+the kernel image: the whole of it except the menu item, the greying
+predicate, a window kind, the boot probe and their thunks is **an on-demand
+module** (§2.8), `HIBER.DRV`, `MOD_HIBER`, read into a heap claim when the
+item is picked or a hibernation file is found at boot, and freed when the
+Hibernate window closes. It qualifies under docs/ONDEMAND-PLAN.md §1's test
+twice over: at hibernate the user is leaving the machine, and at boot the
+system disk is in the drive by definition.
+
+### 86.1 The Hibernate window (`KIND_HIBER`)
+
+A task-less, stateless singleton kind (§29.3), 320 px wide, with one mode byte
+`[hb_mode]` in kernel `.bss` and three faces:
+
+```
+HB_M_ASK     Save everything in memory to                  [Hibernate] [Cancel]
+             C:\HIBERNAT.IMG and stop the machine?
+             Restarting offers to resume it.
+HB_M_BUSY    Hibernating...                                (no buttons)
+HB_M_RESUME  A hibernation file is on drive C:.            [Resume]  [Discard]
+             Resume where you left off, or discard it
+             and start normally?
+```
+
+The drive letter in both faces is patched into the string at paint time,
+because the disk is chosen when the window opens: `hbm_pickvol` takes
+`[dsk_bootvol]` when that row is a fixed disk (§18.7, §52.10.3) and the first
+fixed row otherwise, and the window is the confirmation — Hibernate stops
+the machine, and `Restart` beside it asks nothing only because a restart
+costs seconds and a hibernate costs a file and a minute.
+
+Every string, every button label and the whole painter live in the module and
+are read through `CS` (§2.8.6): nothing can draw them while the image is not
+loaded, because every callback of this window is a `.text` thunk that
+far-calls a `.cold` thunk that runs `mod_need` first — `cpf_cp_paint`'s shape
+exactly (§2.8). The buttons fire on the **release** (§13.8.3): `W_ONCLICK`
+arms `[hb_down]`, `W_ONMOUSEUP` fires when the release lands on the same
+button, and the painter draws the armed one with `OS88UI_DOWN`. `Enter` is the
+first button and `Esc` the second.
+
+**There is no file dialog, and there was one.** The first cut opened the
+Standard File dialog (§38) on this window and let the user name the image
+anywhere on any hard disk. It was taken out on request: a hibernation file
+is not a document, nobody wants to be asked where to put it, and a fixed
+place is what lets the next boot find it without a pointer's path. What it
+cost the kernel was a `.text` thunk for the completion proc and 32 bytes of
+`.bss` for the folder path, both gone.
+
+`Cancel` and `Discard` close the window through `app_close_win` from inside
+the release handler — safe for §38.7's reason — and set `[hb_mode]` to
+`HB_M_GONE`, which is what tells the `.cold` thunk that made the far call to
+`mod_drop` the image on the way back. The module is never freed from inside
+its own code.
+
+### 86.2 The greying predicate, and what it refuses
+
+`hb_ok` (`.cold`, one call from `ui_loc_gate` on the press that opens the bar,
+§47 rule 5) points item 4 of `menu_items_logo` at one of three strings:
+
+| string | when |
+|---|---|
+| `Hibernate...` | a fixed volume exists (§18.7: a `DVK_DRV` row, or a `DVK_BIOS` row whose unit has bit 7 set) and the store above 1MB has no block allocated |
+| `Hibernate (No HD)` (`MENU_DIS`) | no fixed volume |
+| `Hibernate (XMS)` (`MENU_DIS`) | `OSAPI_XM_CAPS` reports fewer than `XM_MAX_BLKS` free entries: a package holds extended memory, and the image does not carry it (§86.7) |
+
+Two more refusals are made when the Hibernate button is taken (`hbm_arm`),
+with a toast each (§47 rule 6 — they need the volume mounted, which the bar
+cannot afford on every press):
+
+- **The disk's transport must be int 13h.** A `DVK_DRV` volume whose driver
+  answers `DSV_GEOM` with CF = 1 — §52.1's rung 1, the IDE task file, which
+  the resume stub cannot speak (§86.5) — is refused: `Hibernate needs a
+  BIOS-known hard disk`.
+- **There must be room**: `dskw_dfree` on the root plus the size of the
+  `HIBERNAT.IMG` already there, if any, must cover `[mem_top]` × 16 + 4,096.
+  `Not enough room for the hibernation file`.
+
+### 86.3 The two files
+
+The **image** is the memory of the machine, linear 0 to `[mem_top]` × 16,
+written as ONE `dskw_write` from `0000:0000` (§18.4.1's segment-walking
+source) as `HIBERNAT.IMG` in the root of the chosen disk. It has no header:
+file offset *n* is linear address *n*, which is what lets the restore be a
+list of sector runs and nothing else.
+
+The **pointer**, `HIBERNAT.PTR`, is written beside it after the image, so a
+boot that finds no pointer finds no hibernation whatever else is on the disk
+— a write that failed half way leaves nothing to resume. It is 64 bytes of
+header and then the image's name; the path field is reserved and zero, and a
+pointer with a path in it is refused as another build's:
+
+```
++0   db 'HIB1'                   magic
++4   dw BUILD_NUM                the commit (§14.2)
++6   dw MOD_STAMP                the layout of this build of it (§2.8.2)
++8   dw [mem_top]                paragraphs of conventional memory
++10  db [vid_kind]               the adapter the desktop was on
++11  db 0
++12  dw SP, dw SS                hb_perform's entry frame (§86.4)
++16  dw off, dw seg              hb_wake, in the module's own segment
++20  dw driver mask              drv_tab rows detached before the image
++22  db 0 x 10
++32  db path[32]                 the folder from the root, 'A\B', NUL (PTH_BUF)
++64  db name[13]                 the image's 8.3 name, NUL
+```
+
+A pointer whose build, stamp, memory size or adapter differ from the kernel
+reading it names an image this kernel cannot enter, and `hb_ask` says so —
+`Hibernation file is from another build` — and deletes it. The same-build
+requirement is what makes the whole design cheap: the fresh kernel's code and
+the image's are byte-identical, so the restore may write over the running
+kernel's `.text` without the machine noticing, and every kernel address the
+resume needs is the fresh kernel's own symbol.
+
+### 86.4 Hibernate — what happens, in order
+
+`hbm_arm` makes the two checks above, repaints the window as `HB_M_BUSY`,
+and **posts** `UI_RBQ_HIBER` in `[ui_rebootq]` — §20.10's deferral, for
+§20.10's reason: a button's release runs with the gfx lock held and what
+follows detaches drivers, which yields. `ui_task` spends the post at the top
+of its pass with nothing held, in `hb_perform`:
+
+1. `dsk_chdir` to the root of `[hb_vol]`.
+2. **Detach every loaded driver whose class is not `DRVC_DISK` or
+   `DRVC_FILE`** (`drv_unload` per row: sound, the parallel link, the NIC),
+   recording the rows in `[hb_drvmask]`. Their hardware state cannot cross a
+   power cycle and their claims would be restored to addresses a fresh boot
+   has given to somebody else; the disk driver and the RAM disk own no
+   hardware the BIOS does not already own, and their state is memory.
+3. `gfx_lock`, and `inc [sch_lock]`: the image must be one instant of the
+   machine, so no other task runs while it is written. Interrupts stay on —
+   int 13h needs them on an AT — and the tick, the mouse and the keyboard
+   ISRs touch nothing the image cares about.
+4. Bank `hb_perform`'s **entry** `SS:SP` and the far address of `hb_wake`.
+   Everything above that SP — the dispatcher's return, the thunk's, the UI
+   task's frame — is written into the image untouched, because the write
+   itself only ever uses the stack below it.
+5. The image, as one `dskw_write`. The progress widget (§12.8) is on the bar
+   throughout, because the lock is held by the task that calls it.
+6. The pointer, in the root.
+7. `vid_reboot` to text mode, the sentence, `int 16h`, then `drv_shutdown`,
+   `sched_unhook` and `int 19h` — the reboot path's tail (§20.10), so a key
+   restarts the machine into the question below.
+
+A failure at 5 or 6 undoes 2–4 — the drivers are loaded again from the mask,
+the lock and `sch_lock` released — and toasts `Hibernate failed`; the window
+goes back to `HB_M_ASK`.
+
+**The image is captured progressively and that is why the disk caches are
+discarded on resume** (§86.6): the FAT window, the read-ahead and the write
+path's own words are written into the image in the state they were in when
+the write reached their addresses, which is mid-write. Nothing else in the
+kernel changes during the write — no task runs — so nothing else needs the
+treatment.
+
+### 86.5 Resume — the probe, the question, the stub
+
+**The probe** (`hb_probe`, `.cold`, resident, from `kmain` after `drv_boot`
+and before the first paint) walks `dsk_vtab` for fixed volumes and looks in
+each one's root for `HIBERNAT.PTR`, inside a `drv_vol_bank`/`drv_vol_back`
+bracket (§51.5.2). A floppy-only machine pays eight compares. A hit records the
+volume in `[hb_vol]` and posts `UI_RBQ_ASK`, which `ui_task`'s first pass
+spends — on the desktop, with nothing held — by loading the module and running
+`hb_ask`: read the pointer, validate it (§86.3), find `HIBERNAT.IMG` beside it
+and check its size against `[mem_top]`, ask the transport question (§86.2),
+and open the window in `HB_M_RESUME`. Any refusal is a toast and a deleted
+pointer.
+
+**Resume** posts `UI_RBQ_RESUME`; `hb_perform` then:
+
+1. Asks the transport facts. For the boot partition (§52.10.3) they are the
+   kernel's own — `DV_UNIT`, `dsk_vbase`, `dsk_bootspt`/`dsk_boothds`; for a
+   driver volume they are `DSV_GEOM`'s (§51.8): the int 13h unit, the
+   partition's 32-bit base, sectors per track and heads.
+2. Walks the image's FAT chain into a list of **extents** — absolute LBA and
+   sector count, contiguous clusters coalesced — in a 10KB `MEM_K_HIB` claim.
+3. `drv_shutdown` (the fresh boot's drivers go, as before any restart),
+   `gfx_lock`, `vid_reboot` to text mode.
+4. Copies the **stub**, its parameters, the fresh clock's twelve bytes and the
+   extents into the text framebuffer — `B800:0000` on a colour primary,
+   `B000:0000` on a Hercules — which is the one RAM on the machine that no
+   rung of §2's ladder owns and every adapter has at least 16KB of. Puts the
+   BIOS's own int 08h vector back (`sch_old08`), masks IRQ 1, 3, 4 and 12 so no
+   kernel ISR can run on a half-restored kernel, and far-jumps to the stub.
+
+**The stub** runs with `CS`, `DS` and `SS` in the framebuffer and reads every
+sector of the image to its own linear address with int 13h `AH=02h`, one run
+per call, a run stopping at the end of the track and at the 64KB DMA page
+(§52.1's rung-0 rules) and retried three times with a controller reset
+between. Its CHS arithmetic is `hd_chs`'s, one `div` pair. File sectors 0..2
+are the one exception: they are read to `0060:0000` and sectors 0..1 copied
+into the staging area, because the IVT can only go back **last**, under
+`cli`, after the final int 13h — and sector 2, the BIOS data area, is never
+written at all: it is the ROM's, and the ROM is the one thing that kept
+running. Then the PIC masks go back, `DS` becomes `KERNEL_SEG`, `SS:SP`
+becomes the banked frame, and a far jump lands in `hb_wake` — inside the
+image's copy of the module, at the segment the pointer recorded. A read that
+still fails after its retries prints one sentence through int 10h and waits
+for a key before `int 19h`: half a memory is not a machine, and the ROM's
+teletype is the only thing left that can be trusted to say so.
+
+### 86.6 `hb_wake` — putting the machine back on its feet
+
+In the restored kernel, on the restored stack, interrupts off, `[sch_lock]`
+still up from step 3 of §86.4 and the gfx lock still held:
+
+1. `sti`. The IVT is the image's, the PIT is in the kernel's mode 2 (the
+   fresh boot's `sched_init` set it and nothing on the resume path unset it),
+   and with `sch_lock` up the tick counts and switches nobody.
+2. The clock: the twelve bytes `clk_sec`..`clk_year` come out of the staging
+   area, where step 4 put the fresh boot's — the RTC ladder is boot-overlay
+   code (§37.90) and cannot be run again, so the boot that just happened is the
+   clock's source. `clk_last` is re-seeded from `[ticks]`.
+3. **The disk caches are discarded** (§86.4): every private FAT window
+   dropped (`dsk_fatw_drop`), the dirty range and the resident window marked
+   empty, the read-ahead flushed, the write gate shut, the batch depths
+   zeroed, `mem_pinseg` cleared and the progress widget given back with
+   `fpg_end` — every one of them a word the write was in the middle of.
+4. `vid_setmode`, then the Hibernate window closed with `app_close_win`, then
+   `menu_force`, `dock_force`, `wm_paint_all` — `fsx_restore`'s return from a
+   foreign mode (§53), which is what a text screen is. Before any disk work,
+   so the widget the next step arms has a graphics mode to draw in.
+5. The pointer and the image are deleted, which is the one mount the resume
+   makes. Both files, because a resumed hibernation is spent, and 640KB of a
+   32MB disk is not nothing.
+6. The drivers in `[hb_drvmask]` are loaded again, in row order, exactly as
+   `drv_boot` would have loaded them.
+7. `blk_wake`, `[hb_resumes]` += 1, `[hb_mode]` = `HB_M_GONE`, `gfx_unlock`,
+   **`[sch_lock]` = 0** — set, not decremented: the image holds the count as
+   the write left it, and `dsk_xfer` raises it around every int 13h, so it
+   reads 2 and one down from that is a machine that never switches again
+   (`tests/hibernate.py` found exactly that) — and a near `ret` into the
+   module's dispatcher with `SP` at the banked frame, which returns through
+   the `.cold` thunk (where the image is dropped) into `ui_task`'s loop.
+
+**What deliberately does not survive**: the BIOS data area (the ROM's, and
+a key typed during the restore is in its buffer, not the kernel's); the
+state of any driver that owns hardware (loaded fresh); extended memory (the
+item greys while any is held); and the disk caches (rebuilt). The mouse
+needs nothing: the fresh boot's `mouse_init` left the UART and the 8042 in
+the state the image's kernel expects, because the image's kernel set them
+up the same way, and the resume path never calls `mouse_unhook`.
+
+### 86.7 What it costs, and what is owed
+
+Resident: the three strings, the template, the two file names, the kind row,
+five `.text` thunks and seven `cw_` shims, and in `.cold` the probe, the
+predicate, eleven far entries and the seven thunks that load the module —
+248 bytes of `.text`, 94 of `.bss` and 329 of `.cold`, which crossed both
+rungs; docs/KERNEL-MEMORY.md has the account. The module is `HIBER.DRV` on
+every system disk, 3,462 bytes, fourth in `mod_tab`, and the stub is ~300
+bytes of it.
+
+Time on the 5150: the image is 1,280 sectors on a 640KB machine, and both the
+write and the read go out in track-sized runs, so it is ~80 int 13h calls
+each way against an XT hard disk — seconds, not minutes. `tests/hibernate.py`
+measures nothing; docs/FIELD-MACHINES.md is where the number would come from.
+
+Owed, and refused rather than guessed at meanwhile: **extended memory** in the
+image (the store's blocks would have to be copied down and up through
+`xm_copy`, a second section of the file); **IDE rung 1** volumes (the stub
+would need the task-file transport); and a **two-card** desktop's second
+display, which comes back as the primary alone until the next
+`vid_disp_init` — the text-mode framebuffer used for staging is the
+primary's.
+
+### 86.8 Testing
+
+`tests/hibernate.py` (soak, MartyPC's `os8088_xt_hdd`, rung 0 — the same
+transport as the field machine) boots a fixture volume built by
+`tools/os88hdd.py` with `HIBER.DRV` on it, opens an About box as the witness,
+picks `Hibernate...` and **clicks** the window's button with the mouse — the
+release path, which once had a hit test that clobbered the click's y so that
+only `Enter` worked — watches the machine reach the text-mode sentence,
+presses a key, sees the question on the fresh desktop, clicks `Resume`, and
+then reads `[hb_resumes]`, the instance table, the two locks and the tick out
+of the guest: the About instance must be live with a visible window,
+`[sch_lock]` and the gfx lock must be down, the tick must advance, and
+`HIBERNAT.PTR` must be gone from the volume. A second pass goes through the
+keyboard and takes `Discard`, and asserts the opposite. The driver-backed shape — a floppy boot
+with a `SYSTEM.CFG` that wants `HDD.DRV`, the same VHD mounted through it —
+is the same script with `--driver`, registered as `hibernatedrv`. Both write
+four rendered screenshots to `build/hiber-*.png`; docs/TESTING.md has the
+recipe and what it cannot see.

--- a/SPEC.md
+++ b/SPEC.md
@@ -16171,7 +16171,8 @@ Window" (CMD_CLOSE); and **Builtins**: "Timer" (CMD_TIMER), "Bounce"
 (CMD_BOUNCE), "Disk" (CMD_FILES) — see §12.3.1 for why that is not how they
 started. The System menu is cell 0 for every application: "About os8088..."
 (CMD_ABOUT), "Control Panel" (CMD_CTRL, §31), "Task Manager" (CMD_TASKS,
-§28), a rule, and "Restart" (CMD_REBOOT).
+§28), a rule, "Hibernate..." (CMD_HIBER, §86 — kern_big only, so the ids
+below it are one lower in kern_small), and "Restart" (CMD_REBOOT).
 
 **"Close Window" greys when there is nothing to close.** `ui_loc_gate` points
 that item at its `MENU_DIS` twin from `wm_top`, on the press that opens the
@@ -16187,12 +16188,13 @@ predicate is per-kind rather than one word.
 CMD_ABOUT  equ 1   ; --- System (cell 0, every application) ---
 CMD_CTRL   equ 2
 CMD_TASKS  equ 3
-CMD_SEP    equ 4   ; the rule above Restart - no handler, see below
-CMD_REBOOT equ 5
-CMD_CLOSE  equ 6   ; --- Locator: File ---
-CMD_TIMER  equ 7   ; --- Locator: Builtins ---
-CMD_BOUNCE equ 8
-CMD_FILES  equ 9
+CMD_SEP    equ 4   ; the rule above Hibernate - no handler, see below
+CMD_HIBER  equ 5   ; kern_big only (§86); kern_small has no such item and
+CMD_REBOOT equ 6   ;   its ids from here stay one lower: REBOOT 5, CLOSE 6,
+CMD_CLOSE  equ 7   ;   TIMER 7, BOUNCE 8, FILES 9
+CMD_TIMER  equ 8   ; --- Locator: Builtins ---
+CMD_BOUNCE equ 9
+CMD_FILES  equ 10
 ```
 
 The ids are contiguous **within** a menu, because that is what makes
@@ -35161,7 +35163,8 @@ decoded from `CLS_OWN`:
 | `MEM_K_MOD` | `ModImg` | an on-demand kernel module's image (§2.8) |
 | `MEM_K_CLONE` | `Cloner` | the disk cloner's buffer (§18.99) |
 | `MEM_K_BAND` | `BandBuf` | the 1bpp band composer's buffer (§5.9.2) |
-| `MEM_K_OVL` | `BootOvl` | the relocated boot overlay (§2.5.1) |
+| `MEM_K_OVL` | `BootOvl` | the relocated boot overlay (§2.5.1) — retired, and its value 0xFF0B left unused (§2.9.6) |
+| `MEM_K_HIB` | `Resume` | the resume's extent list (§86.5) — 0xFF0C, the next free value |
 | `MEM_P_WSAVE` + slot | `WinSave` | a window's raise cache (a RANGE, §11.96.3) |
 | `MEM_P_DIRW` | `DirRead` | the directory read-ahead window |
 | anything else | `xxxx` | **the raw owner word, in hex** |
@@ -36270,7 +36273,8 @@ KIND_BOUNCE  equ 2       ;  NOTEPAD package, §27 — the numbering closed up;
                          ;  kind 1 was the Clock until it gained its buttons
                          ;  and became the Timer, §14)
 KIND_FILES   equ 3
-KIND_CTRL    equ 5       ; Control Panel (§31)
+KIND_CTRL    equ 4       ; Control Panel (§31)
+KIND_HIBER   equ 5       ; the Hibernate window (§86.1), kern_big only
 KIND_PKG     equ 0x80    ; bit 7: package instance
 ```
 
@@ -55159,7 +55163,12 @@ So the dispatcher's pad byte at **+15 is `DRV_H_DSV`, the byte length of the
 there for every class; `drv_publish` copies that many bytes and **publishes 0
 for every cell past it**, so a cell the driver does not have is refused by the
 `or bp, bp` / `jz` test every consumer already makes — `drv_pkg_call`'s fence,
-`cp_drv_ev`'s three page cells — instead of being far-called. **A byte of 0
+`cp_drv_ev`'s three page cells — instead of being far-called — `drv_publish` copies exactly that length,
+clamped to `DSV_SIZE`, over a table it has zeroed first. (It was "all or
+`DSV_TAB0`" until `DSV_GEOM` took `DSV_SIZE` 36 → 38 in §86, when every
+released driver became "shorter" and lost its four newest cells — the Control
+Panel page's and `DSV_PKGCALL`, which for `ETHER.DRV` is the whole socket
+surface.) **A byte of 0
 means `DSV_TAB0` = 28**, the length every released driver has, so a mismatched
 floppy set degrades to a driver with no page key and no package door rather
 than a wild far call. `DRV_VER` does not change, for §62.9.1.1's reason: every
@@ -83160,7 +83169,7 @@ HB_M_RESUME  A hibernation file is on drive C:.            [Resume]  [Discard]
 ```
 
 The drive letter in both faces is patched into the string at paint time,
-because the disk is chosen when the window opens: `hbm_pickvol` takes
+because the disk is chosen when the window opens: `hb_pick` (`.cold`) takes
 `[dsk_bootvol]` when that row is a fixed disk (§18.7, §52.10.3) and the first
 fixed row otherwise, and the window is the confirmation — Hibernate stops
 the machine, and `Restart` beside it asks nothing only because a restart
@@ -83187,7 +83196,13 @@ cost the kernel was a `.text` thunk for the completion proc and 32 bytes of
 the release handler — safe for §38.7's reason — and set `[hb_mode]` to
 `HB_M_GONE`, which is what tells the `.cold` thunk that made the far call to
 `mod_drop` the image on the way back. The module is never freed from inside
-its own code.
+its own code. Every **other** way the window closes — the close box, Locator's
+Close Window, the Task Manager, the restart sweep — reaches `app_close_win`
+with nothing of the module on the stack, and `app_close_win`'s `KIND_HIBER`
+hook (`hbf_closed`, `.cold`) drops the image there; the module's own closes
+set `HB_M_GONE` *before* calling `app_close_win`, and a GONE window is how the
+hook knows to leave that drop to the thunk. So the claim really is freed when
+the window closes, by whichever route.
 
 ### 86.2 The greying predicate, and what it refuses
 
@@ -83196,7 +83211,7 @@ its own code.
 
 | string | when |
 |---|---|
-| `Hibernate...` | a fixed volume exists (§18.7: a `DVK_DRV` row, or a `DVK_BIOS` row whose unit has bit 7 set) and the store above 1MB has no block allocated |
+| `Hibernate...` | a fixed volume exists (§18.7: a `DVK_DRV` row, or a `DVK_BIOS` row whose unit has bit 7 set — never a `DVK_FILE` one: a RAM disk or a redirected volume answers `dsk_vol_fixed` as fixed and has no sectors the stub could read, so `hb_pick` — THE predicate, the one `hb_ok`, `hb_probe` and the window all ask, so what greys, what is probed and what is written to cannot disagree — skips it) and the store above 1MB has no block allocated |
 | `Hibernate (No HD)` (`MENU_DIS`) | no fixed volume |
 | `Hibernate (XMS)` (`MENU_DIS`) | `OSAPI_XM_CAPS` reports fewer than `XM_MAX_BLKS` free entries: a package holds extended memory, and the image does not carry it (§86.7) |
 
@@ -83222,7 +83237,13 @@ list of sector runs and nothing else.
 
 The **pointer**, `HIBERNAT.PTR`, is written beside it after the image, so a
 boot that finds no pointer finds no hibernation whatever else is on the disk
-— a write that failed half way leaves nothing to resume. It is 64 bytes of
+— a write that failed half way leaves nothing to resume. And the **old**
+pointer goes first: `hbm_hib` deletes both files (pointer, then image) before
+it writes a byte, because a pointer that outlived its question — the window
+closed by its box, or a boot that could not load the module to ask — would
+otherwise name the new image with the old session's wake address for as long
+as the new image's write took, and for good if the new pointer's write
+failed. It is 64 bytes of
 header and then the image's name; the path field is reserved and zero, and a
 pointer with a path in it is refused as another build's:
 
@@ -83257,17 +83278,20 @@ and **posts** `UI_RBQ_HIBER` in `[ui_rebootq]` — §20.10's deferral, for
 follows detaches drivers, which yields. `ui_task` spends the post at the top
 of its pass with nothing held, in `hb_perform`:
 
-1. `dsk_chdir` to the root of `[hb_vol]`.
-2. **Detach every loaded driver whose class is not `DRVC_DISK` or
+1. **Detach every loaded driver whose class is not `DRVC_DISK` or
    `DRVC_FILE`** (`drv_unload` per row: sound, the parallel link, the NIC),
    recording the rows in `[hb_drvmask]`. Their hardware state cannot cross a
    power cycle and their claims would be restored to addresses a fresh boot
    has given to somebody else; the disk driver and the RAM disk own no
    hardware the BIOS does not already own, and their state is memory.
-3. `gfx_lock`, and `inc [sch_lock]`: the image must be one instant of the
+2. `gfx_lock`, and `inc [sch_lock]`: the image must be one instant of the
    machine, so no other task runs while it is written. Interrupts stay on —
    int 13h needs them on an AT — and the tick, the mouse and the keyboard
    ISRs touch nothing the image cares about.
+3. `dsk_chdir` to the root of `[hb_vol]` — only now, because the detach
+   yields and a task that took the turn could have moved the current
+   directory — and `hbm_forget`: the old pointer and image are deleted before
+   a byte is written (§86.3).
 4. Bank `hb_perform`'s **entry** `SS:SP` and the far address of `hb_wake`.
    Everything above that SP — the dispatcher's return, the thunk's, the UI
    task's frame — is written into the image untouched, because the write
@@ -83275,11 +83299,13 @@ of its pass with nothing held, in `hb_perform`:
 5. The image, as one `dskw_write`. The progress widget (§12.8) is on the bar
    throughout, because the lock is held by the task that calls it.
 6. The pointer, in the root.
-7. `vid_reboot` to text mode, the sentence, `int 16h`, then `drv_shutdown`,
+7. The ROM's keyboard buffer emptied (a key typed during the write is not
+   the answer), `vid_reboot` to text mode, the sentence, `int 16h`, then `drv_shutdown`,
    `sched_unhook` and `int 19h` — the reboot path's tail (§20.10), so a key
    restarts the machine into the question below.
 
-A failure at 5 or 6 undoes 2–4 — the drivers are loaded again from the mask,
+A failure at 3, 5 or 6 undoes 1, 2 and 4 — the drivers are loaded again from the mask, the user's volume and folder
+put back (`drv_vol_bank`/`back`, as `hbm_arm` and a refused resume do),
 the lock and `sch_lock` released — and toasts `Hibernate failed`; the window
 goes back to `HB_M_ASK`.
 
@@ -83293,15 +83319,22 @@ treatment.
 ### 86.5 Resume — the probe, the question, the stub
 
 **The probe** (`hb_probe`, `.cold`, resident, from `kmain` after `drv_boot`
-and before the first paint) walks `dsk_vtab` for fixed volumes and looks in
-each one's root for `HIBERNAT.PTR`, inside a `drv_vol_bank`/`drv_vol_back`
-bracket (§51.5.2). A floppy-only machine pays eight compares. A hit records the
+and before the first paint) looks for `HIBERNAT.PTR` in the root of the ONE
+volume a hibernate writes to — `hb_pick`'s — inside a
+`drv_vol_bank`/`drv_vol_back` bracket (§51.5.2), and reaches it the way
+`drv_load` reaches a driver: a quiet navigation (§18.9, no listing and no
+icon harvest) and `drv_find`'s walk of the directory sectors rather than the
+snapshot. A floppy-only machine pays eight compares and no I/O; a machine
+with a hard disk pays one quiet mount of its root, which on a hard-disk boot
+is the root it is already standing in. A hit records the
 volume in `[hb_vol]` and posts `UI_RBQ_ASK`, which `ui_task`'s first pass
 spends — on the desktop, with nothing held — by loading the module and running
 `hb_ask`: read the pointer, validate it (§86.3), find `HIBERNAT.IMG` beside it
 and check its size against `[mem_top]`, ask the transport question (§86.2),
-and open the window in `HB_M_RESUME`. Any refusal is a toast and a deleted
-pointer.
+empty the ROM's keyboard buffer — a key held at the hibernate's own "press
+any key" repeats through `int 19h` into this boot, `ui_task`'s next step
+hands it to the front window, and `Esc` there is Discard — and open the
+window in `HB_M_RESUME`. Any refusal is a toast and a deleted pointer.
 
 **Resume** posts `UI_RBQ_RESUME`; `hb_perform` then:
 
@@ -83311,13 +83344,16 @@ pointer.
    partition's 32-bit base, sectors per track and heads.
 2. Walks the image's FAT chain into a list of **extents** — absolute LBA and
    sector count, contiguous clusters coalesced — in a 10KB `MEM_K_HIB` claim.
-3. `drv_shutdown` (the fresh boot's drivers go, as before any restart),
-   `gfx_lock`, `vid_reboot` to text mode.
-4. Copies the **stub**, its parameters, the fresh clock's twelve bytes and the
+3. `cp_flush_close` (the Control Panel's unsaved settings, §31.8), then
+   `drv_shutdown` (the fresh boot's drivers go) — `ui_cmd_reboot`'s order,
+   as before any restart — then `gfx_lock`, `vid_reboot` to text mode.
+4. Copies the **stub**, its parameters, the fresh clock's ten bytes and the
    extents into the text framebuffer — `B800:0000` on a colour primary,
    `B000:0000` on a Hercules — which is the one RAM on the machine that no
    rung of §2's ladder owns and every adapter has at least 16KB of. Puts the
-   BIOS's own int 08h vector back (`sch_old08`), masks IRQ 1, 3, 4 and 12 so no
+   BIOS's own int 08h vector back (`sch_old08`), masks IRQ 1, 3, 4 — and 12
+   on a machine that has a second 8259; an XT has none, and its port 0xA0 is
+   the NMI mask register, §9.9.2 — so no
    kernel ISR can run on a half-restored kernel, and far-jumps to the stub.
 
 **The stub** runs with `CS`, `DS` and `SS` in the framebuffer and reads every
@@ -83332,9 +83368,12 @@ written at all: it is the ROM's, and the ROM is the one thing that kept
 running. Then the PIC masks go back, `DS` becomes `KERNEL_SEG`, `SS:SP`
 becomes the banked frame, and a far jump lands in `hb_wake` — inside the
 image's copy of the module, at the segment the pointer recorded. A read that
-still fails after its retries prints one sentence through int 10h and waits
-for a key before `int 19h`: half a memory is not a machine, and the ROM's
-teletype is the only thing left that can be trusted to say so.
+still fails after its retries prints one sentence through int 10h — from row
+8 of the page down, over the IVT copy that is dead on that path, because rows
+0–2 of the same page *are* the stub and the teletype writes at the cursor the
+mode set homed — and waits for a key before `int 19h`: half a memory is not a
+machine, and the ROM's teletype is the only thing left that can be trusted to
+say so.
 
 ### 86.6 `hb_wake` — putting the machine back on its feet
 
@@ -83344,7 +83383,8 @@ still up from step 3 of §86.4 and the gfx lock still held:
 1. `sti`. The IVT is the image's, the PIT is in the kernel's mode 2 (the
    fresh boot's `sched_init` set it and nothing on the resume path unset it),
    and with `sch_lock` up the tick counts and switches nobody.
-2. The clock: the twelve bytes `clk_sec`..`clk_year` come out of the staging
+2. The clock: the ten bytes `clk_sec`..`clk_year` (not the two display
+   toggles after them, which are the image's) come out of the staging
    area, where step 4 put the fresh boot's — the RTC ladder is boot-overlay
    code (§37.90) and cannot be run again, so the boot that just happened is the
    clock's source. `clk_last` is re-seeded from `[ticks]`.
@@ -83353,7 +83393,9 @@ still up from step 3 of §86.4 and the gfx lock still held:
    empty, the read-ahead flushed, the write gate shut, the batch depths
    zeroed, `mem_pinseg` cleared and the progress widget given back with
    `fpg_end` — every one of them a word the write was in the middle of.
-4. `vid_setmode`, then the Hibernate window closed with `app_close_win`, then
+4. `vid_setmode`, then `[hb_mode]` = `HB_M_GONE` and the Hibernate window
+   closed with `app_close_win` — GONE first, so §86.1's hook leaves this
+   image, which is the code running, to the thunk — then
    `menu_force`, `dock_force`, `wm_paint_all` — `fsx_restore`'s return from a
    foreign mode (§53), which is what a text screen is. Before any disk work,
    so the widget the next step arms has a graphics mode to draw in.
@@ -83362,7 +83404,7 @@ still up from step 3 of §86.4 and the gfx lock still held:
    32MB disk is not nothing.
 6. The drivers in `[hb_drvmask]` are loaded again, in row order, exactly as
    `drv_boot` would have loaded them.
-7. `blk_wake`, `[hb_resumes]` += 1, `[hb_mode]` = `HB_M_GONE`, `gfx_unlock`,
+7. `blk_wake`, `[hb_resumes]` += 1, `gfx_unlock`,
    **`[sch_lock]` = 0** — set, not decremented: the image holds the count as
    the write left it, and `dsk_xfer` raises it around every int 13h, so it
    reads 2 and one down from that is a machine that never switches again
@@ -83383,10 +83425,13 @@ up the same way, and the resume path never calls `mouse_unhook`.
 Resident: the three strings, the template, the two file names, the kind row,
 five `.text` thunks and seven `cw_` shims, and in `.cold` the probe, the
 predicate, eleven far entries and the seven thunks that load the module —
-248 bytes of `.text`, 94 of `.bss` and 329 of `.cold`, which crossed both
-rungs; docs/KERNEL-MEMORY.md has the account. The module is `HIBER.DRV` on
-every system disk, 3,462 bytes, fourth in `mod_tab`, and the stub is ~300
-bytes of it.
+259 bytes of `.text`, 94 of `.bss` and 365 of `.cold`, which crossed both
+rungs; docs/KERNEL-MEMORY.md has the account. (The first cut was 248/94/329;
+the review's `app_close_win` hook and `hbf_closed`, the `DVK_FILE` test in
+three places, the keyboard drain and `drv_publish`'s exact-length copy are
+the rest.) The module is `HIBER.DRV` on
+every system disk, 3,515 bytes, fourth in `mod_tab`, and the stub is ~450 bytes of it,
+its one message included.
 
 Time on the 5150: the image is 1,280 sectors on a 640KB machine, and both the
 write and the read go out in track-sized runs, so it is ~80 int 13h calls
@@ -83412,10 +83457,12 @@ only `Enter` worked — watches the machine reach the text-mode sentence,
 presses a key, sees the question on the fresh desktop, clicks `Resume`, and
 then reads `[hb_resumes]`, the instance table, the two locks and the tick out
 of the guest: the About instance must be live with a visible window,
-`[sch_lock]` and the gfx lock must be down, the tick must advance, and
-`HIBERNAT.PTR` must be gone from the volume. A second pass goes through the
-keyboard and takes `Discard`, and asserts the opposite. The driver-backed shape — a floppy boot
+`[sch_lock]` and the gfx lock must be down, the tick must advance, and both
+`HIBERNAT.PTR` and `HIBERNAT.IMG` must be gone from the volume — read on the
+host by a FAT reader that is not the kernel's, after a positive control that
+the pointer was there once the text-mode sentence was up. A second pass goes
+through the keyboard and takes `Discard`, and asserts the opposite. The driver-backed shape — a floppy boot
 with a `SYSTEM.CFG` that wants `HDD.DRV`, the same VHD mounted through it —
 is the same script with `--driver`, registered as `hibernatedrv`. Both write
-four rendered screenshots to `build/hiber-*.png`; docs/TESTING.md has the
+three rendered screenshots to `build/hiber-*.png`; docs/TESTING.md has the
 recipe and what it cannot see.

--- a/apps/os88api.inc
+++ b/apps/os88api.inc
@@ -1138,6 +1138,7 @@ MEM_K_CLIP  equ 0xFF07          ; the system clipboard's text (SPEC.md 55)
 MEM_K_MOD   equ 0xFF08          ; an on-demand kernel module's image (SPEC.md 2.8)
 MEM_K_CLONE equ 0xFF09          ; the disk cloner's buffer (SPEC.md 18.99)
 MEM_K_BAND  equ 0xFF0A          ; the 1bpp band composer's buffer (SPEC.md 5.9.2)
+MEM_K_HIB   equ 0xFF0B          ; the resume's extent list (SPEC.md 86.5)
 ; 0xFF0B WAS MEM_K_OVL, the relocated boot overlay. It rides stage 2's blob
 ; now (SPEC.md 2.9.6) and is not a claim at all, so the tag is retired and
 ; LEFT UNUSED - a value that meant one thing in a shipped kernel and another

--- a/apps/os88api.inc
+++ b/apps/os88api.inc
@@ -1138,11 +1138,11 @@ MEM_K_CLIP  equ 0xFF07          ; the system clipboard's text (SPEC.md 55)
 MEM_K_MOD   equ 0xFF08          ; an on-demand kernel module's image (SPEC.md 2.8)
 MEM_K_CLONE equ 0xFF09          ; the disk cloner's buffer (SPEC.md 18.99)
 MEM_K_BAND  equ 0xFF0A          ; the 1bpp band composer's buffer (SPEC.md 5.9.2)
-MEM_K_HIB   equ 0xFF0B          ; the resume's extent list (SPEC.md 86.5)
 ; 0xFF0B WAS MEM_K_OVL, the relocated boot overlay. It rides stage 2's blob
 ; now (SPEC.md 2.9.6) and is not a claim at all, so the tag is retired and
 ; LEFT UNUSED - a value that meant one thing in a shipped kernel and another
 ; in the next is a collision a debug read cannot see.
+MEM_K_HIB   equ 0xFF0C          ; the resume's extent list (SPEC.md 86.5)
 
 MEM_PG_TRIV equ 0xFB            ; the purge tiers (SPEC.md 50.6.4), low to
 MEM_PG_LOW  equ 0xFC            ; high: what LOSING the block costs, which is

--- a/apps/taskmgr/taskmgr.asm
+++ b/apps/taskmgr/taskmgr.asm
@@ -1105,6 +1105,8 @@ tm_s_tclon: db 'Cloner', 0      ; the job block AND the sectors in flight,
                                 ; which is why freeing it is the whole of a
                                 ; clone's teardown (SPEC.md 18.99)
 tm_s_tband: db 'BandBuf', 0     ; the 1bpp composer's, one per machine (5.9.2)
+tm_s_thib:  db 'Resume', 0      ; the resume's extent list (SPEC.md 86.5), alive
+                                ; only on the way into the stub
 ; (owner word, name) pairs, ended by a 0 owner. MEM_P_WSAVE is NOT here: it is
 ; a RANGE (SPEC.md 11.96.3), one cache per window slot, and tm_htype tests it
 ; before it walks this.
@@ -1127,6 +1129,7 @@ tm_ktab:
     dw MEM_K_MOD,   tm_s_tmod
     dw MEM_K_CLONE, tm_s_tclon
     dw MEM_K_BAND,  tm_s_tband
+    dw MEM_K_HIB,   tm_s_thib
     dw MEM_P_DIRW,  tm_s_tdirw
     dw 0
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -396,6 +396,7 @@ The tree's own worked examples. When a convention is unclear, the shortest packa
 | 83 | Text input for packages (`apps/os88line.inc`, `apps/os88text.inc`) |
 | 84 | Software floating point (`apps/os88fp.inc`) |
 | 85 | TANK ATTACK — a wireframe tank duel in a foreign mode (`apps/tank/`) |
+| 86 | Hibernate — the machine to a file on the hard disk, and back (`kernel/hiber.inc`, `HIBER.DRV`) |
 
 ## docs/
 

--- a/docs/KERNEL-MEMORY.md
+++ b/docs/KERNEL-MEMORY.md
@@ -2228,6 +2228,24 @@ thunks rather than through the window record.
 more except doing less. There is one precedent for doing less, and it is the
 Task Manager.
 
+> **The fourth MODULE, and the first feature to cross two rungs for a
+> feature the kernel does not carry: HIBERNATE (SPEC.md §86).** `HIBER.DRV`
+> is 3,462 bytes on the system disk and 0 resident. What the kernel spends
+> is **248 bytes of `.text`, 94 of `.bss` and 329 of `.cold`** — three menu
+> strings, a window template, a title and two file names, a kind row, five
+> `.text` thunks and seven `cw_` shims; the state block the image carries;
+> and in `.cold` the boot probe, the greying predicate, eleven far entries
+> and the seven thunks that load the module — against rungs that had 96
+> (image) and 157 (`.cold`) left. So both crossed: `KERN_SIZE` 120,320 →
+> **121,344**, spare under `KERN_BUDGET` 9,216 → **8,192** (16 steps). The
+> `.bss` is the part worth a second look: a button label and its rect are
+> staged there because the button drawer reads through `DS`, and a module's
+> own bytes are not `DS` — the pointer file's 80-byte buffer and every
+> string went into the module for the same reason in reverse. It was 141
+> while a file dialog chose the image's place; the path it needed went with
+> the dialog. Nothing was reclaimed to pay for it; the two steps are spent
+> out of the spare, which is what the spare is for.
+>
 > **A THIRD lever, and the third thing has gone through it: an OVERLAY.**
 > SPEC.md §79's animated screen saver ships as `SAVER.DRV`, 10,064 bytes,
 > `DRVC_OVL` like `XMEM.DRV` and `HDDTOOL.DRV` (SPEC.md §41.12, §52.11). It is

--- a/docs/KERNEL-MEMORY.md
+++ b/docs/KERNEL-MEMORY.md
@@ -897,32 +897,32 @@ Three things about it:
   "big": {
     "boot2": 2498,
     "bootmax": 189952,
-    "bss": 5955,
+    "bss": 6049,
     "budget": 129536,
     "codemax": 65536,
-    "cold": 40803,
-    "coldpara": 2560,
+    "cold": 41168,
+    "coldpara": 2592,
     "fatpara": 288,
-    "imgpara": 3968,
-    "kend": 7616,
+    "imgpara": 4000,
+    "kend": 7680,
     "kseg": 96,
-    "ksize": 120320,
+    "ksize": 121344,
     "lowbss": 8982,
     "lowpara": 640,
     "minramkb": 196,
     "ovl": 3969,
     "stk0": 1024,
-    "text": 57437,
+    "text": 57696,
     "vgabuf": 848,
     "vgabufpara": 64
   },
   "small": {
     "boot2": 2498,
     "bootmax": 120320,
-    "bss": 5442,
+    "bss": 5484,
     "budget": 107520,
     "codemax": 65536,
-    "cold": 37889,
+    "cold": 37900,
     "coldpara": 2400,
     "fatpara": 288,
     "imgpara": 3392,
@@ -934,7 +934,7 @@ Three things about it:
     "minramkb": 128,
     "ovl": 3886,
     "stk0": 1024,
-    "text": 48660,
+    "text": 48678,
     "vgabuf": 0,
     "vgabufpara": 0
   }
@@ -1748,14 +1748,14 @@ generated in the first place.
 <!-- kernsize:themes -->
 | theme | bytes | share |
 |---|---:|---:|
-| the file system, end to end | 33,628 | 34.2% |
-| the window system and its furniture | 26,240 | 26.7% |
-| drawing: adapters, primitives, glyphs, icons | 17,048 | 17.4% |
-| hardware: drivers, clock, mouse, sound, CPU, XMS | 10,119 | 10.3% |
-| the kernel proper: API table, heap, scheduler, events | 8,288 | 8.4% |
+| the file system, end to end | 33,628 | 34.0% |
+| the window system and its furniture | 26,366 | 26.7% |
+| drawing: adapters, primitives, glyphs, icons | 17,048 | 17.2% |
+| hardware: drivers, clock, mouse, sound, CPU, XMS | 10,562 | 10.7% |
+| the kernel proper: API table, heap, scheduler, events | 8,343 | 8.4% |
 | the three built-in kinds | 1,843 | 1.9% |
 | the Control Panel | 1,074 | 1.1% |
-| **total** | **98,240** | |
+| **total** | **98,864** | |
 <!-- /kernsize:themes -->
 
 <!-- BEGIN generated table -->
@@ -1768,12 +1768,12 @@ generated in the first place.
 | `fdlg.inc` — the Standard File dialog (§38) | 274 | 5,323 | **5,597** | 169 | — | — |
 | `diskw.inc` — the FAT write path (§18.4–18.6) | 179 | 5,067 | **5,246** | 155 | — | — |
 | `mouse.inc` — serial mouse and the cursor (§9) | 4,828 | — | **4,828** | 149 | — | — |
-| `ui.inc` — the UI task and the event ladder (§13) | 3,516 | — | **3,516** | 58 | — | — |
-| `menu.inc` — the menu bar and pull-downs (§12) | 3,086 | — | **3,086** | 197 | 98 | — |
-| `driver.inc` — loadable drivers + `SYSTEM.CFG` (§51) | 543 | 2,491 | **3,034** | 348 | — | — |
+| `ui.inc` — the UI task and the event ladder (§13) | 3,562 | — | **3,562** | 58 | — | — |
+| `menu.inc` — the menu bar and pull-downs (§12) | 3,139 | — | **3,139** | 197 | 98 | — |
+| `driver.inc` — loadable drivers + `SYSTEM.CFG` (§51) | 543 | 2,498 | **3,041** | 358 | — | — |
 | `assoc.inc` — file type associations (§54) | 528 | 2,415 | **2,943** | 43 | — | — |
 | `memory.inc` — the claim heap (§50) | 20 | 2,765 | **2,785** | 20 | 324 | — |
-| `instance.inc` — instances and the built-in kinds (§29) | 2,452 | — | **2,452** | 694 | — | — |
+| `instance.inc` — instances and the built-in kinds (§29) | 2,479 | — | **2,479** | 694 | — | — |
 | `filecp.inc` — Cut/Copy/Paste (§22.3–22.5) | — | 2,440 | **2,440** | 148 | — | — |
 | `font.inc` — the 8×8 glyph renderer (§6) | 2,167 | — | **2,167** | 218 | 768 | — |
 | `apps.inc` — the three built-in kinds (§14) | 279 | 1,564 | **1,843** | 15 | 240 | — |
@@ -1791,8 +1791,9 @@ generated in the first place.
 | `fprog.inc` — the file-operation progress widget (§12.8) | 682 | — | **682** | — | — | — |
 | `clock.inc` — the clock ladder (§37) | 678 | — | **678** | 89 | — | — |
 | `toast.inc` — the menu bar's transient message (§59) | 537 | — | **537** | 25 | — | — |
-| `mod.inc` — on-demand kernel modules (§2.8) | 54 | 416 | **470** | 98 | — | — |
+| `mod.inc` — on-demand kernel modules (§2.8) | 72 | 420 | **492** | 130 | — | — |
 | `blank.inc` — the idle screen blanker (§64) | 208 | 240 | **448** | — | — | — |
+| `hiber.inc` — **(undescribed)** | 82 | 354 | **436** | 52 | — | — |
 | `xmem.inc` — memory above 1MB (§41.4–41.5) | 263 | 104 | **367** | 22 | — | — |
 | `clip.inc` — the system clipboard (§55) | 229 | — | **229** | 6 | — | — |
 | `events.inc` — the event ring (§10) | 173 | — | **173** | 134 | — | — |
@@ -1802,8 +1803,8 @@ generated in the first place.
 | `band.inc` — the 1bpp band composer (§5.9), `BAND=1` | — | — | **0** | — | — | — |
 | `bootprof.inc` — the boot phase table (§15.5), `BOOTPROF=1` | — | — | **0** | — | — | — |
 | `moudiag.inc` — what the identify window saw (§9.4.6), `MOUDIAG=1` | — | — | **0** | — | — | — |
-| `kernel.asm` — API table, entry points, `kmain`, the shims | 3,583 | — | **3,583** | — | — | 468 |
-| **total** | **57,437** | **40,803** | **98,240** | **5,955** | **8,982** | **2,498** |
+| `kernel.asm` — API table, entry points, `kmain`, the shims | 3,616 | — | **3,616** | — | — | 468 |
+| **total** | **57,696** | **41,168** | **98,864** | **6,049** | **8,982** | **2,498** |
 <!-- END generated table -->
 
 ### Reading it
@@ -2230,8 +2231,8 @@ Task Manager.
 
 > **The fourth MODULE, and the first feature to cross two rungs for a
 > feature the kernel does not carry: HIBERNATE (SPEC.md §86).** `HIBER.DRV`
-> is 3,462 bytes on the system disk and 0 resident. What the kernel spends
-> is **248 bytes of `.text`, 94 of `.bss` and 329 of `.cold`** — three menu
+> is 3,515 bytes on the system disk and 0 resident. What the kernel spends
+> is **259 bytes of `.text`, 94 of `.bss` and 365 of `.cold`** — three menu
 > strings, a window template, a title and two file names, a kind row, five
 > `.text` thunks and seven `cw_` shims; the state block the image carries;
 > and in `.cold` the boot probe, the greying predicate, eleven far entries

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1049,6 +1049,36 @@ for n,a,c,sz in ents(v):
 EOF
 ```
 
+### Hibernate and resume (SPEC.md §86)
+
+```sh
+python3 tests/hibernate.py            # the boot partition, DVK_BIOS
+python3 tests/hibernate.py --driver   # ...and the same VHD through HDD.DRV
+```
+
+Both on `os8088_xt_hdd`, both building their own fixture volume with
+`tools/os88hdd.py` (`HIBER.DRV`, `CTRL.DRV` and `HDD.DRV` in its root) under
+`build/`, and the second one a 360KB floppy whose `SYSTEM.CFG` wants the
+driver, the `ethertest` shape. Each opens an About box as the witness, picks
+`Hibernate...` from the System menu (item 4: `mo.menu(8, 8, 8, 88)`), takes the
+window's first button - with the MOUSE on the first pass, `Enter` on the
+second, because the two are different code paths and the mouse one shipped
+broken once - waits for the ROM's text mode (`os88marty.video_is_text`),
+restarts with a key, and answers the question the same two ways: a click on
+`Resume`, `Esc` to discard. **The assertions
+are memory reads, not pixels**: `[hb_mode]`, `[hb_resumes]`, the instance
+table (the About box must be live with a visible window after a resume and
+absent after a discard), `[sch_lock]` and `[gfx_lock_flag]` back to 0, the
+tick advancing, and `HIBERNAT.PTR` gone from the VHD, read on the host with
+`tests/instdeep.py`'s FAT reader. Four rendered screenshots land in
+`build/hiber-*.png` for the eye. It ERASES `build/hiber.vhd` every run.
+
+**What it cannot see**: time (MartyPC is not disk-accurate), a VGA desktop
+coming back with its palette (the machine is CGA), and IDE rung 1, which the
+stub refuses by design - QEMU's `HDD=` disk is SeaBIOS int 13h and would pass
+the same way; `make test HDD=40` and the Control Panel are how to look at it
+by hand there.
+
 **Persistence: EVERYTHING needs the panel closed first.** Nothing on this page
 writes `SYSTEM.CFG` from a click any more - not the geometry editor, and since
 SPEC.md 51.9's verb 2 was retired not Mount and Unmount either. All of it is

--- a/drivers/hdd/hdd.asm
+++ b/drivers/hdd/hdd.asm
@@ -678,6 +678,38 @@ hd_bn_hit:
 %endif
 
 ; -----------------------------------------------------------------------------
+; hd_geom - DSV_GEOM (SPEC.md 51.8, 86.5)
+; in:  AH = our volume handle
+; out: CF = 0 and DL = the int 13h drive, CX:BX = the partition's first LBA,
+;      SI = sectors per track, DI = heads; CF = 1 no such volume, or a device
+;      on rung 1 (the task file), which the ROM cannot read for the caller
+; clobbers: the outputs, flags
+; -----------------------------------------------------------------------------
+hd_geom:
+    push ax
+    mov al, ah
+    call hd_vol_row             ; BX = the volume row
+    jc .no
+    mov si, bx
+    mov al, [si+HDV_DEV]
+    call hd_dev_row             ; DI = its device
+    cmp byte [di+HDD_KIND], HDK_BIOS
+    jne .no
+    mov dl, [di+HDD_UNIT]
+    mov bx, [si+HDV_BASE]
+    mov cx, [si+HDV_BASE+2]
+    mov ax, [di+HDD_SPT]
+    mov di, [di+HDD_HEADS]
+    mov si, ax
+    pop ax
+    clc
+    ret
+.no:
+    pop ax
+    stc
+    ret
+
+; -----------------------------------------------------------------------------
 ; hd_vol_row - a volume handle's row
 ; in:  AL = handle (0..HD_MAXVOL-1)
 ; out: CF = 0 and BX = the row (live); CF = 1 otherwise
@@ -1310,6 +1342,9 @@ hd_services:
     dw hd_page_up               ; DSV_CPUP    - the page acts on the RELEASE
     dw hd_page_drag             ; DSV_CPDRAG  - ...and follows the pointer
                                 ;               between the edges (13.8.4)
+    dw 0                        ; DSV_PKGCALL - no package reaches a raw sector
+    dw hd_geom                  ; DSV_GEOM    - the transport facts (SPEC.md
+                                ;               86.5), for the resume stub
     times DSV_SIZE - ($ - hd_services) db 0
                                 ; drv_publish copies DSV_SIZE bytes
                                 ; whatever this table's length is, so

--- a/drivers/os88drv.inc
+++ b/drivers/os88drv.inc
@@ -282,7 +282,19 @@ DSV_PKGCALL  equ 34             ; dw: near proc reached by OSAPI_DRV_CALL -
                                 ; no lock and raises no sch_lock, so a verb of
                                 ; yours is callable from a package's worker
                                 ; only if what it does is. Say so per verb.
-DSV_SIZE     equ 36
+DSV_GEOM     equ 36             ; dw: near proc, DRVC_DISK only (SPEC.md 51.8,
+                                ; 86.5): the TRANSPORT FACTS of one volume,
+                                ; for a caller that has to reach its sectors
+                                ; without you - the resume stub, which runs
+                                ; after every driver has been detached.
+                                ;   in  AH = your volume handle
+                                ;   out CF = 0: DL = the int 13h drive,
+                                ;       CX:BX = the partition's first LBA,
+                                ;       SI = sectors per track, DI = heads;
+                                ;       CF = 1: no such volume, or one the
+                                ;       ROM's int 13h does not reach (52.1's
+                                ;       rung 1). 0 = never, which is CF = 1
+DSV_SIZE     equ 38
 
 ; --- DSV_FS: the file redirector's verbs (SPEC.md 62.9) ----------------------
 ; A DRVC_FILE volume has NO SECTORS - no BPB, no FAT, no directory to walk -

--- a/kernel/driver.inc
+++ b/kernel/driver.inc
@@ -2805,25 +2805,27 @@ drv_publish:
     mov al, [bx+DRVR_CLASS]
     call drv_cls_svc_x            ; DI = this CLASS's copy, not the one copy
     jc .out
-    mov cx, DSV_SIZE / 2        ; ...AS FAR AS THE DRIVER'S TABLE REACHES
-                                ; (SPEC.md 51.2), which is DRV_H_FSV's test one
-                                ; level up: the header says how long a table it
-                                ; was built with, a LONGER one still means
-                                ; these cells, and anything shorter - 0 is a
-                                ; driver written before the byte existed - has
-                                ; only DSV_TAB0 of them. The rest are published
-                                ; as 0, so every consumer's `or bp, bp / jz`
-                                ; refuses them as unpublished instead of
-                                ; far-calling the name string a released driver
-                                ; keeps directly after its table
-    cmp byte [es:DRV_H_DSV], DSV_SIZE
-    jae .copy
-    mov cx, DSV_TAB0 / 2
-    xor ax, ax
-    mov [di+DSV_CPKEY], ax
-    mov [di+DSV_CPUP], ax
-    mov [di+DSV_CPDRAG], ax
-    mov [di+DSV_PKGCALL], ax
+    push di                     ; every cell is published as 0 FIRST, so a
+    xor ax, ax                  ; cell the driver's table stops short of is
+    mov cx, DSV_SIZE / 2        ; refused by every consumer's `or bp, bp / jz`
+.zero:                          ; instead of far-calling the name string a
+    mov [di], ax                ; released driver keeps directly after it
+    inc di
+    inc di
+    loop .zero
+    pop di
+    mov cl, [es:DRV_H_DSV]      ; ...then AS FAR AS THE DRIVER'S TABLE REACHES
+    or cl, cl                   ; (SPEC.md 51.2), which is DRV_H_FSV's test one
+    jnz .len                    ; level up: the header says how long a table it
+    mov cl, DSV_TAB0            ; was built with; 0 is a driver written before
+.len:                           ; the byte existed and means DSV_TAB0. EXACTLY
+    cmp cl, DSV_SIZE            ; that many, not "all or DSV_TAB0": when
+    jbe .fit                    ; DSV_GEOM took DSV_SIZE 36 -> 38 every released
+    mov cl, DSV_SIZE            ; driver became "shorter" and the old two-way
+.fit:                           ; test threw its four newest cells away - the
+    xor ch, ch                  ; Control Panel page's and DSV_PKGCALL, which
+    shr cx, 1                   ; for ETHER.DRV is the whole socket surface.
+                                ; A LONGER table still means these cells
 .copy:
     mov ax, [es:si]
     mov [di], ax

--- a/kernel/driver.inc
+++ b/kernel/driver.inc
@@ -310,7 +310,15 @@ DSV_PKGCALL equ 34              ; dw: THE FENCE for OSAPI_DRV_CALL. A driver
                                 ; a package could name DRVC_DISK and arrive at
                                 ; DSV_BLK, which is a raw sector write to the
                                 ; hard disk from any .O88 on the floppy
-DSV_SIZE    equ 36              ; ...and it must stay EVEN: drv_publish copies
+DSV_GEOM    equ 36              ; dw: DRVC_DISK only - one volume's TRANSPORT
+                                ; FACTS (SPEC.md 51.8, 86.5): in AH = the
+                                ; driver's handle; out CF = 0 and DL = the
+                                ; int 13h drive, CX:BX = the partition's first
+                                ; LBA, SI = sectors per track, DI = heads; or
+                                ; CF = 1 for a volume the ROM does not reach.
+                                ; For the resume stub, which runs after every
+                                ; driver has been detached and speaks CHS
+DSV_SIZE    equ 38              ; ...and it must stay EVEN: drv_publish copies
                                 ; the table DSV_SIZE/2 WORDS at a time
 DSV_TAB0    equ 28              ; ...and the length every driver that carries 0
                                 ; at DRV_H_DSV has: the table stood at 28 until

--- a/kernel/hiber.inc
+++ b/kernel/hiber.inc
@@ -14,8 +14,8 @@
 ; entries, and the thunks that load the module before calling into it -
 ; cpf_cp_paint's shape (SPEC.md 2.8).
 ;
-; EVERYTHING ELSE IS HIBER.DRV, MOD_HIBER: the window, the file dialog's
-; completion, the write, the boot-time question, the extent walk, the stub
+; EVERYTHING ELSE IS HIBER.DRV, MOD_HIBER: the window, the write, the
+; boot-time question, the extent walk, the stub
 ; that puts memory back, and the routine that wakes the restored kernel. It
 ; is .cold code with the address changed (SPEC.md 2.8): CS = its own claim,
 ; DS = KERNEL_SEG, every kernel address the one this assembly gave it, and
@@ -84,12 +84,15 @@ HS_SP       equ 0x040A          ; ...and SP
 HS_WAKE     equ 0x040C          ; dd hbm_wake, off:seg
 HS_MASKM    equ 0x0410          ; db the master PIC's mask before the stub
 HS_MASKS    equ 0x0411          ; db ...and the slave's
-HS_CLK      equ 0x0412          ; db[12] clk_sec..clk_year of the fresh boot
+HS_CLK      equ 0x0412          ; db[10] clk_sec..clk_year of the fresh boot
 HS_LBA      equ 0x0420          ; dd the run's first LBA (scratch)
 HS_LEFT     equ 0x0424          ; dw sectors left in this extent
 HS_K        equ 0x0426          ; dw the file sector index = linear / 512
 HS_N        equ 0x0428          ; dw sectors in the call being issued
 HS_CHS      equ 0x042A          ; dw CX, dw DX as int 13h wants them
+HS_SLAVE    equ 0x042E          ; db 1 = there is a second 8259 to mask and
+                                ; put back; 0 on an XT, whose port 0xA0 is
+                                ; the NMI mask register (SPEC.md 9.9.2)
 HS_IVT      equ 0x0500          ; db[1024] file sectors 0..1, the IVT
 HS_EXT      equ 0x0A00          ; {dd lba, dw count, dw 0} x HS_XMAX
 HS_XMAX     equ 1280            ; one per sector of a 640KB image at worst
@@ -153,49 +156,86 @@ section .cold
 ; out: nothing (all registers preserved). A hit records the volume in [hb_vol]
 ;      and posts UI_RBQ_ASK, which ui_task's first pass spends.
 ;
-; Every FIXED volume's root, in a drv_vol_bank/back bracket (SPEC.md 51.5.2)
-; so the machine is left standing where drv_boot left it. A floppy-only
-; machine pays eight compares and no I/O.
+; The ONE root a pointer can be in - hb_pick's volume, the one a hibernate
+; writes to - in a drv_vol_bank/back bracket (SPEC.md 51.5.2) so the machine
+; is left standing where drv_boot left it, and reached the way drv_load
+; reaches a driver: a QUIET navigation (18.9: no listing, no icon harvest)
+; and a walk of the directory sectors, not the snapshot. A floppy-only
+; machine pays eight compares and no I/O; a machine with a hard disk pays
+; one quiet mount of its root.
 ; -----------------------------------------------------------------------------
 hb_probe_x:
     push ax
-    push bx
-    push cx
     push dx
     push si
     mov byte [hb_mode], HB_M_GONE   ; .bss is whatever the LAST kernel left
     mov word [hb_resumes], 0    ; (a warm boot clears nothing), and two of
     mov word [hb_xseg], 0       ; these are read before anything writes them
+    call COLD_SEG:hb_pick_x     ; AL = the volume
+    jc .out
+    mov [hb_vol], al
     call drv_vol_bank
+    mov dl, al
+    xor ax, ax                  ; the root
+    call dsk_chdir_q_x
+    jc .back
+    mov si, hb_s_ptr
+    call drv_find               ; the directory sectors themselves
+    jc .back
+    mov byte [ui_rebootq], UI_RBQ_ASK
+.back:
+    call drv_vol_back
+.out:
+    pop si
+    pop dx
+    pop ax
+    retf
+
+; -----------------------------------------------------------------------------
+; hb_pick - the disk a hibernation goes to, or is looked for on (SPEC.md 86.2):
+;           the one the machine BOOTED from when that is a fixed disk, else
+;           the first fixed volume there is - and never a DVK_FILE row, which
+;           dsk_vol_fixed calls fixed and which has no sectors the stub could
+;           read. THE predicate: the menu item, the probe and the window all
+;           ask it, so what greys, what is probed and what is written to
+;           cannot disagree (SPEC.md 47 rule 5)
+; in:  nothing
+; out: CF = 0 and AL = its index; CF = 1 no such volume
+; clobbers: AX (the output), flags
+; -----------------------------------------------------------------------------
+hb_pick_x:
+    push bx
+    push cx
+    mov cl, [dsk_bootvol]
+    call hb_pick1
+    jnc .out
     xor cx, cx
 .vol:
-    mov bl, cl
-    call dsk_vol_fixed_x        ; AL = 1 fixed; CF = no such row
-    jc .next
-    or al, al
-    jz .next
-    mov dl, cl
-    xor ax, ax                  ; the root
-    call dsk_chdir_x
-    jc .next
-    mov si, hb_s_ptr
-    call dsk_find_name_x        ; no I/O: the snapshot the mount just built
-    jc .next
-    mov [hb_vol], cl
-    mov byte [ui_rebootq], UI_RBQ_ASK
-    jmp short .out
-.next:
+    call hb_pick1
+    jnc .out
     inc cx
     cmp cx, DVOL_MAX
     jb .vol
+    stc
 .out:
-    call drv_vol_back
-    pop si
-    pop dx
     pop cx
     pop bx
-    pop ax
     retf
+
+hb_pick1:                       ; is volume CL one? out: CF = 0 and AL = CL
+    mov bl, cl
+    call dsk_vol_fixed_x        ; AL = 1 fixed, AH = the kind; CF = no row
+    jc .no
+    or al, al
+    jz .no
+    cmp ah, DVK_FILE
+    je .no
+    mov al, cl
+    clc
+    ret
+.no:
+    stc
+    ret
 
 ; -----------------------------------------------------------------------------
 ; hb_ok - may the machine hibernate? (SPEC.md 86.2, 47 rule 5)
@@ -203,27 +243,14 @@ hb_probe_x:
 ; out: CF = 0 yes; CF = 1 and AL = 1 no fixed volume / 2 extended memory held
 ; clobbers: AL (the output), flags
 ;
-; Called on the press that opens the menu bar, so it is eight row tests and
-; one far call into a table - no I/O, no probe.
+; Called on the press that opens the menu bar, so it is at most eight row
+; tests and one far call into a table - no I/O, no probe.
 ; -----------------------------------------------------------------------------
 hb_ok_x:
     push bx
-    push cx
-    push dx
-    xor cx, cx
-.vol:
-    mov bl, cl
-    call dsk_vol_fixed_x
-    jc .next
-    or al, al
-    jnz .hd
-.next:
-    inc cx
-    cmp cx, DVOL_MAX
-    jb .vol
+    call COLD_SEG:hb_pick_x     ; the volume a hibernate would go to
     mov al, 1
-    jmp short .no
-.hd:
+    jc .no
     call KERNEL_SEG:HB_API_XCAPS    ; BL = free block-table entries; on a
     cmp bl, XM_MAX_BLKS         ; machine with no store, all of them
     jb .xms
@@ -234,8 +261,6 @@ hb_ok_x:
 .no:
     stc
 .out:
-    pop dx
-    pop cx
     pop bx
     retf
 
@@ -250,8 +275,6 @@ hbk_dsk_get_dir:    call dsk_get_dir_x
 hbk_dsk_clus2lba:   call dsk_clus2lba_x
                     retf
 hbk_dsk_next_clus:  call dsk_next_clus_x
-                    retf
-hbk_dsk_vol_fixed:  call dsk_vol_fixed_x
                     retf
 hbk_dsk_fatw_drop:  call dsk_fatw_drop
                     retf
@@ -377,6 +400,24 @@ hbf_dropck:
     pop ax
 .out:
     ret
+
+; hbf_closed - app_close_win's KIND_HIBER hook (SPEC.md 86.1): the window went
+;              by a route the module did not take - the close box, Close
+;              Window, the Task Manager, the restart sweep - so nothing of the
+;              module is on the stack and the image can go now. The module's
+;              own closes set HB_M_GONE FIRST, and that is the test: a GONE
+;              window is the module closing itself, and hbf_dropck drops the
+;              image once it has returned
+hbf_closed:
+    cmp byte [hb_mode], HB_M_GONE
+    je .out
+    mov byte [hb_mode], HB_M_GONE
+    push ax
+    mov al, MOD_HIBER
+    call mod_drop
+    pop ax
+.out:
+    retf
 
 ; =============================================================================
 ; THE MODULE - HIBER.DRV (SPEC.md 2.8, 86)
@@ -842,9 +883,12 @@ hbm_act:
     call hbm_forget             ; the pointer and the image go
     call COLD_SEG:drvf_drv_vol_back
 .close:
-    mov bx, si
-    call KERNEL_SEG:cw_app_close_win    ; synchronous: task-less kind
-    mov byte [hb_mode], HB_M_GONE       ; ...and the thunk drops the image
+    mov byte [hb_mode], HB_M_GONE       ; BEFORE the close: app_close_win's
+    mov bx, si                          ; KIND_HIBER hook drops the image on
+    call KERNEL_SEG:cw_app_close_win    ; every OTHER route (SPEC.md 86.1), and
+                                        ; GONE is how it knows this is not one.
+                                        ; Synchronous: task-less kind; the
+                                        ; thunk drops the image on the way back
 .out:
     pop di
     pop si
@@ -855,7 +899,8 @@ hbm_act:
     ret
 
 ; -----------------------------------------------------------------------------
-; hbm_forget - delete the pointer and the image (SPEC.md 86.6 step 5)
+; hbm_forget - delete the pointer and the image (SPEC.md 86.6 step 5, and
+;              86.4 step 3, before a new pair is written)
 ; in:  [hb_vol] = the volume; both files are in its root
 ; out: nothing (all registers preserved); failures are ignored - there is
 ;      nothing further to do about a file that is already gone. The volume is
@@ -870,9 +915,9 @@ hbm_forget:
     xor ax, ax                  ; both live in the root (SPEC.md 86.3)
     call COLD_SEG:hbk_dsk_chdir
     jc .out
-    mov si, hb_s_img
-    call COLD_SEG:dwf_dskw_delete
-    mov si, hb_s_ptr
+    mov si, hb_s_ptr            ; the pointer FIRST: with it gone there is
+    call COLD_SEG:dwf_dskw_delete   ; nothing to resume whatever becomes of
+    mov si, hb_s_img            ; the image (SPEC.md 86.3)
     call COLD_SEG:dwf_dskw_delete
 .out:
     pop si
@@ -895,43 +940,6 @@ hbm_kinit:
     pop ax
     ret
 
-; hbm_pickvol - the disk the image goes to (SPEC.md 86.2): the one the
-;               machine BOOTED from when that is a fixed disk, else the first
-;               fixed volume there is
-; out: CF = 0 and AL = its index; CF = 1 no fixed volume
-hbm_pickvol:
-    push bx
-    push cx
-    mov cl, [dsk_bootvol]
-    mov bl, cl
-    call COLD_SEG:hbk_dsk_vol_fixed
-    jc .scan
-    or al, al
-    jz .scan
-    mov al, cl
-    clc
-    jmp short .out
-.scan:
-    xor cx, cx
-.vol:
-    mov bl, cl
-    call COLD_SEG:hbk_dsk_vol_fixed
-    jc .next
-    or al, al
-    jz .next
-    mov al, cl
-    clc
-    jmp short .out
-.next:
-    inc cx
-    cmp cx, DVOL_MAX
-    jb .vol
-    stc
-.out:
-    pop cx
-    pop bx
-    ret
-
 ; -----------------------------------------------------------------------------
 ; hbm_open - the System menu's Hibernate... (SPEC.md 86.1): open the window
 ; in:  nothing; UI task, no lock
@@ -942,8 +950,8 @@ hbm_open:
     push si
     call hbm_win                ; already up, in whatever mode: app_launch
     jnc .launch                 ; fronts it and the mode stays what it is
-    call hbm_pickvol            ; the item was live, so there is one
-    jc .out
+    call COLD_SEG:hb_pick_x     ; the disk (SPEC.md 86.2): the item was
+    jc .out                     ; live, so there is one
     mov [hb_vol], al            ; ...and the window names it
     mov byte [hb_mode], HB_M_ASK
     mov byte [hb_down], 0
@@ -1055,9 +1063,9 @@ hbm_arm:
     mov dl, [hb_vol]
     xor ax, ax
     call COLD_SEG:hbk_dsk_chdir ; the root: where the image goes, and where
-    jc .noroom                  ; dfree answers for
+    jc .failed                  ; dfree answers for
     call COLD_SEG:dwf_dskw_dfree    ; DX:AX = free bytes
-    jc .noroom
+    jc .failed
     push ax
     push dx
     push si
@@ -1102,8 +1110,11 @@ hbm_arm:
 .nobios:
     mov si, hbm_s_nobios
     jmp short .refuse
-.noroom:
-    mov si, hbm_s_noroom
+.failed:
+    mov si, hbm_s_failed        ; the disk could not be read, which is not
+    jmp short .refuse           ; "no room" (LESSONS: the right refusal with
+.noroom:                        ; the wrong reason sends the user deleting
+    mov si, hbm_s_noroom        ; files that were never the problem)
 .refuse:
     call hbm_toast
     call COLD_SEG:drvf_drv_vol_back
@@ -1135,13 +1146,19 @@ hbm_perform:
 
 ; --- hbm_hib: write the image and stop (SPEC.md 86.4) ------------------------
 hbm_hib:
-    mov dl, [hb_vol]
-    xor ax, ax
-    call COLD_SEG:hbk_dsk_chdir ; 1. the root of the disk the boot picked
-    jc .fail0
-    call hbm_detach             ; 2. the hardware drivers go, and are noted
-    call KERNEL_SEG:cw_gfx_lock ; 3. held from here: the machine is one
-    inc byte [sch_lock]         ;    instant from here on
+    call COLD_SEG:drvf_drv_vol_bank ; where the user stands, for a refusal
+    call hbm_detach             ; 1. the hardware drivers go, and are noted
+    call KERNEL_SEG:cw_gfx_lock ; 2. held from here: the machine is one
+    inc byte [sch_lock]         ;    instant from here on - and only NOW
+    mov dl, [hb_vol]            ; 3. the root of the disk the boot picked:
+    xor ax, ax                  ;    the detach yields, and a task that took
+    call COLD_SEG:hbk_dsk_chdir ;    the turn could have moved the current
+    jc .fail                    ;    directory under the write
+    call hbm_forget             ;    ...and the OLD pointer and image go
+                                ;    before a byte is written: a pointer that
+                                ;    outlived its question would otherwise
+                                ;    name the NEW image with the old session's
+                                ;    wake address (SPEC.md 86.3)
     mov word [hb_wakep], hbm_wake   ; 4. where the restored kernel enters
     mov [hb_wakep + 2], cs
     mov si, hb_s_img            ; 5. the image: all of memory, one write
@@ -1160,7 +1177,8 @@ hbm_hib:
     mov cx, HBP_SIZE
     call COLD_SEG:dwf_dskw_write
     jc .fail
-    call KERNEL_SEG:cw_vid_reboot   ; 7. text mode, the sentence, a key
+    call hbm_kbdrain            ; 7. a key typed during the write is not the
+    call KERNEL_SEG:cw_vid_reboot   ;    answer; text mode, the sentence, a key
     mov si, hbm_s_off
     call hbm_tty
     xor ah, ah
@@ -1173,7 +1191,7 @@ hbm_hib:
     dec byte [sch_lock]
     call KERNEL_SEG:cw_gfx_unlock
     call hbm_reload             ; the drivers come back
-.fail0:
+    call COLD_SEG:drvf_drv_vol_back
     mov byte [hb_mode], HB_M_ASK
     mov si, hbm_s_failed
     call hbm_toast
@@ -1192,6 +1210,21 @@ hbm_winback:
     call KERNEL_SEG:cw_gfx_unlock
 .out:
     pop si
+    ret
+
+; hbm_kbdrain - empty the ROM's keyboard buffer (SPEC.md 86.4 step 7, 86.5)
+; in:  nothing; out: nothing (all registers preserved)
+hbm_kbdrain:
+    push ax
+.more:
+    mov ah, 0x01
+    int 0x16
+    jz .out
+    xor ah, ah
+    int 0x16
+    jmp short .more
+.out:
+    pop ax
     ret
 
 ; hbm_tty - print one of this image's strings through the ROM's teletype
@@ -1368,6 +1401,10 @@ hbm_ask:
     call COLD_SEG:drvf_drv_vol_back
     mov byte [hb_mode], HB_M_RESUME
     mov byte [hb_down], 0
+    call hbm_kbdrain            ; a key held at the hibernate's own prompt
+                                ; repeats through int 19h into this boot, and
+                                ; ui_task's next step hands it to the front
+                                ; window - where Esc is Discard
     mov al, KIND_HIBER
     call KERNEL_SEG:cw_app_launch
     jmp short .out
@@ -1406,6 +1443,7 @@ hbm_imgsize:
 ; in:  the question was answered Resume; no lock held
 ; -----------------------------------------------------------------------------
 hbm_res:
+    call COLD_SEG:drvf_drv_vol_bank ; where the user stands, for a refusal
     mov dl, [hb_vol]
     xor ax, ax
     call COLD_SEG:hbk_dsk_chdir
@@ -1424,7 +1462,9 @@ hbm_res:
     mov [hb_xseg], dx
     call hbm_extents            ; AX = first cluster in; [hb_nx] out
     jc .failx
-    ; 3. the fresh boot's drivers go, the lock is taken, text mode ----------
+    ; 3. the panel's settings, the fresh boot's drivers go, the lock is taken,
+    ;    text mode - ui_cmd_reboot's order (SPEC.md 20.10, 31.8) -----------
+    call COLD_SEG:cpf_cp_flush_close
     call COLD_SEG:drv_shutdown_x
     call KERNEL_SEG:cw_gfx_lock
     call KERNEL_SEG:cw_vid_reboot
@@ -1455,10 +1495,10 @@ hbm_res:
     mov [es:HS_WAKE], ax
     mov ax, [cs:bx+HBP_WAKE+2]
     mov [es:HS_WAKE+2], ax
-    mov si, clk_sec             ; the fresh boot's clock (SPEC.md 86.6)
-    mov di, HS_CLK
-    mov cx, 6
-    rep movsw
+    mov si, clk_sec             ; the fresh boot's clock (SPEC.md 86.6): ten
+    mov di, HS_CLK              ; bytes, clk_sec..clk_year, and NOT the two
+    mov cx, 5                   ; display toggles after them, which are the
+    rep movsw                   ; image's to keep
     push ds
     mov ds, [hb_xseg]           ; the extents
     xor si, si
@@ -1482,10 +1522,15 @@ hbm_res:
     mov [es:HS_MASKM], al
     or al, 0x1A                 ; IRQ 1, 3, 4: the keyboard and the mice
     out 0x21, al
+    mov byte [es:HS_SLAVE], 0
+    cmp byte [cpu_tier], CPU_8086   ; an XT has no second 8259, and its port
+    je .noslave                 ; 0xA0 is the NMI mask register with 0xA1 an
+    mov byte [es:HS_SLAVE], 1   ; alias of it - mou_p2_init's refusal (9.9.2)
     in al, 0xA1
     mov [es:HS_MASKS], al
     or al, 0x10                 ; IRQ 12: the auxiliary port
     out 0xA1, al
+.noslave:
     push es
     mov ax, HS_CODE
     push ax
@@ -1496,6 +1541,7 @@ hbm_res:
     call COLD_SEG:hbk_mem_free
     mov word [hb_xseg], 0
 .fail:
+    call COLD_SEG:drvf_drv_vol_back
     mov byte [hb_mode], HB_M_RESUME
     mov si, hbm_s_lost
     call hbm_toast
@@ -1611,7 +1657,7 @@ hbm_wake:
     call hbm_stageseg           ; 2. the clock the boot just read
     mov si, HS_CLK
     mov di, clk_sec
-    mov cx, 12
+    mov cx, 10
 .clk:
     mov al, [es:si]
     mov [di], al
@@ -1645,8 +1691,9 @@ hbm_wake:
     ; 4. the desktop, the way fsx_restore gets it back (SPEC.md 53) - before
     ;    any disk work, so the progress widget has a graphics mode to draw in
     call KERNEL_SEG:cw_vid_setmode
-    call hbm_win
-    jc .nowin
+    mov byte [hb_mode], HB_M_GONE   ; before the close: app_close_win's hook
+    call hbm_win                ; leaves a GONE window's image to the thunk
+    jc .nowin                   ; (SPEC.md 86.1), and this code IS the image
     mov bx, si
     call KERNEL_SEG:cw_app_close_win
 .nowin:
@@ -1659,7 +1706,6 @@ hbm_wake:
     ; 6. and the machine is the user's again --------------------------------
     call KERNEL_SEG:cw_blk_wake
     inc word [hb_resumes]
-    mov byte [hb_mode], HB_M_GONE
     call KERNEL_SEG:cw_gfx_unlock
     mov byte [sch_lock], 0      ; NOT a dec: the image holds the count as the
                                 ; write left it, and dsk_xfer raises it around
@@ -1808,15 +1854,22 @@ hbs_stub:
     rep movsw
     mov al, [HS_MASKM]
     out 0x21, al
+    cmp byte [HS_SLAVE], 0
+    je .noslave
     mov al, [HS_MASKS]
     out 0xA1, al
+.noslave:
     mov ax, KERNEL_SEG
     mov ds, ax
     mov ss, [cs:HS_SS]
     mov sp, [cs:HS_SP]
     jmp far [cs:HS_WAKE]
 .fail:
-    mov si, hbs_s_fail - hbs_stub
+    mov ah, 0x02                ; the cursor to row 8 first: rows 0-2 of this
+    xor bh, bh                  ; page ARE the stub, and the ROM's teletype
+    mov dx, 0x0800              ; writes at the cursor the mode set homed. Row
+    int 0x10                    ; 8 is the IVT copy, dead on this path, and
+    mov si, hbs_s_fail - hbs_stub   ; three lines from there never scroll
 .ch:
     mov al, [si]
     or al, al

--- a/kernel/hiber.inc
+++ b/kernel/hiber.inc
@@ -1,0 +1,1896 @@
+; =============================================================================
+; os8088 - hiber.inc
+;
+; Hibernate the machine to a file on the hard disk, and resume it at the next
+; boot (SPEC.md 86). Prefix `hb_` for the resident half, `hbf_` for its .cold
+; thunks, `hbk_` for the far entries the module reaches cold code through,
+; `hbm_` for the on-demand module and `hbs_` for the resume stub.
+;
+; WHAT IS RESIDENT is the least that has to be: the System menu's three
+; strings live in menu.inc beside their siblings; here are the window
+; template and title, the state block the image carries, the .text thunks a
+; kernel window's callbacks need (a W_SEG-0 window is dispatched NEAR in
+; KERNEL_SEG), and in .cold the boot probe, the greying predicate, the far
+; entries, and the thunks that load the module before calling into it -
+; cpf_cp_paint's shape (SPEC.md 2.8).
+;
+; EVERYTHING ELSE IS HIBER.DRV, MOD_HIBER: the window, the file dialog's
+; completion, the write, the boot-time question, the extent walk, the stub
+; that puts memory back, and the routine that wakes the restored kernel. It
+; is .cold code with the address changed (SPEC.md 2.8): CS = its own claim,
+; DS = KERNEL_SEG, every kernel address the one this assembly gave it, and
+; its own strings read through CS (SPEC.md 2.8.6) - nothing can draw them
+; while the image is not loaded, because every path in is a thunk below that
+; runs mod_need first.
+;
+; kern_small has none of it (SPEC.md 62.9.15's reason: the 128KB machine is
+; not the one with a hard disk to hibernate to), and ships a one-entry stub
+; module so that os88mod.py cuts the same four files out of every kernel.
+; =============================================================================
+
+HB_M_ASK    equ 0               ; the window offers Hibernate... / Cancel
+HB_M_BUSY   equ 1               ; the image is being written (or read)
+HB_M_RESUME equ 2               ; the boot-time question: Resume / Discard
+HB_M_GONE   equ 3               ; the window closed: the thunk drops the image
+
+; --- the module's entry slots (SPEC.md 2.8.1) - its ABI with the thunks -----
+HBE_PAINT   equ 0
+HBE_ONCLICK equ 1
+HBE_ONUP    equ 2
+HBE_ONKEY   equ 3
+HBE_KINIT   equ 4
+HBE_PERFORM equ 5
+HBE_OPEN    equ 6
+HB_NENT     equ 7
+%if HB_NENT > MOD_NENT
+  %error "hiber: more entries than mod_fp has slots for"
+%endif
+HBFP        equ mod_fp + MOD_HIBER * MODFP_STRIDE
+
+; --- API cells the module calls (SPEC.md 20.3); the kernel has no copy of
+; --- apps/os88api.inc, so the four it needs are named here ------------------
+HB_API_FILL   equ 0x0038        ; AX=x1, BX=y1, CX=x2, DX=y2 in [gfx_color]
+HB_API_FONTX  equ 0x0068        ; CX=x, DX=y, the string at the CALLER's DS:SI
+HB_API_COLOR  equ 0x00C0        ; AL -> [gfx_color]
+HB_API_XCAPS  equ 0x0190        ; out BL = free block-table entries (SPEC.md 41)
+
+; --- the pointer file, HIBERNAT.PTR (SPEC.md 86.3) ---------------------------
+HBP_MAGIC   equ 0               ; 'HIB1'
+HBP_BUILD   equ 4               ; dw BUILD_NUM
+HBP_STAMP   equ 6               ; dw MOD_STAMP
+HBP_MEMTOP  equ 8               ; dw [mem_top]
+HBP_VID     equ 10              ; db [vid_kind]
+HBP_SP      equ 12              ; dw the banked SP...
+HBP_SS      equ 14              ; ...and SS
+HBP_WAKE    equ 16              ; dd hbm_wake, off:seg
+HBP_DRVS    equ 20              ; dw the rows detached before the image
+HBP_PATH    equ 32              ; db[32] the folder from the root (PTH_BUF)
+HBP_NAME    equ 64              ; db[13] the image's name
+HBP_SIZE    equ 80
+
+; --- the staging area in the text framebuffer (SPEC.md 86.5) -----------------
+; B800:0000 (or B000:0000 on a Hercules primary), which vid_reboot has just
+; made a linear 16KB+ of RAM that no rung of the ladder owns. The stub's CS,
+; DS and SS are all this segment, and every datum it reads is at one of
+; these offsets - numeric, so the stub is position-independent.
+HS_CODE     equ 0x0000          ; the stub, up to HS_CODE_MAX bytes
+HS_CODE_MAX equ 0x0400
+HS_UNIT     equ 0x0400          ; dw the int 13h drive
+HS_SPT      equ 0x0402          ; dw sectors per track
+HS_HEADS    equ 0x0404          ; dw heads
+HS_NX       equ 0x0406          ; dw extents
+HS_SS       equ 0x0408          ; dw the banked SS...
+HS_SP       equ 0x040A          ; ...and SP
+HS_WAKE     equ 0x040C          ; dd hbm_wake, off:seg
+HS_MASKM    equ 0x0410          ; db the master PIC's mask before the stub
+HS_MASKS    equ 0x0411          ; db ...and the slave's
+HS_CLK      equ 0x0412          ; db[12] clk_sec..clk_year of the fresh boot
+HS_LBA      equ 0x0420          ; dd the run's first LBA (scratch)
+HS_LEFT     equ 0x0424          ; dw sectors left in this extent
+HS_K        equ 0x0426          ; dw the file sector index = linear / 512
+HS_N        equ 0x0428          ; dw sectors in the call being issued
+HS_CHS      equ 0x042A          ; dw CX, dw DX as int 13h wants them
+HS_IVT      equ 0x0500          ; db[1024] file sectors 0..1, the IVT
+HS_EXT      equ 0x0A00          ; {dd lba, dw count, dw 0} x HS_XMAX
+HS_XMAX     equ 1280            ; one per sector of a 640KB image at worst
+HS_STACK    equ 0x3FF0          ; the stub's stack top: under a CGA's 16KB
+%if HS_EXT + HS_XMAX*8 > HS_STACK - 512
+  %error "hiber: the extent list would run into the stub's stack"
+%endif
+HB_XKB      equ (HS_XMAX*8 + 1023) / 1024   ; the claim the walk builds it in
+
+%ifdef KERN_BIG
+
+section .text
+; --- resident data: the template and the title (read through DS by wm) -----
+hb_tpl:     dw 160, 150, 320, 100, hb_ttl, hb_paint, hb_onkey, hb_onclick
+hb_ttl:     db 'Hibernate', 0
+hb_s_ptr:   db 'HIBERNAT.PTR', 0    ; read by the probe (cold) and the module
+hb_s_img:   db 'HIBERNAT.IMG', 0    ; the image, beside it in the root
+
+; --- the .text thunks: a kernel window's callbacks are near procs here ------
+hb_paint:   call COLD_SEG:hbf_paint
+            ret
+hb_onclick: call COLD_SEG:hbf_onclick
+            ret
+hb_onup:    call COLD_SEG:hbf_onup
+            ret
+hb_onkey:   call COLD_SEG:hbf_onkey
+            ret
+hb_kinit:   call COLD_SEG:hbf_kinit     ; KD_INIT: preserves every register
+            ret
+
+section .bss
+; The state block. Part of the image, which is the point: what hb_perform
+; banks before the write is what hbm_wake reads after the restore.
+hb_mode:    resb 1              ; HB_M_*
+hb_vol:     resb 1              ; the volume the image is (or will be) on
+hb_down:    resb 1              ; the button the press armed, 1/2, 0 = none
+hb_pad:     resb 1
+hb_drvmask: resw 1              ; drv_tab rows detached before the image
+hb_sp:      resw 1              ; hbm_perform's entry SP (SPEC.md 86.4)
+hb_wakep:   resw 2              ; hbm_wake as off:seg, in the image's module
+hb_resumes: resw 1              ; how many times this machine has woken
+hb_unit:    resw 1              ; the transport facts (SPEC.md 86.5 step 1)
+hb_spt:     resw 1
+hb_heads:   resw 1
+hb_base:    resd 1
+hb_xseg:    resw 1              ; the extent list's claim, 0 = none
+hb_nx:      resw 1              ; ...and how many it holds
+hb_lbl:     resb 16             ; a module string staged where DS can see it
+hb_rect:    resw 4              ; a button rect staged for os88ui_btn
+
+section .cold
+; =============================================================================
+; The resident half's cold code: the probe, the predicate, the far entries
+; and the thunks.
+; =============================================================================
+
+; -----------------------------------------------------------------------------
+; hb_probe - is there a hibernation to offer? (SPEC.md 86.5; kmain, after
+;            drv_boot and before the first paint)
+; in:  nothing
+; out: nothing (all registers preserved). A hit records the volume in [hb_vol]
+;      and posts UI_RBQ_ASK, which ui_task's first pass spends.
+;
+; Every FIXED volume's root, in a drv_vol_bank/back bracket (SPEC.md 51.5.2)
+; so the machine is left standing where drv_boot left it. A floppy-only
+; machine pays eight compares and no I/O.
+; -----------------------------------------------------------------------------
+hb_probe_x:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    mov byte [hb_mode], HB_M_GONE   ; .bss is whatever the LAST kernel left
+    mov word [hb_resumes], 0    ; (a warm boot clears nothing), and two of
+    mov word [hb_xseg], 0       ; these are read before anything writes them
+    call drv_vol_bank
+    xor cx, cx
+.vol:
+    mov bl, cl
+    call dsk_vol_fixed_x        ; AL = 1 fixed; CF = no such row
+    jc .next
+    or al, al
+    jz .next
+    mov dl, cl
+    xor ax, ax                  ; the root
+    call dsk_chdir_x
+    jc .next
+    mov si, hb_s_ptr
+    call dsk_find_name_x        ; no I/O: the snapshot the mount just built
+    jc .next
+    mov [hb_vol], cl
+    mov byte [ui_rebootq], UI_RBQ_ASK
+    jmp short .out
+.next:
+    inc cx
+    cmp cx, DVOL_MAX
+    jb .vol
+.out:
+    call drv_vol_back
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    retf
+
+; -----------------------------------------------------------------------------
+; hb_ok - may the machine hibernate? (SPEC.md 86.2, 47 rule 5)
+; in:  nothing
+; out: CF = 0 yes; CF = 1 and AL = 1 no fixed volume / 2 extended memory held
+; clobbers: AL (the output), flags
+;
+; Called on the press that opens the menu bar, so it is eight row tests and
+; one far call into a table - no I/O, no probe.
+; -----------------------------------------------------------------------------
+hb_ok_x:
+    push bx
+    push cx
+    push dx
+    xor cx, cx
+.vol:
+    mov bl, cl
+    call dsk_vol_fixed_x
+    jc .next
+    or al, al
+    jnz .hd
+.next:
+    inc cx
+    cmp cx, DVOL_MAX
+    jb .vol
+    mov al, 1
+    jmp short .no
+.hd:
+    call KERNEL_SEG:HB_API_XCAPS    ; BL = free block-table entries; on a
+    cmp bl, XM_MAX_BLKS         ; machine with no store, all of them
+    jb .xms
+    clc
+    jmp short .out
+.xms:
+    mov al, 2
+.no:
+    stc
+.out:
+    pop dx
+    pop cx
+    pop bx
+    retf
+
+; --- far entries for the module (SPEC.md 2.6): cold bodies that end in a near
+; --- ret, reached from a segment of their own. Four bytes each.
+hbk_dsk_chdir:      call dsk_chdir_x
+                    retf
+hbk_dsk_find_name:  call dsk_find_name_x
+                    retf
+hbk_dsk_get_dir:    call dsk_get_dir_x
+                    retf
+hbk_dsk_clus2lba:   call dsk_clus2lba_x
+                    retf
+hbk_dsk_next_clus:  call dsk_next_clus_x
+                    retf
+hbk_dsk_vol_fixed:  call dsk_vol_fixed_x
+                    retf
+hbk_dsk_fatw_drop:  call dsk_fatw_drop
+                    retf
+hbk_dsk_rah_flush:  call dsk_rah_flush
+                    retf
+hbk_drv_blk_call:   call drv_blk_call_x
+                    retf
+hbk_mem_claim:      call mem_claim_x
+                    retf
+hbk_mem_free:       call mem_free_x
+                    retf
+
+; --- the thunks that load the module and call in (SPEC.md 2.8, cpf_'s shape)
+hbf_paint:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .gone
+    call far [HBFP + HBE_PAINT*4]
+.gone:
+    retf
+
+hbf_onclick:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .gone
+    call far [HBFP + HBE_ONCLICK*4]
+.gone:
+    retf
+
+hbf_onup:                       ; a release can only follow a press this
+    push ax                     ; window took, so mod_live, not mod_need
+    mov al, MOD_HIBER           ; (SPEC.md 13.8.3)
+    call mod_live
+    pop ax
+    jc .gone
+    call far [HBFP + HBE_ONUP*4]
+    call hbf_dropck
+.gone:
+    retf
+
+hbf_onkey:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .gone
+    call far [HBFP + HBE_ONKEY*4]
+    call hbf_dropck
+.gone:
+    retf
+
+hbf_kinit:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .gone
+    call far [HBFP + HBE_KINIT*4]
+.gone:
+    retf
+
+; hbf_open - the System menu's Hibernate... (ui_cmd, no lock held)
+; A refusal here is about the DISK - the module could not be read - and the
+; toast names it the way the Control Panel's does, out of the same table.
+hbf_open:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .no
+    call far [HBFP + HBE_OPEN*4]
+    retf
+.no:
+    call hbf_nodisk
+    retf
+
+hbf_nodisk:
+    push ax
+    push bx
+    push cx
+    mov al, 1
+    mov bx, cp_opentab
+    mov cx, CP_NOPEN
+    call KERNEL_SEG:toast_say
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; hbf_perform - a posted UI_RBQ_HIBER / UI_RBQ_RESUME / UI_RBQ_ASK, spent by
+;               ui_task with nothing held (SPEC.md 86.4, 86.5)
+; in:  AL = which
+; out: nothing. Returns only on a refusal or a discard: a hibernate ends in
+;      int 19h and a resume ends in the stub.
+hbf_perform:
+    push ax
+    mov al, MOD_HIBER
+    call mod_need
+    pop ax
+    jc .no
+    call far [HBFP + HBE_PERFORM*4]
+    call hbf_dropck
+    retf
+.no:
+    cmp al, UI_RBQ_ASK          ; a question that cannot be asked is not
+    je .quiet                   ; worth a toast: the pointer stays for a
+    call hbf_nodisk             ; boot that has the system disk in
+.quiet:
+    retf
+
+; hbf_dropck - the window closed inside the call that just returned, so the
+;              image goes back now, from OUTSIDE it (SPEC.md 86.1)
+hbf_dropck:
+    cmp byte [hb_mode], HB_M_GONE
+    jne .out
+    push ax
+    mov al, MOD_HIBER
+    call mod_drop
+    pop ax
+.out:
+    ret
+
+; =============================================================================
+; THE MODULE - HIBER.DRV (SPEC.md 2.8, 86)
+;
+; CS = the image's own claim, DS = KERNEL_SEG. Kernel data by name through
+; DS; this file's own strings through CS; kernel code through KERNEL_SEG:cw_*
+; shims (.text), COLD_SEG:*_x / hbk_* far entries (.cold) and the API cells.
+; =============================================================================
+section .modh
+modh_hdr:
+    dw 0x384F                   ; MOD_H_MAGIC
+    db MOD_VER                  ; MOD_H_VER
+    db MOD_HIBER                ; MOD_H_ID
+    dw BUILD_NUM                ; MOD_H_BUILD  (SPEC.md 2.8.2)
+    dw MOD_STAMP                ; MOD_H_STAMP
+    dw modh_end                 ; MOD_H_IMG
+    dw HB_NENT                  ; MOD_H_NENT
+    dw modh_e_paint             ; HBE_PAINT
+    dw modh_e_onclick           ; HBE_ONCLICK
+    dw modh_e_onup              ; HBE_ONUP
+    dw modh_e_onkey             ; HBE_ONKEY
+    dw modh_e_kinit             ; HBE_KINIT
+    dw modh_e_perform           ; HBE_PERFORM
+    dw modh_e_open              ; HBE_OPEN
+    times MOD_NENT - HB_NENT dw 0
+
+modh_e_paint:   call hbm_paint
+                retf
+modh_e_onclick: call hbm_onclick
+                retf
+modh_e_onup:    call hbm_onup
+                retf
+modh_e_onkey:   call hbm_onkey
+                retf
+modh_e_kinit:   call hbm_kinit
+                retf
+modh_e_perform: call hbm_perform
+                retf
+modh_e_open:    call hbm_open
+                retf
+
+; --- geometry of the window's content (SPEC.md 86.1) -------------------------
+HBW_LX      equ 8               ; text left, content-relative
+HBW_LY      equ 6               ; first line's top
+HBW_LH      equ 12              ; line pitch
+HBW_BY      equ 54              ; the button band's top
+HBW_BH      equ 16              ; ...and height
+HBW_B1X     equ 8               ; the first button
+HBW_B1W     equ 120
+HBW_B2X     equ 140             ; the second
+HBW_B2W     equ 80
+HBW_CW      equ 320 - 2         ; content width: the template's W_W less the
+HBW_CH      equ 100 - TITLE_H - 1   ; borders; height less the title bar
+
+; -----------------------------------------------------------------------------
+; hbm_str - draw one of THIS image's strings (SPEC.md 2.8.6)
+; in:  CX = x, DX = y, SI = the string's offset in this image; the pen is set
+; out: nothing (all registers preserved)
+;
+; The transparent string cell is an X stub: ES becomes the CALLER's DS and DS
+; the kernel's, so with DS = CS for the call the string is read from here and
+; [gfx_color] from where it lives.
+; -----------------------------------------------------------------------------
+hbm_str:
+    push ds
+    push cs
+    pop ds
+    call KERNEL_SEG:HB_API_FONTX
+    pop ds
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_stage - copy one of this image's NUL strings to DS:DI (kernel memory)
+; in:  SI = the string's offset here, DI = the destination, CX = its size
+; out: nothing (all registers preserved). Always NUL-terminated.
+; -----------------------------------------------------------------------------
+hbm_stage:
+    push ax
+    push cx
+    push si
+    push di
+    dec cx                      ; room for the NUL
+.copy:
+    mov al, [cs:si]
+    mov [di], al
+    or al, al
+    jz .done
+    inc si
+    inc di
+    loop .copy
+    mov byte [di], 0
+.done:
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_toast - say one of this image's strings in the menu bar (SPEC.md 59)
+; in:  SI = the string's offset here
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_toast:
+    push cx
+    push es
+    push cs
+    pop es                      ; toast_show takes ES:SI
+    xor cx, cx
+    call KERNEL_SEG:cw_toast_show
+    pop es
+    pop cx
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_origin - the window's content origin
+; in:  SI = window ptr
+; out: AX = content left, DX = content top
+; -----------------------------------------------------------------------------
+hbm_origin:
+    push bx
+    mov bx, si
+    call KERNEL_SEG:cw_wm_content
+    pop bx
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_btnrect - one button's rect, staged in hb_rect
+; in:  AL = 1 or 2, SI = window ptr
+; out: BX = hb_rect, filled; SI = the label's offset here (for this mode)
+; clobbers: AX, BX, CX, DX, SI, flags
+; -----------------------------------------------------------------------------
+hbm_btnrect:
+    push ax
+    call hbm_origin             ; AX = left, DX = top
+    mov bx, hb_rect
+    add dx, HBW_BY
+    mov [bx+2], dx
+    add dx, HBW_BH - 1
+    mov [bx+6], dx
+    mov cx, ax
+    pop ax
+    cmp al, 1
+    jne .two
+    add cx, HBW_B1X
+    mov [bx], cx
+    add cx, HBW_B1W - 1
+    mov [bx+4], cx
+    mov si, hbm_s_bhib
+    cmp byte [hb_mode], HB_M_RESUME
+    jne .out
+    mov si, hbm_s_bres
+    jmp short .out
+.two:
+    add cx, HBW_B2X
+    mov [bx], cx
+    add cx, HBW_B2W - 1
+    mov [bx+4], cx
+    mov si, hbm_s_bcan
+    cmp byte [hb_mode], HB_M_RESUME
+    jne .out
+    mov si, hbm_s_bdis
+.out:
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_btn - draw one button, upright or pressed as [hb_down] says
+; in:  AL = 1 or 2, SI = window ptr; the gfx lock is held
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_btn:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov di, OS88UI_FILL         ; the interior is erased first, so a redraw
+    cmp al, 1                   ; between the two states never leaves a mark
+    jne .flags
+    or di, OS88UI_DEF           ; Enter is the first button
+.flags:
+    cmp al, [hb_down]
+    jne .up
+    or di, OS88UI_DOWN
+.up:
+    call hbm_btnrect            ; BX = the rect, SI = the label here
+    push di
+    mov di, hb_lbl
+    mov cx, 16
+    call hbm_stage              ; ...staged where the button drawer reads it
+    pop di
+    mov si, hb_lbl
+    call COLD_SEG:os88ui_btn_f
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_hit - which button is a point in?
+; in:  CX = x, DX = y (screen), SI = window ptr
+; out: AL = 1, 2 or 0
+; clobbers: AL (the output), flags
+; -----------------------------------------------------------------------------
+hbm_hit:
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov di, cx                  ; DI = x, BX = y, across hbm_btnrect
+    mov bx, dx
+    mov al, 1
+    call hbm_hitone
+    jc .yes
+    mov al, 2
+    call hbm_hitone
+    jc .yes
+    xor al, al
+.yes:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    ret
+
+; hbm_hitone - is the point DI,BX inside button AL? (out CF = 1 yes)
+hbm_hitone:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bx                     ; y, across hbm_btnrect - which clobbers CX,
+    call hbm_btnrect            ; BX = hb_rect. (It was `mov cx, bx` BEFORE
+    pop cx                      ; the call, and no click ever landed)
+    cmp di, [bx]
+    jb .no
+    cmp di, [bx+4]
+    ja .no
+    cmp cx, [bx+2]
+    jb .no
+    cmp cx, [bx+6]
+    ja .no
+    stc
+    jmp short .out
+.no:
+    clc
+.out:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_paint - W_PAINT (SPEC.md 86.1)
+; in:  SI = window ptr; content already white; the gfx lock is held
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_paint:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    mov al, CBLACK
+    call KERNEL_SEG:HB_API_COLOR
+    call hbm_origin             ; AX = left, DX = top
+    mov cx, ax
+    add cx, HBW_LX
+    add dx, HBW_LY
+    mov bx, hbm_lines_ask
+    mov al, [hb_mode]
+    cmp al, HB_M_BUSY
+    jne .notbusy
+    mov bx, hbm_lines_busy
+.notbusy:
+    push ax
+    mov al, [hb_vol]            ; the letter, patched into both faces' lines
+    add al, 'A'
+    mov [cs:hbm_s_r1 + HBM_R1_LTR], al
+    mov [cs:hbm_s_a2 + HBM_A2_LTR], al
+    pop ax
+    cmp al, HB_M_RESUME
+    jne .lines
+    mov bx, hbm_lines_res
+.lines:
+    push si
+.line:
+    mov si, [cs:bx]
+    or si, si
+    jz .lined
+    call hbm_str
+    add dx, HBW_LH
+    add bx, 2
+    jmp short .line
+.lined:
+    pop si
+    cmp byte [hb_mode], HB_M_BUSY
+    je .out                     ; no buttons while it is happening
+    mov al, 1
+    call hbm_btn
+    mov al, 2
+    call hbm_btn
+.out:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; hbm_repaint - erase the content and paint it again, for a mode change
+; in:  SI = window ptr; the gfx lock is held
+hbm_repaint:
+    push ax
+    push bx
+    push cx
+    push dx
+    call hbm_origin             ; AX = left, DX = top
+    mov bx, dx
+    mov cx, ax
+    add cx, HBW_CW - 1
+    mov dx, bx
+    add dx, HBW_CH - 1
+    push ax
+    mov al, CWHITE
+    call KERNEL_SEG:HB_API_COLOR
+    pop ax
+    call KERNEL_SEG:HB_API_FILL ; AX=x1, BX=y1, CX=x2, DX=y2
+    call hbm_paint
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; hbm_win - this kind's window, if it is up
+; out: CF = 0 and SI = window ptr; CF = 1 none
+hbm_win:
+    push ax
+    push di
+    mov al, KIND_HIBER
+    call KERNEL_SEG:cw_inst_find_kind   ; DI = the record
+    jc .no
+    mov si, [di+I_WIN]
+    or si, si
+    jz .no
+    pop di
+    pop ax
+    clc
+    ret
+.no:
+    pop di
+    pop ax
+    stc
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_onclick - W_ONCLICK: arm the button the press landed on (SPEC.md 13.8)
+; in:  CX = x, DX = y, SI = window ptr; the gfx lock is held
+; -----------------------------------------------------------------------------
+hbm_onclick:
+    push ax
+    cmp byte [hb_mode], HB_M_BUSY
+    je .out
+    call hbm_hit
+    mov [hb_down], al
+    or al, al
+    jz .out
+    call hbm_btn                ; ...drawn pressed
+.out:
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_onup - W_ONMOUSEUP: fire if the release is on the armed button
+; in:  CX = x, DX = y, SI = window ptr; the gfx lock is held
+; -----------------------------------------------------------------------------
+hbm_onup:
+    push ax
+    push bx
+    mov bl, [hb_down]
+    mov byte [hb_down], 0
+    or bl, bl
+    jz .out
+    cmp byte [hb_mode], HB_M_BUSY
+    je .out
+    mov al, bl
+    call hbm_btn                ; upright again, whatever happens next
+    call hbm_hit
+    cmp al, bl
+    jne .out
+    call hbm_act
+.out:
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_onkey - W_ONKEY: Enter is the first button, Esc the second
+; in:  AL = ascii, AH = scan, SI = window ptr; the gfx lock is held
+; -----------------------------------------------------------------------------
+hbm_onkey:
+    push ax
+    cmp byte [hb_mode], HB_M_BUSY
+    je .out
+    cmp al, 13
+    jne .notcr
+    mov al, 1
+    jmp short .act
+.notcr:
+    cmp al, 27
+    jne .out
+    mov al, 2
+.act:
+    call hbm_act
+.out:
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_act - one of the two buttons, in this mode (SPEC.md 86.1)
+; in:  AL = 1 or 2, SI = window ptr; the gfx lock is held, UI task
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_act:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    cmp byte [hb_mode], HB_M_RESUME
+    je .resume
+    cmp al, 2
+    je .close
+    call hbm_arm                ; Hibernate: check the disk, then post
+    jmp short .out
+.resume:
+    cmp al, 2
+    je .discard
+    ; --- Resume: say so, and post the restore for the top of the pass -------
+    mov byte [hb_mode], HB_M_BUSY
+    call hbm_repaint
+    cmp byte [ui_rebootq], 0
+    jne .out                    ; a restart already posted wins (SPEC.md 20.10)
+    mov byte [ui_rebootq], UI_RBQ_RESUME
+    jmp short .out
+.discard:
+    call COLD_SEG:drvf_drv_vol_bank
+    call hbm_forget             ; the pointer and the image go
+    call COLD_SEG:drvf_drv_vol_back
+.close:
+    mov bx, si
+    call KERNEL_SEG:cw_app_close_win    ; synchronous: task-less kind
+    mov byte [hb_mode], HB_M_GONE       ; ...and the thunk drops the image
+.out:
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_forget - delete the pointer and the image (SPEC.md 86.6 step 5)
+; in:  [hb_vol] = the volume; both files are in its root
+; out: nothing (all registers preserved); failures are ignored - there is
+;      nothing further to do about a file that is already gone. The volume is
+;      left at the root of [hb_vol]: a caller standing elsewhere brackets
+;      this with drv_vol_bank/back.
+; -----------------------------------------------------------------------------
+hbm_forget:
+    push ax
+    push dx
+    push si
+    mov dl, [hb_vol]
+    xor ax, ax                  ; both live in the root (SPEC.md 86.3)
+    call COLD_SEG:hbk_dsk_chdir
+    jc .out
+    mov si, hb_s_img
+    call COLD_SEG:dwf_dskw_delete
+    mov si, hb_s_ptr
+    call COLD_SEG:dwf_dskw_delete
+.out:
+    pop si
+    pop dx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_kinit - KD_INIT (SPEC.md 29.3): the release hook and the snap
+; in:  BX = window ptr, DI = 0, SI = the record; no lock; not yet visible
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_kinit:
+    push ax
+    mov byte [hb_down], 0
+    mov ax, hb_onup
+    call KERNEL_SEG:cw_wm_onmouseup
+    mov al, 1
+    call KERNEL_SEG:cw_wm_snap  ; text on cell boundaries (SPEC.md 11.94)
+    pop ax
+    ret
+
+; hbm_pickvol - the disk the image goes to (SPEC.md 86.2): the one the
+;               machine BOOTED from when that is a fixed disk, else the first
+;               fixed volume there is
+; out: CF = 0 and AL = its index; CF = 1 no fixed volume
+hbm_pickvol:
+    push bx
+    push cx
+    mov cl, [dsk_bootvol]
+    mov bl, cl
+    call COLD_SEG:hbk_dsk_vol_fixed
+    jc .scan
+    or al, al
+    jz .scan
+    mov al, cl
+    clc
+    jmp short .out
+.scan:
+    xor cx, cx
+.vol:
+    mov bl, cl
+    call COLD_SEG:hbk_dsk_vol_fixed
+    jc .next
+    or al, al
+    jz .next
+    mov al, cl
+    clc
+    jmp short .out
+.next:
+    inc cx
+    cmp cx, DVOL_MAX
+    jb .vol
+    stc
+.out:
+    pop cx
+    pop bx
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_open - the System menu's Hibernate... (SPEC.md 86.1): open the window
+; in:  nothing; UI task, no lock
+; out: nothing (all registers preserved)
+; -----------------------------------------------------------------------------
+hbm_open:
+    push ax
+    push si
+    call hbm_win                ; already up, in whatever mode: app_launch
+    jnc .launch                 ; fronts it and the mode stays what it is
+    call hbm_pickvol            ; the item was live, so there is one
+    jc .out
+    mov [hb_vol], al            ; ...and the window names it
+    mov byte [hb_mode], HB_M_ASK
+    mov byte [hb_down], 0
+.launch:
+    mov al, KIND_HIBER
+    call KERNEL_SEG:cw_app_launch
+    jnc .out
+    call KERNEL_SEG:cw_snd_beep
+.out:
+    pop si
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_geom - the transport facts for a volume (SPEC.md 86.5 step 1)
+; in:  AL = the volume index
+; out: CF = 0 and [hb_unit], [hb_spt], [hb_heads], [hb_base] filled;
+;      CF = 1: not a fixed disk the ROM's int 13h reaches
+; clobbers: flags
+; -----------------------------------------------------------------------------
+hbm_geom:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    mov bl, al
+    call COLD_SEG:dskf_dsk_vol_row  ; BX = the row
+    jc .no
+    cmp byte [bx+DV_KIND], DVK_BIOS
+    jne .drv
+    mov dl, [bx+DV_UNIT]        ; the boot partition (SPEC.md 52.10.3): the
+    test dl, 0x80               ; kernel holds every fact itself
+    jz .no
+    xor dh, dh
+    mov [hb_unit], dx
+    mov bl, al
+    xor bh, bh
+    shl bx, 1
+    shl bx, 1
+    mov dx, [dsk_vbase + bx]
+    mov [hb_base], dx
+    mov dx, [dsk_vbase + bx + 2]
+    mov [hb_base + 2], dx
+    mov dx, [dsk_bootspt]
+    mov [hb_spt], dx
+    mov dx, [dsk_boothds]
+    mov [hb_heads], dx
+    jmp short .check
+.drv:
+    cmp byte [bx+DV_KIND], DVK_DRV
+    jne .no
+    mov ah, [bx+DV_UNIT]        ; the driver's handle
+    mov al, [bx+DV_CLASS]
+    mov [drv_blkcls], al
+    call COLD_SEG:drvf_drv_cls_svc  ; DI = the class's service table
+    jc .no
+    mov bp, [di+DSV_GEOM]
+    call COLD_SEG:hbk_drv_blk_call  ; DL = unit, CX:BX = base, SI = spt,
+    jc .no                      ; DI = heads; CF = 1 not int 13h
+    xor dh, dh
+    mov [hb_unit], dx
+    mov [hb_base], bx
+    mov [hb_base + 2], cx
+    mov [hb_spt], si
+    mov [hb_heads], di
+.check:
+    cmp word [hb_spt], 0
+    je .no
+    cmp word [hb_spt], 63
+    ja .no
+    cmp word [hb_heads], 0
+    je .no
+    cmp word [hb_heads], 255
+    ja .no
+    clc
+    jmp short .out
+.no:
+    stc
+.out:
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_arm - the Hibernate button (SPEC.md 86.2, 86.4): the disk in [hb_vol]
+;           has to be one the ROM reaches and have the room, and then the
+;           write is POSTED for the top of the pass
+; in:  SI = the window; the gfx lock is held
+; out: nothing (all registers preserved); a refusal is a toast
+; -----------------------------------------------------------------------------
+hbm_arm:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    call COLD_SEG:drvf_drv_vol_bank ; the user may be standing anywhere
+    mov al, [hb_vol]
+    call hbm_geom
+    jc .nobios
+    mov dl, [hb_vol]
+    xor ax, ax
+    call COLD_SEG:hbk_dsk_chdir ; the root: where the image goes, and where
+    jc .noroom                  ; dfree answers for
+    call COLD_SEG:dwf_dskw_dfree    ; DX:AX = free bytes
+    jc .noroom
+    push ax
+    push dx
+    push si
+    mov si, hb_s_img            ; ...plus what replacing an old image frees
+    call COLD_SEG:hbk_dsk_find_name
+    jc .noold
+    call COLD_SEG:hbk_dsk_get_dir   ; SI = the staged entry, its size at 20
+    pop bx
+    pop dx
+    pop ax
+    add ax, [si+20]
+    adc dx, [si+22]
+    push ax
+    push dx
+    push bx
+.noold:
+    pop si
+    pop dx
+    pop ax
+    push ax
+    push dx
+    call hbm_imgsize            ; DX:AX = the image's bytes
+    add ax, 0x1000              ; ...and the pointer, with room to spare
+    adc dx, 0
+    mov cx, ax
+    mov bx, dx                  ; BX:CX = the need
+    pop dx
+    pop ax                      ; DX:AX = the room
+    cmp dx, bx
+    jb .noroom
+    ja .room
+    cmp ax, cx
+    jb .noroom
+.room:
+    call COLD_SEG:drvf_drv_vol_back
+    mov byte [hb_mode], HB_M_BUSY
+    call hbm_repaint
+    cmp byte [ui_rebootq], 0
+    jne .out                    ; a restart already posted wins (SPEC.md 20.10)
+    mov byte [ui_rebootq], UI_RBQ_HIBER
+    jmp short .out
+.nobios:
+    mov si, hbm_s_nobios
+    jmp short .refuse
+.noroom:
+    mov si, hbm_s_noroom
+.refuse:
+    call hbm_toast
+    call COLD_SEG:drvf_drv_vol_back
+.out:
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_perform - a posted request, spent with nothing held (SPEC.md 86.4/86.5)
+; in:  AL = UI_RBQ_HIBER / UI_RBQ_RESUME / UI_RBQ_ASK; UI task, no lock
+; out: nothing; returns only from a refusal, a discard, or the question
+;
+; [hb_sp] is this routine's entry SP - the word under it is the return into
+; modh_e_perform - and it is the frame hbm_wake comes back to after a
+; resume, and the one every exit below returns through.
+; -----------------------------------------------------------------------------
+hbm_perform:
+    mov [hb_sp], sp
+    cld
+    cmp al, UI_RBQ_HIBER
+    je hbm_hib
+    cmp al, UI_RBQ_RESUME
+    je hbm_res
+    jmp hbm_ask
+
+; --- hbm_hib: write the image and stop (SPEC.md 86.4) ------------------------
+hbm_hib:
+    mov dl, [hb_vol]
+    xor ax, ax
+    call COLD_SEG:hbk_dsk_chdir ; 1. the root of the disk the boot picked
+    jc .fail0
+    call hbm_detach             ; 2. the hardware drivers go, and are noted
+    call KERNEL_SEG:cw_gfx_lock ; 3. held from here: the machine is one
+    inc byte [sch_lock]         ;    instant from here on
+    mov word [hb_wakep], hbm_wake   ; 4. where the restored kernel enters
+    mov [hb_wakep + 2], cs
+    mov si, hb_s_img            ; 5. the image: all of memory, one write
+    xor bx, bx
+    mov es, bx
+    call hbm_imgsize            ; DX:AX = bytes
+    mov cx, ax
+    call COLD_SEG:dwf_dskw_write
+    jc .fail
+    call hbm_ptr_build          ; 6. the pointer, beside it
+    mov si, hb_s_ptr
+    push cs
+    pop es
+    mov bx, hbm_ptrbuf
+    xor dx, dx
+    mov cx, HBP_SIZE
+    call COLD_SEG:dwf_dskw_write
+    jc .fail
+    call KERNEL_SEG:cw_vid_reboot   ; 7. text mode, the sentence, a key
+    mov si, hbm_s_off
+    call hbm_tty
+    xor ah, ah
+    int 0x16
+    call COLD_SEG:drv_shutdown_x    ; ...and the reboot path's tail (20.10)
+    call KERNEL_SEG:cw_sched_unhook
+    int 0x19
+    jmp $
+.fail:
+    dec byte [sch_lock]
+    call KERNEL_SEG:cw_gfx_unlock
+    call hbm_reload             ; the drivers come back
+.fail0:
+    mov byte [hb_mode], HB_M_ASK
+    mov si, hbm_s_failed
+    call hbm_toast
+    call hbm_winback
+    mov sp, [hb_sp]
+    ret
+
+; hbm_winback - the window, if it is up, painted for the mode it is in now
+; in:  nothing; no lock held
+hbm_winback:
+    push si
+    call hbm_win
+    jc .out
+    call KERNEL_SEG:cw_gfx_lock
+    call hbm_repaint
+    call KERNEL_SEG:cw_gfx_unlock
+.out:
+    pop si
+    ret
+
+; hbm_tty - print one of this image's strings through the ROM's teletype
+; in:  SI = the string's offset here; text mode
+hbm_tty:
+    push ax
+    push bx
+    push si
+.ch:
+    mov al, [cs:si]
+    or al, al
+    jz .out
+    mov ah, 0x0E
+    mov bx, 0x0007
+    int 0x10
+    inc si
+    jmp short .ch
+.out:
+    pop si
+    pop bx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_detach / hbm_reload - the drivers that own hardware (SPEC.md 86.4 step 2)
+; in:  nothing; UI task, NO lock held (an unload waits on its worker)
+; out: nothing (all registers preserved); [hb_drvmask] says which rows
+; -----------------------------------------------------------------------------
+hbm_detach:
+    push ax
+    push bx
+    push cx
+    mov word [hb_drvmask], 0
+    xor cx, cx
+.row:
+    mov al, cl
+    call COLD_SEG:drvf_drv_row  ; BX = the row
+    cmp word [bx+DRVR_SEG], 0
+    je .next
+    mov al, [bx+DRVR_CLASS]
+    cmp al, DRVC_DISK
+    je .next                    ; memory and the ROM's int 13h: it stays
+    cmp al, DRVC_FILE
+    je .next                    ; the RAM disk: memory, and it stays
+    mov ax, 1
+    shl ax, cl
+    or [hb_drvmask], ax
+    mov al, cl
+    call COLD_SEG:drvf_drv_unload
+.next:
+    inc cx
+    cmp cx, DRV_MAX
+    jb .row
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+hbm_reload:
+    push ax
+    push cx
+    push dx
+    xor cx, cx
+    mov dx, [hb_drvmask]
+.row:
+    shr dx, 1
+    jnc .next
+    mov al, cl
+    call COLD_SEG:drvf_drv_load ; failures show on the Drivers page, as at boot
+.next:
+    inc cx
+    cmp cx, DRV_MAX
+    jb .row
+    pop dx
+    pop cx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_ptr_build - compose the pointer file in this image's buffer (86.3)
+; -----------------------------------------------------------------------------
+hbm_ptr_build:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    push cs
+    pop es
+    cld
+    mov di, hbm_ptrbuf
+    xor ax, ax
+    mov cx, HBP_SIZE / 2
+    rep stosw
+    mov di, hbm_ptrbuf
+    mov word [es:di+HBP_MAGIC], 'HI'
+    mov word [es:di+HBP_MAGIC+2], 'B1'
+    mov word [es:di+HBP_BUILD], BUILD_NUM
+    mov word [es:di+HBP_STAMP], MOD_STAMP
+    mov ax, [mem_top]
+    mov [es:di+HBP_MEMTOP], ax
+    mov al, [vid_kind]
+    mov [es:di+HBP_VID], al
+    mov ax, [hb_sp]
+    mov [es:di+HBP_SP], ax
+    mov [es:di+HBP_SS], ss
+    mov ax, [hb_wakep]
+    mov [es:di+HBP_WAKE], ax
+    mov ax, [hb_wakep + 2]
+    mov [es:di+HBP_WAKE + 2], ax
+    mov ax, [hb_drvmask]
+    mov [es:di+HBP_DRVS], ax
+    mov si, hb_s_img            ; HBP_PATH stays zero: the root (SPEC.md 86.3)
+    mov di, hbm_ptrbuf + HBP_NAME
+    mov cx, 13
+    rep movsb
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_ask - the boot-time question (SPEC.md 86.5): validate the pointer,
+;           find the image, and open the window in HB_M_RESUME
+; in:  [hb_vol] = the volume the probe found the pointer on; no lock
+; -----------------------------------------------------------------------------
+hbm_ask:
+    call COLD_SEG:drvf_drv_vol_bank
+    mov dl, [hb_vol]
+    xor ax, ax
+    call COLD_SEG:hbk_dsk_chdir
+    jc .gone
+    mov si, hb_s_ptr
+    push cs
+    pop es
+    mov bx, hbm_ptrbuf
+    xor dx, dx
+    mov cx, HBP_SIZE
+    call COLD_SEG:dwf_dskw_read ; DX:AX = bytes
+    jc .gone
+    cmp ax, HBP_SIZE
+    jne .stale
+    mov bx, hbm_ptrbuf
+    cmp word [cs:bx+HBP_MAGIC], 'HI'
+    jne .stale
+    cmp word [cs:bx+HBP_MAGIC+2], 'B1'
+    jne .stale
+    cmp word [cs:bx+HBP_BUILD], BUILD_NUM
+    jne .stale
+    cmp word [cs:bx+HBP_STAMP], MOD_STAMP
+    jne .stale
+    mov ax, [mem_top]
+    cmp [cs:bx+HBP_MEMTOP], ax
+    jne .stale
+    mov al, [vid_kind]
+    cmp [cs:bx+HBP_VID], al
+    jne .stale
+    cmp byte [cs:bx+HBP_PATH], 0    ; a pointer with a path is not one this
+    jne .stale                  ; build wrote: the image lives in the root
+    mov si, hb_s_img            ; ...which is mounted: the pointer came from it
+    call COLD_SEG:hbk_dsk_find_name
+    jc .lost
+    call COLD_SEG:hbk_dsk_get_dir   ; SI = the staged entry
+    call hbm_imgsize            ; DX:AX = what the image must be
+    cmp [si+20], ax
+    jne .lost
+    cmp [si+22], dx
+    jne .lost
+    mov al, [hb_vol]
+    call hbm_geom
+    jc .nobios
+    call COLD_SEG:drvf_drv_vol_back
+    mov byte [hb_mode], HB_M_RESUME
+    mov byte [hb_down], 0
+    mov al, KIND_HIBER
+    call KERNEL_SEG:cw_app_launch
+    jmp short .out
+.stale:
+    mov si, hbm_s_stale
+    jmp short .drop
+.lost:
+    mov si, hbm_s_lost
+    jmp short .drop
+.nobios:
+    mov si, hbm_s_nobios
+.drop:
+    call hbm_toast
+    call hbm_forget             ; a pointer nothing can act on
+.gone:
+    call COLD_SEG:drvf_drv_vol_back
+    mov byte [hb_mode], HB_M_GONE   ; ...and the image goes back too
+.out:
+    mov sp, [hb_sp]
+    ret
+
+; hbm_imgsize - out: DX:AX = [mem_top] * 16, the bytes an image must have
+hbm_imgsize:
+    push cx
+    mov ax, [mem_top]
+    mov dx, ax
+    mov cl, 4
+    shl ax, cl
+    mov cl, 12
+    shr dx, cl
+    pop cx
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_res - put the image back (SPEC.md 86.5): the extents, then the stub
+; in:  the question was answered Resume; no lock held
+; -----------------------------------------------------------------------------
+hbm_res:
+    mov dl, [hb_vol]
+    xor ax, ax
+    call COLD_SEG:hbk_dsk_chdir
+    jc .fail
+    mov si, hb_s_img
+    call COLD_SEG:hbk_dsk_find_name
+    jc .fail
+    call COLD_SEG:hbk_dsk_get_dir   ; SI = the entry: [si+18] its first cluster
+    mov ax, [si+18]
+    push ax
+    mov ax, HB_XKB              ; 2. the extent list's claim
+    mov bx, MEM_K_HIB
+    call COLD_SEG:hbk_mem_claim ; DX = its segment
+    pop ax
+    jc .fail
+    mov [hb_xseg], dx
+    call hbm_extents            ; AX = first cluster in; [hb_nx] out
+    jc .failx
+    ; 3. the fresh boot's drivers go, the lock is taken, text mode ----------
+    call COLD_SEG:drv_shutdown_x
+    call KERNEL_SEG:cw_gfx_lock
+    call KERNEL_SEG:cw_vid_reboot
+    ; 4. the staging area ---------------------------------------------------
+    call hbm_stageseg           ; ES = the text framebuffer
+    push ds
+    push cs
+    pop ds
+    mov si, hbs_stub            ; the stub, to offset 0
+    mov di, HS_CODE
+    mov cx, hbs_stub_end - hbs_stub
+    rep movsb
+    pop ds
+    mov ax, [hb_unit]
+    mov [es:HS_UNIT], ax
+    mov ax, [hb_spt]
+    mov [es:HS_SPT], ax
+    mov ax, [hb_heads]
+    mov [es:HS_HEADS], ax
+    mov ax, [hb_nx]
+    mov [es:HS_NX], ax
+    mov bx, hbm_ptrbuf
+    mov ax, [cs:bx+HBP_SS]
+    mov [es:HS_SS], ax
+    mov ax, [cs:bx+HBP_SP]
+    mov [es:HS_SP], ax
+    mov ax, [cs:bx+HBP_WAKE]
+    mov [es:HS_WAKE], ax
+    mov ax, [cs:bx+HBP_WAKE+2]
+    mov [es:HS_WAKE+2], ax
+    mov si, clk_sec             ; the fresh boot's clock (SPEC.md 86.6)
+    mov di, HS_CLK
+    mov cx, 6
+    rep movsw
+    push ds
+    mov ds, [hb_xseg]           ; the extents
+    xor si, si
+    mov di, HS_EXT
+    mov cx, [es:HS_NX]
+    shl cx, 1
+    shl cx, 1                   ; words: 4 per extent
+    rep movsw
+    pop ds
+    ; 5. the ROM's int 08h back, the kernel's IRQs masked, and go ----------
+    cli
+    push es
+    xor ax, ax
+    mov es, ax
+    mov ax, [sch_old08]
+    mov [es:0x20], ax
+    mov ax, [sch_old08 + 2]
+    mov [es:0x22], ax
+    pop es
+    in al, 0x21
+    mov [es:HS_MASKM], al
+    or al, 0x1A                 ; IRQ 1, 3, 4: the keyboard and the mice
+    out 0x21, al
+    in al, 0xA1
+    mov [es:HS_MASKS], al
+    or al, 0x10                 ; IRQ 12: the auxiliary port
+    out 0xA1, al
+    push es
+    mov ax, HS_CODE
+    push ax
+    retf                        ; into the stub, IF = 0
+.failx:
+    mov dx, [hb_xseg]
+    mov bx, MEM_K_HIB
+    call COLD_SEG:hbk_mem_free
+    mov word [hb_xseg], 0
+.fail:
+    mov byte [hb_mode], HB_M_RESUME
+    mov si, hbm_s_lost
+    call hbm_toast
+    call hbm_winback
+    mov sp, [hb_sp]
+    ret
+
+; hbm_stageseg - out: ES = the text framebuffer the stub will run in
+hbm_stageseg:
+    push ax
+    mov ax, 0xB800
+    cmp byte [vid_kind], VID_HERC
+    jne .set
+    mov ax, 0xB000
+.set:
+    mov es, ax
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
+; hbm_extents - the image's chain as absolute sector runs (SPEC.md 86.5 step 2)
+; in:  AX = the first cluster; [hb_xseg] = where to build; the volume mounted
+; out: CF = 0 and [hb_nx] runs of {dd lba, dw count, dw 0} at [hb_xseg]:0;
+;      CF = 1 the chain is broken or too fragmented
+; -----------------------------------------------------------------------------
+hbm_extents:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov es, [hb_xseg]
+    xor di, di                  ; the next entry
+    mov word [hb_nx], 0
+    mov si, ax                  ; SI = the cluster in hand
+    mov cx, [mem_top]
+    mov bl, 5
+    xchg cx, bx
+    shr bx, cl                  ; BX = sectors the image has: paragraphs / 32
+    mov cx, bx                  ; CX = sectors still to place
+.clus:
+    mov ax, si
+    call COLD_SEG:hbk_dsk_clus2lba  ; AX = its first LBA, volume-relative
+    jc .bad
+    xor dx, dx
+    add ax, [hb_base]
+    adc dx, [hb_base + 2]       ; DX:AX = absolute
+    mov bl, [dsk_spc]
+    xor bh, bh                  ; BX = this cluster's sectors...
+    cmp bx, cx
+    jbe .whole
+    mov bx, cx                  ; ...capped at what the image still needs
+.whole:
+    cmp word [hb_nx], 0
+    je .new
+    cmp ax, [cs:hbm_nextlo]     ; does this cluster follow the run in hand?
+    jne .new
+    cmp dx, [cs:hbm_nexthi]
+    jne .new
+    add [es:di-4], bx           ; contiguous: the run grows
+    jmp short .grown
+.new:
+    cmp word [hb_nx], HS_XMAX
+    jae .bad
+    mov [es:di], ax
+    mov [es:di+2], dx
+    mov [es:di+4], bx
+    mov word [es:di+6], 0
+    add di, 8
+    inc word [hb_nx]
+    mov [cs:hbm_nextlo], ax
+    mov [cs:hbm_nexthi], dx
+.grown:
+    add [cs:hbm_nextlo], bx
+    adc word [cs:hbm_nexthi], 0
+    sub cx, bx
+    jz .done
+    mov ax, si
+    call COLD_SEG:hbk_dsk_next_clus ; AX = the next
+    jc .bad
+    mov si, ax
+    jmp short .clus
+.done:
+    clc
+    jmp short .out
+.bad:
+    stc
+.out:
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+hbm_nextlo: dw 0                ; the LBA the run in hand ends at
+hbm_nexthi: dw 0
+
+; -----------------------------------------------------------------------------
+; hbm_wake - the restored kernel wakes up here (SPEC.md 86.6)
+; in:  CS = this image's segment IN THE RESTORED MEMORY, DS = KERNEL_SEG,
+;      SS:SP = hbm_perform's entry frame, IF = 0, the gfx lock held and
+;      [sch_lock] up - all of it as the write left it
+; out: does not return: it RETURNS THROUGH THE FRAME, into modh_e_perform
+; -----------------------------------------------------------------------------
+hbm_wake:
+    sti                         ; 1. the IVT is the image's; nobody switches
+    cld
+    call hbm_stageseg           ; 2. the clock the boot just read
+    mov si, HS_CLK
+    mov di, clk_sec
+    mov cx, 12
+.clk:
+    mov al, [es:si]
+    mov [di], al
+    inc si
+    inc di
+    loop .clk
+    mov ax, [ticks]
+    mov [clk_last], ax
+    mov word [clk_acc], 0
+    mov byte [clk_barq], 1
+    ; 3. the disk caches are the write's, not the disk's (SPEC.md 86.4) -----
+    xor al, al
+.drop:
+    push ax
+    call COLD_SEG:hbk_dsk_fatw_drop
+    pop ax
+    inc al
+    cmp al, DVOL_MAX
+    jb .drop
+    mov word [dsk_fatd0], 0xFFFF
+    mov word [dsk_fatw0], 0xFFFF
+    mov byte [dsk_mntok], 0
+    mov word [disk_nfiles], 0
+    mov byte [dsk_batch], 0
+    mov byte [dskw_batch], 0
+    mov byte [dskw_syswr], 0
+    mov byte [dskw_isdir], 0
+    call COLD_SEG:hbk_dsk_rah_flush
+    mov word [mem_pinseg], 0    ; dsk_xfer's pin, mid-transfer in the image
+    call KERNEL_SEG:fpg_end     ; ...and the progress widget it had up
+    ; 4. the desktop, the way fsx_restore gets it back (SPEC.md 53) - before
+    ;    any disk work, so the progress widget has a graphics mode to draw in
+    call KERNEL_SEG:cw_vid_setmode
+    call hbm_win
+    jc .nowin
+    mov bx, si
+    call KERNEL_SEG:cw_app_close_win
+.nowin:
+    call KERNEL_SEG:cw_menu_force
+    call KERNEL_SEG:cw_dock_force
+    call KERNEL_SEG:cw_wm_paint_all
+    ; 5. the two files are spent, and the drivers come back -----------------
+    call hbm_forget
+    call hbm_reload
+    ; 6. and the machine is the user's again --------------------------------
+    call KERNEL_SEG:cw_blk_wake
+    inc word [hb_resumes]
+    mov byte [hb_mode], HB_M_GONE
+    call KERNEL_SEG:cw_gfx_unlock
+    mov byte [sch_lock], 0      ; NOT a dec: the image holds the count as the
+                                ; write left it, and dsk_xfer raises it around
+                                ; every int 13h - so it reads 2, and one down
+                                ; from that is a machine that never switches
+    mov sp, [hb_sp]
+    ret
+
+; =============================================================================
+; THE STUB (SPEC.md 86.5). Copied to HS_CODE in the text framebuffer and
+; entered by a far jump with IF = 0. Position-independent: every jump is
+; relative and every datum is at a numeric HS_* offset in its own segment.
+; =============================================================================
+hbs_stub:
+    mov ax, cs
+    mov ds, ax
+    mov ss, ax
+    mov sp, HS_STACK
+    cld
+    mov word [HS_K], 0
+    mov si, HS_EXT
+    mov cx, [HS_NX]
+.extent:
+    or cx, cx
+    jnz .have
+    jmp .done
+.have:
+    push cx
+    mov ax, [si]
+    mov [HS_LBA], ax
+    mov ax, [si+2]
+    mov [HS_LBA+2], ax
+    mov ax, [si+4]
+    mov [HS_LEFT], ax
+.run:
+    cmp word [HS_LEFT], 0
+    je .nextext
+    ; --- CHS of [HS_LBA] (hd_chs's one div pair), and the track's remainder --
+    mov ax, [HS_LBA+2]
+    xor dx, dx
+    div word [HS_SPT]
+    mov bx, ax                  ; BX:AX = track after the second div...
+    mov ax, [HS_LBA]
+    div word [HS_SPT]           ; ...and DX = sector - 1
+    mov cx, [HS_SPT]
+    sub cx, dx                  ; CX = sectors from this one to the track end
+    mov [HS_N], cx
+    inc dx
+    push dx                     ; the sector, 1-based
+    mov dx, bx
+    div word [HS_HEADS]         ; AX = cylinder, DX = head
+    pop bx                      ; BL = the sector
+    mov dh, dl                  ; DH = head
+    mov dl, [HS_UNIT]           ; DL = drive
+    mov ch, al                  ; CH = cylinder low 8, CL = sector | high 2
+    mov cl, ah
+    ror cl, 1
+    ror cl, 1
+    and cl, 0xC0
+    or cl, bl
+    mov [HS_CHS], cx
+    mov [HS_CHS+2], dx
+    ; --- the run: to the track's end, the extent's end, the DMA page ---------
+    mov cx, [HS_N]
+    cmp cx, [HS_LEFT]
+    jbe .cap1
+    mov cx, [HS_LEFT]
+.cap1:
+    mov bx, [HS_K]
+    cmp bx, 3
+    jae .high
+    mov cx, 1                   ; file sectors 0..2 go to 0060:0000, singly
+    mov bx, 0x0060
+    jmp short .go
+.high:
+    push cx
+    mov cl, 5
+    shl bx, cl                  ; ES = k * 32: linear k * 512
+    mov ax, bx
+    and ax, 0x0FFF
+    neg ax
+    add ax, 0x1000              ; paragraphs to the 64KB page's end...
+    shr ax, cl                  ; ...in sectors
+    pop cx
+    cmp cx, ax
+    jbe .go
+    mov cx, ax
+.go:
+    mov [HS_N], cx
+    mov es, bx
+    xor bx, bx
+    mov di, 3                   ; tries
+.try:
+    mov ax, [HS_N]
+    mov ah, 0x02
+    mov cx, [HS_CHS]
+    mov dx, [HS_CHS+2]
+    sti                         ; the ROM wants its interrupts on an AT
+    int 0x13
+    jnc .ok
+    xor ah, ah
+    mov dl, [HS_UNIT]
+    int 0x13                    ; reset, and again
+    dec di
+    jnz .try
+    jmp short .fail
+.ok:
+    mov bx, [HS_K]
+    cmp bx, 2
+    jae .advance
+    ; --- file sector 0 or 1: the IVT, into the staging area for later -------
+    push ds
+    push si
+    mov cl, 9
+    shl bx, cl
+    add bx, HS_IVT
+    mov di, bx
+    mov ax, cs
+    mov es, ax
+    mov ax, 0x0060
+    mov ds, ax
+    xor si, si
+    mov cx, 256
+    rep movsw
+    pop si
+    pop ds
+.advance:
+    mov ax, [HS_N]
+    add [HS_K], ax
+    add [HS_LBA], ax
+    adc word [HS_LBA+2], 0
+    sub [HS_LEFT], ax
+    jmp .run
+.nextext:
+    add si, 8
+    pop cx
+    dec cx
+    jmp .extent
+.done:
+    cli                         ; --- the IVT goes back last, under cli ------
+    xor ax, ax
+    mov es, ax
+    xor di, di
+    mov si, HS_IVT
+    mov cx, 512
+    rep movsw
+    mov al, [HS_MASKM]
+    out 0x21, al
+    mov al, [HS_MASKS]
+    out 0xA1, al
+    mov ax, KERNEL_SEG
+    mov ds, ax
+    mov ss, [cs:HS_SS]
+    mov sp, [cs:HS_SP]
+    jmp far [cs:HS_WAKE]
+.fail:
+    mov si, hbs_s_fail - hbs_stub
+.ch:
+    mov al, [si]
+    or al, al
+    jz .key
+    mov ah, 0x0E
+    mov bx, 0x0007
+    int 0x10
+    inc si
+    jmp short .ch
+.key:
+    xor ah, ah
+    int 0x16
+    int 0x19
+    jmp $
+hbs_s_fail: db 13, 10, 'Resume failed: the disk could not be read.', 13, 10
+            db 'Press any key to restart.', 13, 10, 0
+hbs_stub_end:
+%if hbs_stub_end - hbs_stub > HS_CODE_MAX
+  %error "hiber: the resume stub is bigger than its staging slot"
+%endif
+
+; =============================================================================
+; The image's own data (SPEC.md 2.8.6): strings read through CS, and the
+; pointer's buffer, which dskw_write and dskw_read reach as ES:BX.
+; =============================================================================
+hbm_ptrbuf:     times HBP_SIZE db 0
+
+hbm_lines_ask:  dw hbm_s_a1, hbm_s_a2, hbm_s_a3, 0
+hbm_lines_busy: dw hbm_s_b1, 0
+hbm_lines_res:  dw hbm_s_r1, hbm_s_r2, hbm_s_r3, 0
+
+hbm_s_a1:   db 'Save everything in memory to', 0
+hbm_s_a2:   db 'C:\HIBERNAT.IMG and stop the machine?'
+HBM_A2_LTR  equ 0
+            db 0
+hbm_s_a3:   db 'Restarting offers to resume it.', 0
+hbm_s_b1:   db 'Hibernating...', 0
+hbm_s_r1:   db 'A hibernation file is on drive '
+HBM_R1_LTR  equ $ - hbm_s_r1
+            db 'C:.', 0        ; 34 cells: the content is 39 wide
+hbm_s_r2:   db 'Resume where you left off, or', 0
+hbm_s_r3:   db 'discard it and start normally?', 0
+
+hbm_s_bhib: db 'Hibernate', 0
+hbm_s_bcan: db 'Cancel', 0
+hbm_s_bres: db 'Resume', 0
+hbm_s_bdis: db 'Discard', 0
+
+hbm_s_nobios: db 'Hibernate needs a BIOS-known hard disk', 0
+hbm_s_noroom: db 'Not enough room for the hibernation file', 0
+hbm_s_failed: db 'Hibernate failed', 0
+hbm_s_stale:  db 'Hibernation file is from another build', 0
+hbm_s_lost:   db 'Hibernation file could not be read', 0
+
+hbm_s_off:  db 13, 10, 'os8088 has hibernated.', 13, 10, 13, 10
+            db 'It is now safe to switch the machine off.', 13, 10
+            db 'Press any key to restart it.', 13, 10, 0
+
+%else                           ; --- kern_small: a stub module, so every
+                                ; kernel cuts the same four files ----------
+section .modh
+modh_hdr:
+    dw 0x384F
+    db MOD_VER
+    db MOD_HIBER
+    dw BUILD_NUM
+    dw MOD_STAMP
+    dw modh_end
+    dw 1
+    dw modh_e_none
+    times MOD_NENT - 1 dw 0
+modh_e_none:    stc
+                retf
+%endif
+
+section .text                   ; every module ends where the next include
+                                ; expects to begin (SPEC.md 1)

--- a/kernel/instance.inc
+++ b/kernel/instance.inc
@@ -61,8 +61,8 @@ KIND_FILES   equ 3
 KIND_CTRL    equ 4              ; (the Task Manager was kind 4 until it
                                 ;  became the TASKMGR package - SPEC.md 28)
 KIND_HIBER   equ 5              ; the Hibernate window (SPEC.md 86.1): the
-                                ; file dialog's requester, and the boot-time
-                                ; question. kern_big only
+                                ; confirmation, and the boot-time question.
+                                ; kern_big only
 KIND_PKG     equ 0x80           ; bit 7: package instance
 
 ; --- osapi_sys_snapshot's buffer, API slot 0x0298 (SPEC.md 20.9) ------------------
@@ -1549,6 +1549,13 @@ app_close_win:
                                 ; with it, and the ordering is what makes
                                 ; that impossible rather than a claim about
                                 ; whose slot inst_caller answers with
+%ifdef KERN_BIG
+    cmp byte [di+I_KIND], KIND_HIBER
+    jne .nohib
+    call COLD_SEG:hbf_closed    ; the Hibernate window went by a route its
+.nohib:                         ; module did not take - the close box, Close
+%endif                          ; Window, the Task Manager - so the image can
+                                ; go now (SPEC.md 86.1)
     cmp byte [di+I_KIND], KIND_CTRL
     jne .noflush                ; the Control Panel defers its settings write
     call COLD_SEG:drv_cp_closed_x ; ...and tell the drivers, which is where the

--- a/kernel/instance.inc
+++ b/kernel/instance.inc
@@ -60,6 +60,9 @@ KIND_BOUNCE  equ 2              ;  NOTEPAD package - SPEC.md 27; kind 1 was
 KIND_FILES   equ 3
 KIND_CTRL    equ 4              ; (the Task Manager was kind 4 until it
                                 ;  became the TASKMGR package - SPEC.md 28)
+KIND_HIBER   equ 5              ; the Hibernate window (SPEC.md 86.1): the
+                                ; file dialog's requester, and the boot-time
+                                ; question. kern_big only
 KIND_PKG     equ 0x80           ; bit 7: package instance
 
 ; --- osapi_sys_snapshot's buffer, API slot 0x0298 (SPEC.md 20.9) ------------------
@@ -128,6 +131,12 @@ inst_kinds:                     ; indexed by KIND_* * 16; caps are binding
     dw cp_tpl,         0,               0,             0,   cp_kinit,         cp_sname
     dw inst_ico_ctrl
     db 1, 0                     ; Control Panel: stateless task-less singleton
+%ifdef KERN_BIG
+    dw hb_tpl,         0,               0,             0,   hb_kinit,         hb_ttl
+    dw 0                        ; the generic icon: it is never in the dock
+    db 1, 0                     ; Hibernate: stateless task-less singleton
+                                ; (SPEC.md 86.1), painted by its module
+%endif
 
 ; --- the built-in kinds' icons (SPEC.md 25/29.3) -----------------------------
 ; 16 mask words then 16 data words, bit 15 leftmost - icon_draw16's layout,

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -2191,6 +2191,7 @@ section .ovl     start=OVL_AT vstart=OVL_AT
 section .modc    start=MODC_START vstart=0
 section .modf    start=MODF_START vstart=0
 section .modl    start=MODL_START vstart=0
+section .modh    start=MODH_START vstart=0
 section .modmap  start=MODMAP_START vstart=0
 section .text
 
@@ -4343,6 +4344,13 @@ kmain:
                                 ; settings file did not ask for - a driver is
                                 ; several seconds of floppy on this machine
     MARK 29
+%ifdef KERN_BIG
+    call COLD_SEG:hb_probe_x    ; ...and is there a hibernation to resume?
+                                ; (SPEC.md 86.5) After drv_boot, so a driver
+                                ; volume is mounted to be looked at; before
+                                ; the first paint, because the answer is a
+                                ; window ui_task's first pass puts up
+%endif
 
     ; --- the overlay is dead from here, and costs nothing to say so ---------
     ; drv_boot was the last thing that wanted it. It is part of the blob now
@@ -4966,6 +4974,10 @@ section .text
 %include "desk.inc"
 %include "dock.inc"
 %include "ctrl.inc"
+%include "hiber.inc"            ; hibernate and resume (SPEC.md 86): the
+                                ; resident thunks, the probe, and HIBER.DRV.
+                                ; After files.inc for PTH_MAX and after
+                                ; mod.inc for MOD_NENT - both are sizes here
 %include "driver.inc"           ; loadable drivers (SPEC.md 51): after
                                 ; diskw (it reads and writes the system disk)
                                 ; and memory (a driver image is a claim)
@@ -5627,6 +5639,23 @@ cw_wm_onmouseup:        call wm_onmouseup
                     retf
 cw_wm_ondrag:           call wm_ondrag
                     retf
+; ...and the seven HIBER.DRV needs (SPEC.md 86): a kernel window closed from
+; its own release handler, and the reboot path's and fsx_restore's pieces -
+; text mode out, the desktop mode back, the two forced strips, the idle clock
+cw_app_close_win:       call app_close_win
+                    retf
+cw_vid_reboot:          call vid_reboot
+                    retf
+cw_vid_setmode:         call vid_setmode
+                    retf
+cw_menu_force:          call menu_force
+                    retf
+cw_dock_force:          call dock_force
+                    retf
+cw_blk_wake:            call blk_wake
+                    retf
+cw_sched_unhook:        call sched_unhook
+                    retf
 %endif
 cw_wm_dmg_add:           call wm_dmg_add
                      retf
@@ -6104,7 +6133,8 @@ OVL_SIZE equ ovl_end - $$       ; `$$` is the SECTION's base, which is OVL_AT
 MODC_START   equ COLD_START + COLD_SIZE
 MODF_START   equ MODC_START + MODC_SIZE
 MODL_START   equ MODF_START + MODF_SIZE
-MODMAP_START equ MODL_START + MODL_SIZE
+MODH_START   equ MODL_START + MODL_SIZE
+MODMAP_START equ MODH_START + MODH_SIZE
 
 section .modc
 modc_end:
@@ -6117,6 +6147,10 @@ MODF_SIZE equ modf_end - $$
 section .modl
 modl_end:
 MODL_SIZE equ modl_end - $$
+
+section .modh
+modh_end:
+MODH_SIZE equ modh_end - $$
 
 ; ...and each of them has to fit the claim mod_need makes for it. MOD_MAX_KB
 ; (mod.inc) is a RUN-TIME test - a module over it is refused cleanly, the
@@ -6131,6 +6165,9 @@ MODL_SIZE equ modl_end - $$
 %endif
 %if MODL_SIZE > MOD_MAX_KB*1024
 %error "the clone module is over MOD_MAX_KB - mod_need would refuse it at run time"
+%endif
+%if MODH_SIZE > MOD_MAX_KB*1024
+%error "the hibernate module is over MOD_MAX_KB - mod_need would refuse it at run time"
 %endif
 
 ; --- the split table, which is HOST-SIDE ONLY --------------------------------
@@ -6155,6 +6192,7 @@ mod_map:
                                 ; flags but this tree's -w+error
     dd MODF_START, MODF_SIZE
     dd MODL_START, MODL_SIZE
+    dd MODH_START, MODH_SIZE
     dd MODMAP_START             ; ...where the table began, and
     dw 0x384F                   ; the last two bytes of the file
 modmap_end:

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -4976,8 +4976,7 @@ section .text
 %include "ctrl.inc"
 %include "hiber.inc"            ; hibernate and resume (SPEC.md 86): the
                                 ; resident thunks, the probe, and HIBER.DRV.
-                                ; After files.inc for PTH_MAX and after
-                                ; mod.inc for MOD_NENT - both are sizes here
+                                ; After mod.inc for MOD_NENT, a size here
 %include "driver.inc"           ; loadable drivers (SPEC.md 51): after
                                 ; diskw (it reads and writes the system disk)
                                 ; and memory (a driver image is a claim)

--- a/kernel/memory.inc
+++ b/kernel/memory.inc
@@ -114,11 +114,6 @@ MEM_K_CLONE equ 0xFF09          ; the disk cloner's buffer (SPEC.md 18.99) -
 ; a value that has meant one thing in a shipped kernel and something else in
 ; the next is exactly the kind of collision a debug read cannot see.
 MEM_K_BAND equ 0xFF0A           ; the 1bpp band composer's buffer (SPEC.md
-MEM_K_HIB  equ 0xFF0B           ; the resume's extent list (SPEC.md 86.5):
-                                ; claimed on the way into the stub and never
-                                ; freed, because the machine it is in is
-                                ; about to be overwritten; freed on the one
-                                ; path that turns back
                                 ; 5.9.2) - taken ONCE at boot and never freed,
                                 ; because a composer with nowhere to compose
                                 ; is a composer that silently stops composing.
@@ -127,6 +122,12 @@ MEM_K_HIB  equ 0xFF0B           ; the resume's extent list (SPEC.md 86.5):
                                 ; 128px band and 2KB of the arena buys a band
                                 ; as wide as the screen, and SPEC.md 5.9.1's
                                 ; cost is per CHUNK
+MEM_K_HIB  equ 0xFF0C           ; the resume's extent list (SPEC.md 86.5):
+                                ; claimed on the way into the stub and never
+                                ; freed, because the machine it is in is
+                                ; about to be overwritten; freed on the one
+                                ; path that turns back. 0xFF0C and not the
+                                ; retired 0xFF0B above, for the reason above
 MEM_K_CLIP equ 0xFF07           ; the system clipboard's text (SPEC.md 55) -
                                 ; sized to what is in it, freed when it is
                                 ; emptied, and deliberately NOT an instance's,

--- a/kernel/memory.inc
+++ b/kernel/memory.inc
@@ -114,6 +114,11 @@ MEM_K_CLONE equ 0xFF09          ; the disk cloner's buffer (SPEC.md 18.99) -
 ; a value that has meant one thing in a shipped kernel and something else in
 ; the next is exactly the kind of collision a debug read cannot see.
 MEM_K_BAND equ 0xFF0A           ; the 1bpp band composer's buffer (SPEC.md
+MEM_K_HIB  equ 0xFF0B           ; the resume's extent list (SPEC.md 86.5):
+                                ; claimed on the way into the stub and never
+                                ; freed, because the machine it is in is
+                                ; about to be overwritten; freed on the one
+                                ; path that turns back
                                 ; 5.9.2) - taken ONCE at boot and never freed,
                                 ; because a composer with nowhere to compose
                                 ; is a composer that silently stops composing.

--- a/kernel/menu.inc
+++ b/kernel/menu.inc
@@ -63,18 +63,27 @@
 CMD_ABOUT   equ 1               ; --- System (cell 0, every application) ---
 CMD_CTRL    equ 2
 CMD_TASKS   equ 3
-CMD_SEP     equ 4               ; the RULE above Restart. It is a MENU_DIS
+CMD_SEP     equ 4               ; the RULE above Hibernate. It is a MENU_DIS
                                 ; item, so menu_hover can never land on it -
                                 ; and it needs no handler either, because
                                 ; ui_cmd is a compare ladder and an id it
                                 ; does not match falls out of the bottom and
                                 ; returns. The id exists only so that
-                                ; CMD_REBOOT below it still equals base+item
+                                ; the items below it still equal base+item
+%ifdef KERN_BIG
+CMD_HIBER   equ 5               ; Hibernate... (SPEC.md 86), kern_big only:
+CMD_REBOOT  equ 6               ; kern_small's menu has no such item and its
+CMD_CLOSE   equ 7               ; ids stay one lower
+CMD_TIMER   equ 8               ; --- Locator: Builtins (SPEC.md 12.3.1) ---
+CMD_BOUNCE  equ 9
+CMD_FILES   equ 10
+%else
 CMD_REBOOT  equ 5
 CMD_CLOSE   equ 6               ; --- Locator: File ---
 CMD_TIMER   equ 7               ; --- Locator: Builtins (SPEC.md 12.3.1) ---
 CMD_BOUNCE  equ 8
 CMD_FILES   equ 9
+%endif
 
 ; --- app menu set layout (SPEC.md 12.2; mirrored in apps/os88api.inc) --------
 AM_NAME     equ 0               ; word: NUL app name for the bar label; 0 =
@@ -2538,11 +2547,23 @@ menu_s_closex   db MENU_DIS, 'Close Window', 0  ; ...with nothing to close;
                                 ; other before the menu can drop (SPEC.md 47)
 menu_s_tasks    db 'Task Manager', 0
 menu_s_restart  db 'Restart', 0
+%ifdef KERN_BIG
+menu_s_hiber    db 'Hibernate...', 0        ; SPEC.md 86.2: ui_loc_gate points
+menu_s_hibernh  db MENU_DIS, 'Hibernate (No HD)', 0  ; item 4 at one of the
+menu_s_hiberxm  db MENU_DIS, 'Hibernate (XMS)', 0    ; three, and the two
+                                ; greyed ones say WHY NOT (SPEC.md 47 rule 3)
+menu_s_msep     db MENU_DIS, '-----------------', 0
+                                ; the rule above Hibernate: seventeen dashes,
+                                ; the width of 'Hibernate (No HD)', so it
+                                ; reads as a rule across the menu rather than
+                                ; as a short dash in the middle of one
+%else
 menu_s_msep     db MENU_DIS, '---------------', 0
                                 ; the rule above Restart: fifteen dashes, the
                                 ; width of 'About os8088...', so it reads as a
                                 ; rule across the menu rather than as a short
                                 ; dash in the middle of one
+%endif
 
 ; The app-name menu's bottom item (SPEC.md 12.7), and the whole of the dock
 ; tile's context menu (SPEC.md 30.2) - dock_ctx_items points here. One
@@ -2559,8 +2580,14 @@ menu_items_logo:
     dw menu_s_ctrl
     dw menu_s_tasks
     dw menu_s_msep
+%ifdef KERN_BIG
+    dw menu_s_hiber             ; item 4, swapped by ui_loc_gate (SPEC.md 86.2)
+    dw menu_s_restart
+MENU_LOGO_N equ 6               ; ...and menu_relayout stamps this into cell
+%else
     dw menu_s_restart
 MENU_LOGO_N equ 5               ; ...and menu_relayout stamps this into cell
+%endif
                                 ; 0's MB_NITEM. It was a literal 3 there, in
                                 ; a different file from the list it counts
 menu_items_file:

--- a/kernel/mod.inc
+++ b/kernel/mod.inc
@@ -35,7 +35,7 @@
 ; NOTHING HERE CAN STOP ANYTHING. Every failure - no system disk, no heap, a
 ; short read, a stamp mismatch - is CF = 1 out of mod_need, and every caller
 ; owes a refusal the user can act on (SPEC.md 47 rule 3, and 59's toast is
-; where all three of the current ones say it).
+; where all four of the current ones say it).
 ; =============================================================================
 
 MOD_MAX     equ 4               ; rows in mod_tab

--- a/kernel/mod.inc
+++ b/kernel/mod.inc
@@ -38,10 +38,11 @@
 ; where all three of the current ones say it).
 ; =============================================================================
 
-MOD_MAX     equ 3               ; rows in mod_tab
+MOD_MAX     equ 4               ; rows in mod_tab
 MOD_CTRL    equ 0               ; the Control Panel (SPEC.md 31)
 MOD_FMT     equ 1               ; the floppy formatter (SPEC.md 18.96)
 MOD_CLONE   equ 2               ; the disk cloner (SPEC.md 18.99)
+MOD_HIBER   equ 3               ; hibernate and resume (SPEC.md 86)
 
 MOD_NENT    equ 8               ; far-pointer slots reserved per module. A
                                 ; fixed stride, so a thunk's
@@ -144,6 +145,9 @@ section .text
 mod_f_ctrl: db 'CTRL.DRV', 0    ; .DRV for the attributes and nothing else
 mod_f_fmt:  db 'FORMAT.DRV', 0  ; (SPEC.md 19.6): os88disk.py stamps anything
 mod_f_clon: db 'CLONE.DRV', 0   ; ...and a third of them (SPEC.md 18.99)
+mod_f_hib:  db 'HIBER.DRV', 0   ; ...and a fourth: hibernate (SPEC.md 86),
+                                ; which qualifies twice - the user is leaving
+                                ; the machine, or has just booted it
                                 ; ending DRV read-only + hidden + system by
                                 ; EXTENSION, the installer's `*.DRV` copy rule
                                 ; picks it up, and neither of these is in
@@ -154,6 +158,7 @@ mod_tab:
     dw 0, mod_f_ctrl, 0, 0      ; MOD_CTRL
     dw 0, mod_f_fmt,  0, 0      ; MOD_FMT
     dw 0, mod_f_clon, 0, 0      ; MOD_CLONE
+    dw 0, mod_f_hib,  0, 0      ; MOD_HIBER
 
 section .cold                   ; ...and the loader itself
 

--- a/kernel/ui.inc
+++ b/kernel/ui.inc
@@ -46,6 +46,12 @@
 ; frozen UI, and a toast about a disk the user was asked to remove.
 UI_RBQ_FLUSH   equ 1            ; flush the Control Panel on the way out
 UI_RBQ_NOFLUSH equ 2            ; ...and do not go near a disk at all
+UI_RBQ_HIBER   equ 3            ; SPEC.md 86: write the image and stop
+UI_RBQ_RESUME  equ 4            ; ...put an image back
+UI_RBQ_ASK     equ 5            ; ...and ask whether to, at boot. All three
+                                ; are spent by the same top-of-pass site as
+                                ; a restart, for the same reason (20.10):
+                                ; what they do detaches drivers and yields
 
 UI_TDBLT    equ 9               ; title-bar double-click window, ticks - the
                                 ; same half second as DESK_DBLT, FM_DBLCLK
@@ -74,11 +80,19 @@ ui_task:
     ; --- 0. a posted restart, spent with NOTHING held (SPEC.md 20.10) --------
     cmp byte [ui_rebootq], 0
     je .keys
-    mov al, [ui_rebootq]        ; what the poster ASKED for, carried into AL:
-    sub al, UI_RBQ_FLUSH        ; 0 = flush the panel first, non-0 = do not
+    mov al, [ui_rebootq]        ; what the poster ASKED for, carried into AL
     mov byte [ui_rebootq], 0    ; ...cleared first: ui_cmd_reboot does not
-    call ui_cmd_reboot          ; return, but a path that ever did must not
+                                ; return, but a path that ever did must not
                                 ; find the post still standing
+%ifdef KERN_BIG
+    cmp al, UI_RBQ_HIBER        ; a hibernate, a resume or the question
+    jb .restart                 ; (SPEC.md 86): these DO return - on a
+    call COLD_SEG:hbf_perform   ; refusal, a Discard, or once the question
+    jmp .keys                   ; is on the screen
+.restart:
+%endif
+    sub al, UI_RBQ_FLUSH        ; 0 = flush the panel first, non-0 = do not
+    call ui_cmd_reboot
 .keys:
     ; --- 1. keyboard: poll, and feed the front window's key handler ----------
     mov ah, 0x01                ; any key pending?
@@ -2069,6 +2083,17 @@ ui_loc_gate:
     mov [menu_items_file], ax   ; Close Window is item 0 now: Locator's File
                                 ; menu is that item and nothing else, the
                                 ; builtins having moved to Builtins (12.3.1)
+%ifdef KERN_BIG
+    call COLD_SEG:hb_ok_x       ; ...and Hibernate greys with its reason
+    mov bx, menu_s_hiber        ; (SPEC.md 86.2): no fixed disk, or extended
+    jnc .hset                   ; memory held that the image would not carry.
+    mov bx, menu_s_hibernh      ; BX for the string, because AL IS the reason
+    cmp al, 1                   ; and a `mov ax` here read '(XMS)' on a
+    je .hset                    ; floppy-only machine
+    mov bx, menu_s_hiberxm
+.hset:
+    mov [menu_items_logo + 8], bx   ; item 4 of the System menu
+%endif
     pop bx
     pop ax
     ret
@@ -2658,8 +2683,18 @@ ui_cmd:
     je .tasks
     cmp ax, CMD_REBOOT
     je .reboot
+%ifdef KERN_BIG
+    cmp ax, CMD_HIBER
+    je .hiber
+%endif
 .done:
     ret
+
+%ifdef KERN_BIG
+.hiber:
+    call COLD_SEG:hbf_open      ; the module first, then the window (SPEC.md
+    ret                         ; 86.1) - cp_open's shape, and its refusal
+%endif
 
 .about:
     mov al, KIND_ABOUT

--- a/tests/hibernate.py
+++ b/tests/hibernate.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Hibernate to the hard disk, and come back (SPEC.md 86).
+
+    python3 tests/hibernate.py            # the boot partition: DVK_BIOS
+    python3 tests/hibernate.py --driver   # ...and through HDD.DRV: DVK_DRV
+
+A fixture volume out of tools/os88hdd.py, with HIBER.DRV, CTRL.DRV and
+HDD.DRV in its root, on MartyPC's os8088_xt_hdd - XT-IDE's option ROM, which
+is rung 0 (SPEC.md 52.1), the transport the field machine has and the only
+one the resume stub speaks.
+
+Two passes, and each ASSERTS out of the guest's memory rather than out of a
+screenshot, because the thing under test is that memory:
+
+  1. RESUME. An About box is opened as the witness. Hibernate... is picked
+     from the System menu and the Hibernate window's first button is CLICKED
+     WITH THE MOUSE (the release path: its hit test once clobbered the y and
+     no click ever landed - only Enter worked), the machine writes the image
+     to the boot disk's root without asking where, and reaches the ROM's text
+     mode with its sentence; a key restarts it. The fresh desktop must carry
+     the question ([hb_mode] = HB_M_RESUME and a live KIND_HIBER instance), a
+     CLICK on Resume must answer it, and the desktop that comes back must be
+     the OLD one: [hb_resumes] = 1, the About instance alive with its window,
+     no Hibernate window left, and HIBERNAT.PTR gone from the volume.
+  2. DISCARD. The same again through the KEYBOARD - Enter to hibernate, Esc at
+     the question: the desktop is a fresh boot's - no About, [hb_resumes] = 0
+     - and the pointer is gone all the same.
+
+--driver boots the same VHD from a 360KB floppy whose SYSTEM.CFG already wants
+HDD.DRV (the ethertest shape), so C: is a DRIVER volume and the transport
+facts come through DSV_GEOM rather than out of the kernel's own table.
+
+REQUIRES: build/martypc (docs/MARTYPC-DEBUG.md). Writes only under build/.
+"""
+import argparse
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, "tools")
+sys.path.insert(0, "tests/unit")
+sys.path.insert(0, "tests")
+import os88marty as M                                     # noqa: E402
+from harness import check, done                           # noqa: E402
+
+RUN = "build/martypc/run"
+TEMPLATE = os.path.join(RUN, "media/hdds/default_xtide.vhd")
+VHD = os.path.abspath("build/hiber.vhd")
+FLOPPY = "build/hiber360.img"
+MACHINE = "os8088_xt_hdd"
+
+# kernel/hiber.inc, kernel/instance.inc - the module's own constants
+HB_M_ASK, HB_M_BUSY, HB_M_RESUME, HB_M_GONE = 0, 1, 2, 3
+KIND_ABOUT, KIND_HIBER = 0, 5
+I_RECSZ, INST_MAX = 32, 12
+I_STATE, I_KIND, I_WIN = 0, 2, 4
+W_FLAGS = 0
+from os88geom import WIN_SIZE, MAX_WIN                    # noqa: E402
+
+CHIP_X, CHIP_Y = 8, 8               # the System menu's cell
+ITEM_Y0, ITEM_H = 24, 16            # MENU_ITEM_H: item n is at 24 + 16n
+ABOUT_Y = ITEM_Y0 + 0 * ITEM_H
+HIBER_Y = ITEM_Y0 + 4 * ITEM_H      # About, Control Panel, Task Manager,
+                                    # the rule, Hibernate..., Restart
+# hiber.inc: the content is at W_X+1, W_Y+TITLE_H (18); the first button at
+# content +8,+54, 120 x 16 - so its middle is this far from the FRAME, and
+# the frame is read out of the window record, because the template's 160,150
+# is only where a 480-line screen leaves it: a CGA moves it up to fit
+BTN1_DX, BTN1_DY = 1 + 8 + 60, 18 + 54 + 8
+W_X, W_Y = 2, 4
+
+
+def button1(m):
+    """Screen coordinates of the Hibernate window's first button."""
+    win = [w for k, w in instances(m) if k == KIND_HIBER][0]
+    r = m.readseg(0x0060, win, 6)
+    x, y = struct.unpack_from("<HH", r, W_X)
+    return x + BTN1_DX, y + BTN1_DY
+
+
+def fixture():
+    """The VHD, rebuilt from the tree every run: KERNEL.SYS plus the three
+    modules and the driver the boot volume must carry (SPEC.md 2.8.4)."""
+    subprocess.check_call(
+        ["python3", "tools/os88hdd.py", "--template", TEMPLATE, "--out", VHD,
+         "--kernel", "build/kernel.bin", "--vbr", "build/boothd.bin",
+         "--mbr", "build/mbr.bin",
+         "--file", "HIBER.DRV=build/hiber.drv",
+         "--file", "CTRL.DRV=build/ctrl.drv",
+         "--file", "HDD.DRV=build/hdd.drv"])
+
+
+def floppy():
+    """A 360KB system disk whose SYSTEM.CFG wants HDD.DRV (row 1 = bit 1),
+    the Makefile's ethertest shape."""
+    os.makedirs("build/hibcfg", exist_ok=True)
+    cfg = "build/hibcfg/system.cfg"          # its basename IS the file's name
+    with open(cfg, "wb") as f:
+        f.write(b"O88CFG\0\0" + (3).to_bytes(2, "little") + b"DW"
+                + bytes([1, 2]) + (1 << 1).to_bytes(2, "little") + b"\0\0")
+    subprocess.check_call(
+        ["python3", "tools/os88disk.py", "-o", FLOPPY, "--size", "360",
+         "--boot", "build/boot360.bin", "--kernel", "build/kernel.bin",
+         "build/hdd.drv", "build/hiber.drv", "build/ctrl.drv", "build/format.drv",
+         "build/clone.drv", cfg])
+
+
+def byte(m, name):
+    return m.read(m.sym(name), 1)[0]
+
+
+def word(m, name):
+    return int.from_bytes(m.read(m.sym(name), 2), "little")
+
+
+def instances(m):
+    """[(kind, win)] of every LIVE instance record."""
+    b = m.read(m.sym("inst_tab"), I_RECSZ * INST_MAX)
+    out = []
+    for i in range(INST_MAX):
+        r = b[i * I_RECSZ:(i + 1) * I_RECSZ]
+        if r[I_STATE] == 1:
+            out.append((r[I_KIND], struct.unpack_from("<H", r, I_WIN)[0]))
+    return out
+
+
+def visible(m, winptr):
+    """Is the window at KERNEL offset winptr used and visible?"""
+    if not winptr:
+        return False
+    flags = int.from_bytes(m.readseg(0x0060, winptr, 2), "little")
+    return (flags & 3) == 3
+
+
+def shot(m, name):
+    """A rendered screenshot into build/, for the eye (the assertions are
+    the memory reads, not this)."""
+    try:
+        M.write_png_rgb("build/hiber-%s.png" % name, 640, 200,
+                        M.crop_rgb(m, 0, 0, 640, 200))
+    except Exception as e:                       # a picture is not a check
+        print("shot %s: %s" % (name, e))
+
+
+def quiet(m, s=8.0):
+    try:
+        M.settle(m, limit=s)
+    except M.MartyError:
+        pass
+
+
+def ptr_present():
+    """Does the VHD's root carry HIBERNAT.PTR? Read on the host with a FAT
+    reader that is not the kernel's."""
+    import instdeep
+    blob = open(VHD, "rb").read()
+    base = int.from_bytes(blob[446 + 8:446 + 12], "little")
+    vol = instdeep.Vol(blob[base * 512:])
+    return "HIBERNAT.PTR" in [e[0] for e in vol.entries(0)]
+
+
+def boot(driver):
+    if driver:
+        return M.launch(FLOPPY, machine=MACHINE,
+                        extra=["--mount", "hd:0:" + VHD])
+    return M.launch(None, machine=MACHINE, extra=["--mount", "hd:0:" + VHD])
+
+
+def hibernate(m, mo, mouse):
+    """From a desktop with the witness up to the ROM's text screen, the
+    Hibernate button taken with the mouse or with Enter."""
+    mo.menu(CHIP_X, CHIP_Y, CHIP_X, HIBER_Y)      # System -> Hibernate...
+    quiet(m)
+    check(byte(m, "hb_mode") == HB_M_ASK, "the Hibernate window opened",
+          got=byte(m, "hb_mode"), want=HB_M_ASK)
+    check(any(k == KIND_HIBER for k, _ in instances(m)),
+          "a KIND_HIBER instance is live")
+    shot(m, "ask")
+    if mouse:
+        mo.click(*button1(m))                     # [Hibernate]
+    else:
+        m.key("Enter")
+    M.until(m, lambda mm: M.video_is_text(mm.video()),
+            "the hibernated sentence in text mode", poll=0.5, limit=240)
+
+
+def pass_resume(driver):
+    with boot(driver) as m:
+        from os88mouse import Mouse
+        mo = Mouse(marty=m)
+        r0 = word(m, "hb_resumes")
+        check(r0 == 0, "a fresh boot has resumed nothing", got=r0, want=0)
+        mo.menu(CHIP_X, CHIP_Y, CHIP_X, ABOUT_Y)  # the witness
+        quiet(m)
+        check(any(k == KIND_ABOUT for k, _ in instances(m)),
+              "the About box is up before hibernating")
+        hibernate(m, mo, mouse=True)
+        m.key("Space")                            # ...and restart
+        time.sleep(1.0)
+        M.settle(m, limit=240)
+        check(byte(m, "hb_mode") == HB_M_RESUME,
+              "the fresh boot asks the question",
+              got=byte(m, "hb_mode"), want=HB_M_RESUME)
+        check(any(k == KIND_HIBER for k, _ in instances(m)),
+              "the question is a live KIND_HIBER instance")
+        check(not any(k == KIND_ABOUT for k, _ in instances(m)),
+              "the fresh boot has no About box yet")
+        shot(m, "question")
+        mo.click(*button1(m))                     # [Resume], with the mouse
+        M.until(m, lambda mm: word(mm, "hb_resumes") == 1,
+                "[hb_resumes] to reach 1", poll=0.5, limit=240)
+        quiet(m)
+        inst = instances(m)
+        about = [w for k, w in inst if k == KIND_ABOUT]
+        check(len(about) == 1, "the About box came back with the memory",
+              got=inst, want="one KIND_ABOUT")
+        check(about and visible(m, about[0]), "...and its window is visible")
+        check(not any(k == KIND_HIBER for k, _ in inst),
+              "the Hibernate window closed itself on waking", got=inst)
+        check(byte(m, "hb_mode") == HB_M_GONE, "the module's state is GONE",
+              got=byte(m, "hb_mode"), want=HB_M_GONE)
+        check(byte(m, "sch_lock") == 0, "sch_lock is down again",
+              got=byte(m, "sch_lock"), want=0)
+        check(byte(m, "gfx_lock_flag") == 0, "the gfx lock is released",
+              got=byte(m, "gfx_lock_flag"), want=0)
+        t0 = word(m, "ticks")
+        time.sleep(1.5)
+        check(word(m, "ticks") != t0, "the tick is running after the resume")
+        shot(m, "resumed")
+        # the menu bar still answers: open and close the System menu
+        mo.menu(CHIP_X, CHIP_Y, CHIP_X, CHIP_Y)
+        quiet(m)
+    check(not ptr_present(), "HIBERNAT.PTR is gone after a resume")
+
+
+def pass_discard(driver):
+    with boot(driver) as m:
+        from os88mouse import Mouse
+        mo = Mouse(marty=m)
+        mo.menu(CHIP_X, CHIP_Y, CHIP_X, ABOUT_Y)
+        quiet(m)
+        hibernate(m, mo, mouse=False)
+        m.key("Space")
+        time.sleep(1.0)
+        M.settle(m, limit=240)
+        check(byte(m, "hb_mode") == HB_M_RESUME, "the question, again",
+              got=byte(m, "hb_mode"), want=HB_M_RESUME)
+        m.key("Escape")                           # Discard
+        quiet(m)
+        inst = instances(m)
+        check(not any(k == KIND_HIBER for k, _ in inst),
+              "Discard closed the window", got=inst)
+        check(not any(k == KIND_ABOUT for k, _ in inst),
+              "...and the desktop is the fresh boot's: no About", got=inst)
+        check(word(m, "hb_resumes") == 0, "nothing was resumed",
+              got=word(m, "hb_resumes"), want=0)
+    check(not ptr_present(), "HIBERNAT.PTR is gone after a discard")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--driver", action="store_true",
+                    help="boot from a floppy and reach the disk through HDD.DRV")
+    ap.add_argument("--only", choices=["resume", "discard"])
+    a = ap.parse_args()
+    fixture()
+    if a.driver:
+        floppy()
+    if a.only != "discard":
+        pass_resume(a.driver)
+    if a.only != "resume":
+        pass_discard(a.driver)
+    done("hibernate" + (" (driver)" if a.driver else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hibernate.py
+++ b/tests/hibernate.py
@@ -152,14 +152,22 @@ def quiet(m, s=8.0):
         pass
 
 
-def ptr_present():
-    """Does the VHD's root carry HIBERNAT.PTR? Read on the host with a FAT
-    reader that is not the kernel's."""
+def root_has(name):
+    """Does the VHD's root carry NAME? Read on the host with a FAT reader
+    that is not the kernel's."""
     import instdeep
     blob = open(VHD, "rb").read()
     base = int.from_bytes(blob[446 + 8:446 + 12], "little")
     vol = instdeep.Vol(blob[base * 512:])
-    return "HIBERNAT.PTR" in [e[0] for e in vol.entries(0)]
+    return name in [e[0] for e in vol.entries(0)]
+
+
+def ptr_present():
+    return root_has("HIBERNAT.PTR")
+
+
+def img_present():
+    return root_has("HIBERNAT.IMG")
 
 
 def boot(driver):
@@ -185,6 +193,9 @@ def hibernate(m, mo, mouse):
         m.key("Enter")
     M.until(m, lambda mm: M.video_is_text(mm.video()),
             "the hibernated sentence in text mode", poll=0.5, limit=240)
+    check(ptr_present() and img_present(),
+          "both files reached the disk (the positive control for the "
+          "'gone' checks below)")
 
 
 def pass_resume(driver):
@@ -200,7 +211,13 @@ def pass_resume(driver):
         hibernate(m, mo, mouse=True)
         m.key("Space")                            # ...and restart
         time.sleep(1.0)
-        M.settle(m, limit=240)
+        M.until(m, lambda mm: byte(mm, "hb_mode") == HB_M_RESUME,
+                "the fresh boot to ask the question", poll=1.0, limit=240)
+        quiet(m)                                  # ...and paint it. Not a
+                                                  # settle: the ROM's disk
+                                                  # probe holds a static
+                                                  # screen long enough to
+                                                  # pass for a quiet desktop
         check(byte(m, "hb_mode") == HB_M_RESUME,
               "the fresh boot asks the question",
               got=byte(m, "hb_mode"), want=HB_M_RESUME)
@@ -234,6 +251,7 @@ def pass_resume(driver):
         mo.menu(CHIP_X, CHIP_Y, CHIP_X, CHIP_Y)
         quiet(m)
     check(not ptr_present(), "HIBERNAT.PTR is gone after a resume")
+    check(not img_present(), "...and so is HIBERNAT.IMG (SPEC.md 86.6 step 5)")
 
 
 def pass_discard(driver):
@@ -245,7 +263,9 @@ def pass_discard(driver):
         hibernate(m, mo, mouse=False)
         m.key("Space")
         time.sleep(1.0)
-        M.settle(m, limit=240)
+        M.until(m, lambda mm: byte(mm, "hb_mode") == HB_M_RESUME,
+                "the fresh boot to ask the question", poll=1.0, limit=240)
+        quiet(m)
         check(byte(m, "hb_mode") == HB_M_RESUME, "the question, again",
               got=byte(m, "hb_mode"), want=HB_M_RESUME)
         m.key("Escape")                           # Discard
@@ -258,6 +278,7 @@ def pass_discard(driver):
         check(word(m, "hb_resumes") == 0, "nothing was resumed",
               got=word(m, "hb_resumes"), want=0)
     check(not ptr_present(), "HIBERNAT.PTR is gone after a discard")
+    check(not img_present(), "...and so is HIBERNAT.IMG")
 
 
 def main():

--- a/tests/suite.py
+++ b/tests/suite.py
@@ -1031,6 +1031,17 @@ SOAK = [
         "tree - the empty SYSTEM/APPDATA and SYSTEM/DOS/OS88NET.COM included, "
         "which one folder level could not reach. It ERASES the VHD.",
         needs=("marty",), serial=True, timeout=1200),
+    Row("hibernate", "soak", py("tests/hibernate.py"), 300.0,
+        "SPEC.md 86: Hibernate... writes the machine to the hard disk and the "
+        "next boot offers to resume it - the About box is the witness, read "
+        "out of the restored instance table; then the same again with "
+        "Discard. Builds its own VHD under build/",
+        needs=("marty",), serial=True, timeout=1500),
+    Row("hibernatedrv", "soak", py("tests/hibernate.py", "--driver"), 300.0,
+        "SPEC.md 86 through HDD.DRV: a floppy boot whose SYSTEM.CFG wants the "
+        "driver, so C: is a DVK_DRV volume and the resume's transport facts "
+        "come through DSV_GEOM",
+        needs=("marty",), serial=True, timeout=1500),
     Row("instrest", "soak", py("tests/instrest.py"), 240.0,
         "SPEC.md 52.10.6.1: the installer's ACTION BUTTON reads Install and "
         "then Restart, there is no third button, and clicking it at the end "

--- a/tools/heapmap.py
+++ b/tools/heapmap.py
@@ -40,7 +40,7 @@ INST_MAX = 12
 # high byte is a PURGEABLE tag carrying its priority (50.6.4).
 KTAG = {0xFF01: "SAVE",  0xFF03: "DRV",   0xFF04: "COPY",
         0xFF06: "ASC",   0xFF07: "CLIP",  0xFF08: "MOD",  0xFF09: "CLONE",
-        0xFF0A: "BAND",  0xFF0B: "OVL"}
+        0xFF0A: "BAND",  0xFF0B: "OVL",   0xFF0C: "HIB"}
 # Purgeable RANGES: base -> (name, count). The consumer adds an ordinal to the
 # base, so these are decoded before the exact-match table (SPEC.md 50.6).
 # 0xFF05 was MEM_K_FATW until the FAT window became a cache (SPEC.md 18.8.4).

--- a/tools/kernsize.py
+++ b/tools/kernsize.py
@@ -174,7 +174,7 @@ THEMES = (
     # mouse_init's identify window saw, so a byte it grows is the mouse's
     # question. It is 0 in a shipped build either way.
     ("hardware: drivers, clock, mouse, sound, CPU, XMS",
-     ("mouse.inc", "moudiag.inc", "clock.inc", "driver.inc", "snd.inc",
+     ("mouse.inc", "moudiag.inc", "clock.inc", "driver.inc", "hiber.inc", "snd.inc",
       "cpudet.inc", "xmem.inc")),
     # blank.inc (SPEC.md 64) is here and not under hardware, although all it
     # does is write a video port: what it owns is whether the SIGNAL is on,

--- a/tools/os88sym.py
+++ b/tools/os88sym.py
@@ -77,7 +77,8 @@ SECTION_SEG = {".text": "KERNEL_SEG", ".bss": "KERNEL_SEG",
                # two-step read the caller has to do for itself: the kernel's
                # own row says where the claim went (tests/xmcheck.py does
                # exactly that for XMEM.DRV, SPEC.md 41.12).
-               ".modc": None, ".modf": None, ".modl": None, ".modmap": None}
+               ".modc": None, ".modf": None, ".modl": None, ".modh": None,
+               ".modmap": None}
 
 _cache = {}
 

--- a/vm/xt-mfm/86box.cfg
+++ b/vm/xt-mfm/86box.cfg
@@ -36,6 +36,7 @@ hdd_01_parameters = 17, 4, 615, 0, mfm
 hdd_01_speed = ramdisk
 
 [Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-360.img
 fdd_01_image_history_01 = ../../build/os8088-360.img
 fdd_02_fn = ../../build/apps360.img
 fdd_host_buffering = 1

--- a/vm/xt-mfm/86box.cfg
+++ b/vm/xt-mfm/86box.cfg
@@ -1,0 +1,41 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = ec7a064e-d080-5197-b148-3f4eb7c42138
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 8088
+cpu_multi = 1
+cpu_speed = 4772728
+cpu_use_dynarec = 0
+machine = ibmxt86
+mem_size = 640
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_pc_xt
+mouse_type = msserial
+
+[Storage controllers]
+hdc_1 = st506_xt
+
+[Hard disks]
+hdd_01_fn = ../../build/mfm20.img
+hdd_01_mfm_channel = 0
+hdd_01_parameters = 17, 4, 615, 0, mfm
+hdd_01_speed = ramdisk
+
+[Floppy and CD-ROM drives]
+fdd_01_image_history_01 = ../../build/os8088-360.img
+fdd_02_fn = ../../build/apps360.img
+fdd_host_buffering = 1


### PR DESCRIPTION
## What this gives you, in one sentence

You can now put the machine to sleep on disk. Pick **Hibernate...** from the chip menu, confirm, and everything that is open — your windows, your documents, the programs running behind them — is saved to the hard disk. Switch the machine off. When you turn it on again, it asks whether you want to carry on where you left off, and if you say yes, you are back at the same desktop within moments.

## Why it matters

A 4.77 MHz machine takes a long time to boot and longer to get everything open again. Hibernate turns "start over" into "continue". It is the same idea a laptop uses, built for an IBM PC/XT with a hard disk.

## How to try it, step by step

1. Boot a machine that has a hard disk. `make xt-mfm` is a new 86Box machine with a 20MB drive for exactly this; the live USB image works too.
2. Open a couple of things. An About box is enough to see the effect.
3. Chip menu (top left) → **Hibernate...**. A small window tells you where the file will go, for example `C:\HIBERNAT.IMG`. Click **Hibernate**.
4. The screen goes to text and says it is safe to switch off. Do that, or press a key to restart.
5. On the next boot the desktop appears with one question: **Resume** or **Discard**. Click Resume. Your windows are back.

Nothing is asked about file names or folders. The file always goes to the root of the disk you booted from, so the next boot can find it by itself.

## What to expect, and what not to

- **Works on:** a hard disk the machine's BIOS knows — the boot partition, or one served by the hard-disk driver. That covers the live USB, an installed disk, and the new MFM machine.
- **Greyed out, with the reason in the menu:** when there is no hard disk (`Hibernate (No HD)`), or when a program is holding extended memory (`Hibernate (XMS)`), which no shipped program currently does.
- **Refused with a message:** a disk the BIOS cannot address directly, or not enough free space. Nothing is written in either case.
- **Does not survive:** network sessions and sound-card state. Those drivers are unloaded before the save and loaded again after the resume, like any power cycle. The clock is taken from the boot that just happened.
- **Safety:** a hibernation file from a different build of the OS, a different memory size, or a different video card is recognised and refused rather than loaded. Discard deletes the file. Resume deletes it once it has been used.

## What it cost, and why that was acceptable

The feature lives almost entirely in a file on the system disk, `HIBER.DRV`, that is loaded only when you pick the item or when a saved file is found at boot. The resident kernel grew by about 670 bytes, which spent two of the eighteen spare steps in the memory budget. That budget is exactly what those steps are held for. This PR also adds the rule to CLAUDE.md that new features consider this "load it only when needed" approach before growing the kernel.

## How we know it works

- A new automated test boots an emulated XT with a hard disk, opens a window, hibernates by clicking the button with the mouse, restarts, resumes by clicking again, and then checks the machine's memory directly: the window is back, the locks are released, the clock is ticking, and the hibernation file is gone. It then repeats the whole thing through the keyboard and takes Discard instead. Both the boot-partition and the driver-served disk configurations pass.
- The full pre-merge test suite passes.
- Two bugs were found and fixed on the way by that test: a click that never landed on a button (a register clobber in the hit test), and a scheduler counter that was captured mid-write and left the resumed machine unable to switch tasks.

## Also in this PR

- `make xt-mfm`: an 86Box IBM XT with a 20MB ST-225 MFM drive, the period configuration this feature is meant for.
- A small addition to the hard-disk driver's interface so the resume can ask a driver-served volume where its sectors physically are.
- SPEC.md §86 is the full design record, including what was deliberately left out (extended memory, IDE drives the BIOS does not see) and why.

## What I would like from a reviewer

If you have a real XT or AT with a BIOS-visible hard disk, try steps 1 to 5 above. The emulators cannot tell us how long the save and the restore take on real iron; docs/FIELD-MACHINES.md is where that number would be recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VfNrZhaL3bF2tDFAKbEPh
