### PR TITLE
Host tooling: guard the package overlay boundary, check the shared-include list, and two portability fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4877,15 +4877,38 @@ zgfx: zh zpic $(BUILD)/stories.stamp
 	python3 tools/zharness.py --all --graphics
 	python3 tools/zharness.py $(ZPICDIR)/zpictest.z6 --graphics
 
+# ...and the PICTURE half on its own. zgfx needs the story fetch, so on a
+# machine with no network - or when the question is only about the drawing
+# path - this is the part that can still run: the v6 fixture is the only thing
+# in the tree that asks for a picture at all (SPEC.md 61.7, 61.14), and it
+# needs neither a story nor a reference interpreter.
+zgfxpic: zh zpic
+	python3 tools/zharness.py $(ZPICDIR)/zpictest.z6 --graphics
+
 # The v6 picture fixture: a story that draws, and three flat blocks to draw.
-# Needs `inform` (`brew install inform6`), which is host-side only.
+# Needs an Inform 6 compiler, which is host-side only.
 ZPICDIR := $(BUILD)/zpic
+
+# WHICH IS NOT ALWAYS CALLED `inform`. Debian's inform6-compiler and Homebrew's
+# inform6 both install it as `inform6`; older and hand-built ones use `inform`.
+# This rule hard-coded the maintainer's name for it, so everywhere else it did
+# not degrade - it died as `make: inform: No such file or directory`, which
+# reads like a broken Makefile rather than a missing package. Look for both,
+# and let INFORM= name a third.
+INFORM ?= $(shell command -v inform6 2>/dev/null || command -v inform 2>/dev/null)
 
 zpic: $(ZPICDIR)/zpictest.z6 $(ZPICDIR)/zpictest.PIX
 
 $(ZPICDIR)/zpictest.z6: tests/frotz/zpictest.inf
 	@mkdir -p $(ZPICDIR)
-	inform -v6 $< $@
+	@if [ -z "$(INFORM)" ]; then \
+		echo "zpic: no Inform 6 compiler found (tried inform6, inform)."; \
+		echo "  Debian/Ubuntu: sudo apt install inform6-compiler"; \
+		echo "  macOS:         brew install inform6"; \
+		echo "  or name one:   make zpic INFORM=/path/to/inform6"; \
+		exit 1; \
+	fi
+	$(INFORM) -v6 $< $@
 
 $(ZPICDIR)/zpictest.PIX: tools/zpicgen.py tools/os88pix.py
 	@mkdir -p $(ZPICDIR)

--- a/Makefile
+++ b/Makefile
@@ -1385,7 +1385,7 @@ KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc boot/boot2.asm
         bench field combo combo144 combo720 stackprobe trklog trkscrl npbench clicktest marty \
         comscan lptlink calcref \
         fonts fontsheets fontlist \
-        stories zdisk ztest zh zhboot zcheck zgfx zpic zscreens xt-z 386-z \
+        stories zdisk ztest zh zhboot zcheck zgfx zpic zgfxpic zscreens xt-z 386-z \
         worddisk wordcheck xt-word 386-word \
         cc-note chello covl cword cworddisk 386-c-word runcpm runcpmdisk \
         runcpm-src cpmsw rcz80test rcmemtest rczex 386-runcpm \
@@ -3371,7 +3371,8 @@ $(BUILD)/mppmove360.img: $(BUILD)/heapfrag.o88 $(BUILD)/modplug.o88 \
 # drive than ModPlug.
 $(BUILD)/zt/ZOPS.Z5: tests/frotz/zopstest.inf
 	@mkdir -p $(BUILD)/zt
-	inform -v5 $< $@
+	@$(INFORMCHK)
+	$(INFORM) -v5 $< $@
 
 $(BUILD)/zmove360.img: $(BUILD)/heapfrag.o88 $(BUILD)/frotz.o88 \
                        $(BUILD)/zt/ZOPS.Z5 tools/os88disk.py
@@ -4781,7 +4782,8 @@ ztest: $(ZTESTDIR)/gold3.txt $(ZTESTDIR)/gold5.txt $(ZTESTDIR)/gold8.txt \
 
 $(ZTESTDIR)/zopstest.z%: tests/frotz/zopstest.inf
 	@mkdir -p $(ZTESTDIR)
-	inform -v$* $< $@
+	@$(INFORMCHK)
+	$(INFORM) -v$* $< $@
 
 $(ZTESTDIR)/gold%.txt: $(ZTESTDIR)/zopstest.z%
 	dfrotz -w 80 -h 200 -p $< | grep -E '^(PASS|FAIL|TEXT|RESULT)' > $@
@@ -4889,25 +4891,34 @@ zgfxpic: zh zpic
 # Needs an Inform 6 compiler, which is host-side only.
 ZPICDIR := $(BUILD)/zpic
 
-# WHICH IS NOT ALWAYS CALLED `inform`. Debian's inform6-compiler and Homebrew's
-# inform6 both install it as `inform6`; older and hand-built ones use `inform`.
-# This rule hard-coded the maintainer's name for it, so everywhere else it did
-# not degrade - it died as `make: inform: No such file or directory`, which
-# reads like a broken Makefile rather than a missing package. Look for both,
-# and let INFORM= name a third.
+# WHICH IS NOT ALWAYS CALLED `inform`. Debian's inform6-compiler installs it as
+# `inform6`; Homebrew's inform6 formula installs it as `inform` (and
+# `inform-6.44`), with no `inform6` at all - so BOTH names are in the field,
+# on the two platforms this repo is built on, and neither is safe to hard-code.
+# These rules hard-coded one of them, so on the other they did not degrade -
+# they died as `make: inform: No such file or directory`, which reads like a
+# broken Makefile rather than a missing package. Look for both, and let
+# INFORM= name a third.
 INFORM ?= $(shell command -v inform6 2>/dev/null || command -v inform 2>/dev/null)
+
+# ...and the SAME refusal for each of the three rules that compile Inform
+# source, because a message worth writing is worth not triplicating. `$(INFORM)`
+# on its own would expand to nothing and run `-v6 <file>`, whose error is worse
+# than the one this replaces. Named `$@` so the reader is told which target
+# wanted the compiler.
+INFORMCHK = if [ -z "$(INFORM)" ]; then \
+		echo "$@: no Inform 6 compiler found (tried inform6, inform)."; \
+		echo "  Debian/Ubuntu: sudo apt install inform6-compiler"; \
+		echo "  macOS:         brew install inform6"; \
+		echo "  or name one:   make INFORM=/path/to/inform6"; \
+		exit 1; \
+	fi
 
 zpic: $(ZPICDIR)/zpictest.z6 $(ZPICDIR)/zpictest.PIX
 
 $(ZPICDIR)/zpictest.z6: tests/frotz/zpictest.inf
 	@mkdir -p $(ZPICDIR)
-	@if [ -z "$(INFORM)" ]; then \
-		echo "zpic: no Inform 6 compiler found (tried inform6, inform)."; \
-		echo "  Debian/Ubuntu: sudo apt install inform6-compiler"; \
-		echo "  macOS:         brew install inform6"; \
-		echo "  or name one:   make zpic INFORM=/path/to/inform6"; \
-		exit 1; \
-	fi
+	@$(INFORMCHK)
 	$(INFORM) -v6 $< $@
 
 $(ZPICDIR)/zpictest.PIX: tools/zpicgen.py tools/os88pix.py

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -259,10 +259,11 @@ A package `%include`s these itself; they are not kernel calls. Include them at t
 
 | include | SPEC | what it gives you |
 |---|---|---|
-| `apps/os88ui.inc` | §13, 75 | Buttons, check boxes, radio dots, scroll bars, group boxes and the standard alert. Opt into the alert with `%define OS88UI_ALERT` and the scroll bar with `%define OS88UI_SCROLL`. |
+| `apps/os88ui.inc` | §13, 75 | Buttons, check boxes, radio dots, scroll bars, group boxes and the standard alert. Opt into the alert with `%define OS88UI_ALERT`, the scroll bar with `%define OS88UI_SCROLL` and its thumb-drag half with `%define OS88UI_SBDRAG`. |
 | `apps/os88line.inc` | §83 | A one-line text field: caret, horizontal scroll, focus, click-to-position and the editing keys. The caller owns a 20-byte block. |
 | `apps/os88text.inc` | §83 | The multi-line sibling of os88line.inc. Enter inserts a newline; no wrap, no selection, no undo. |
-| `apps/os88chart.inc` | §82 | A 4bpp offscreen canvas and five chart types - column, bar, line, area, pie - plus a BMP writer. Shared by CHART.O88 and Sheet's chart window. |
+| `apps/os88chart.inc` | §82 | A 4bpp offscreen canvas and all seven chart types - area, bar, column, line, pie, scatter, combination - plus a BMP writer. Shared by CHART.O88 and Sheet's chart window. |
+| `apps/os88chartbss.inc` | §82 | The ch_* working set os88chart.inc runs on, declared once instead of hand-copied into both callers. Set `CH_BSS_BASE` to where the block goes and carry on from `CH_BSS_END`. |
 | `apps/os88fp.inc` | §84 | IEEE-754 double arithmetic in software, with an 8087 path chosen at run time. Parse, format, add, subtract, multiply, divide, compare, sqrt, trunc, floor, round. |
 | `apps/os88sock.inc` | §62, 72 | The socket layer over NET.DRV or ETHER.DRV. |
 | `apps/os88pit.inc` | §37 | Sub-tick timing off the 8253. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -263,7 +263,6 @@ A package `%include`s these itself; they are not kernel calls. Include them at t
 | `apps/os88line.inc` | §83 | A one-line text field: caret, horizontal scroll, focus, click-to-position and the editing keys. The caller owns a 20-byte block. |
 | `apps/os88text.inc` | §83 | The multi-line sibling of os88line.inc. Enter inserts a newline; no wrap, no selection, no undo. |
 | `apps/os88chart.inc` | §82 | A 4bpp offscreen canvas and all seven chart types - area, bar, column, line, pie, scatter, combination - plus a BMP writer. Shared by CHART.O88 and Sheet's chart window. |
-| `apps/os88chartbss.inc` | §82 | The ch_* working set os88chart.inc runs on, declared once instead of hand-copied into both callers. Set `CH_BSS_BASE` to where the block goes and carry on from `CH_BSS_END`. |
 | `apps/os88fp.inc` | §84 | IEEE-754 double arithmetic in software, with an 8087 path chosen at run time. Parse, format, add, subtract, multiply, divide, compare, sqrt, trunc, floor, round. |
 | `apps/os88sock.inc` | §62, 72 | The socket layer over NET.DRV or ETHER.DRV. |
 | `apps/os88pit.inc` | §37 | Sub-tick timing off the 8253. |

--- a/tools/os88index.py
+++ b/tools/os88index.py
@@ -72,7 +72,7 @@ GROUPS = [
 # not.
 #
 # The NAMES are checked against the tree by check_includes() below, because a
-# hand-written list is exactly what goes quietly stale: os88chartbss.inc was
+# hand-written list is exactly what goes quietly stale: a new shared include was
 # added and this list was not, so the index that exists to answer "does this
 # already exist?" answered no about a file that did.
 INCLUDES = [
@@ -91,10 +91,6 @@ INCLUDES = [
      "A 4bpp offscreen canvas and all seven chart types - area, bar, column, "
      "line, pie, scatter, combination - plus a BMP writer. Shared by CHART.O88 "
      "and Sheet's chart window."),
-    ("os88chartbss.inc", "82",
-     "The ch_* working set os88chart.inc runs on, declared once instead of "
-     "hand-copied into both callers. Set `CH_BSS_BASE` to where the block "
-     "goes and carry on from `CH_BSS_END`."),
     ("os88fp.inc", "84",
      "IEEE-754 double arithmetic in software, with an 8087 path chosen at run "
      "time. Parse, format, add, subtract, multiply, divide, compare, sqrt, "

--- a/tools/os88index.py
+++ b/tools/os88index.py
@@ -70,11 +70,17 @@ GROUPS = [
 # one thing here not extracted, because "what is this FOR" is not in the source
 # in a form worth parsing, and a wrong blurb is visible where a wrong slot is
 # not.
+#
+# The NAMES are checked against the tree by check_includes() below, because a
+# hand-written list is exactly what goes quietly stale: os88chartbss.inc was
+# added and this list was not, so the index that exists to answer "does this
+# already exist?" answered no about a file that did.
 INCLUDES = [
     ("os88ui.inc", "13, 75",
      "Buttons, check boxes, radio dots, scroll bars, group boxes and the "
-     "standard alert. Opt into the alert with `%define OS88UI_ALERT` and the "
-     "scroll bar with `%define OS88UI_SCROLL`."),
+     "standard alert. Opt into the alert with `%define OS88UI_ALERT`, the "
+     "scroll bar with `%define OS88UI_SCROLL` and its thumb-drag half with "
+     "`%define OS88UI_SBDRAG`."),
     ("os88line.inc", "83",
      "A one-line text field: caret, horizontal scroll, focus, click-to-position "
      "and the editing keys. The caller owns a 20-byte block."),
@@ -82,8 +88,13 @@ INCLUDES = [
      "The multi-line sibling of os88line.inc. Enter inserts a newline; no wrap, "
      "no selection, no undo."),
     ("os88chart.inc", "82",
-     "A 4bpp offscreen canvas and five chart types - column, bar, line, area, "
-     "pie - plus a BMP writer. Shared by CHART.O88 and Sheet's chart window."),
+     "A 4bpp offscreen canvas and all seven chart types - area, bar, column, "
+     "line, pie, scatter, combination - plus a BMP writer. Shared by CHART.O88 "
+     "and Sheet's chart window."),
+    ("os88chartbss.inc", "82",
+     "The ch_* working set os88chart.inc runs on, declared once instead of "
+     "hand-copied into both callers. Set `CH_BSS_BASE` to where the block "
+     "goes and carry on from `CH_BSS_END`."),
     ("os88fp.inc", "84",
      "IEEE-754 double arithmetic in software, with an 8087 path chosen at run "
      "time. Parse, format, add, subtract, multiply, divide, compare, sqrt, "
@@ -95,6 +106,29 @@ INCLUDES = [
     ("os88type.inc", "54",
      "File-type recognition by name and by content."),
 ]
+
+
+def check_includes():
+    """Every apps/os88*.inc a package opts into must have a row here.
+
+    os88api.inc is excluded: it is not opted into, it is the API itself and
+    every package includes it. Anything else that appears in apps/ and not in
+    INCLUDES - or the reverse - is a stale index, and this says so by name
+    rather than leaving it to be noticed.
+    """
+    on_disk = {f for f in os.listdir(os.path.join(ROOT, "apps"))
+               if f.startswith("os88") and f.endswith(".inc")
+               and f != "os88api.inc"}
+    listed = {name for name, _, _ in INCLUDES}
+    missing = sorted(on_disk - listed)
+    ghost = sorted(listed - on_disk)
+    if missing or ghost:
+        for f in missing:
+            print("os88index: apps/%s is in the tree and not in INCLUDES" % f)
+        for f in ghost:
+            print("os88index: INCLUDES lists %s, which is not in apps/" % f)
+        return False
+    return True
 
 
 def anchor(num, title):
@@ -369,6 +403,8 @@ def build():
 
 
 def main():
+    if not check_includes():          # a stale list is a stale index, and this
+        return 1                      # one is hand-written, so it is checked
     text = build()
     if "--check" in sys.argv:
         try:

--- a/tools/os88ovlchk.py
+++ b/tools/os88ovlchk.py
@@ -527,8 +527,6 @@ def check_pkgs():
         if not os.path.exists(pkg):
             continue
         walked += 1
-        if not os.path.exists(pkg):
-            continue
         stream = list(expand(pkg, frozenset()))
         # one linear pass for the section each line lands in: a `section`
         # directive inside an include stays in force after it, exactly as it
@@ -557,14 +555,6 @@ def check_pkgs():
         # %ifdef, so it would see every label defined in both sections and
         # report the module calling itself. The code-bearing include is the
         # LAST one, so that is the copy that counts.
-        last = {}
-        for i, (sect, f, n, line) in enumerate(rows):
-            last[f] = i
-        first_of = {}
-        for i, (sect, f, n, line) in enumerate(rows):
-            first_of.setdefault(f, i)
-        dup = {f for f in last if any(
-            r[1] == f for r in rows[:first_of[f]])}
         keep = []
         seenfile = {}
         for sect, f, n, line in rows:

--- a/tools/os88ovlchk.py
+++ b/tools/os88ovlchk.py
@@ -494,7 +494,11 @@ def main():
 # Each package is its own address space, so each gets its own label map: two
 # packages may legitimately define the same wd_* label and neither can call the
 # other's.
-PKGS = ['apps/word/word.asm', 'apps/scribe/scribe.asm']
+# A package listed here that is not in the tree is SKIPPED, not an error: a
+# fork may carry one this branch does not, and the walk should still check the
+# ones that are here. The count reported at the end is what was actually
+# walked, so a skipped package cannot be mistaken for a checked one.
+PKGS = ['apps/word/word.asm']
 
 
 def expand(path, seen):
@@ -518,7 +522,11 @@ def expand(path, seen):
 
 def check_pkgs():
     bad = []
+    walked = 0
     for pkg in PKGS:
+        if not os.path.exists(pkg):
+            continue
+        walked += 1
         if not os.path.exists(pkg):
             continue
         stream = list(expand(pkg, frozenset()))
@@ -586,7 +594,7 @@ def check_pkgs():
     if bad:
         sys.exit("os88ovlchk: %d package call(s) cross a section boundary near "
                  "- SPEC.md 68.10 rule 1" % len(bad))
-    print("os88ovlchk: %d package(s) keep every overlay call far" % len(PKGS))
+    print("os88ovlchk: %d package(s) keep every overlay call far" % walked)
 
 
 if __name__ == '__main__':

--- a/tools/os88ovlchk.py
+++ b/tools/os88ovlchk.py
@@ -33,7 +33,7 @@ that `.text` DOES dispatch through must name the resident thunk and not the
 
 Run it from `make`; it is worth more than any amount of reading.
 """
-import re, sys, glob
+import os, re, sys, glob
 
 CALL = re.compile(r'\b(?:call|jmp|j[a-z]{1,3}|loop[a-z]{0,2})\s+'
                   r'(?:(?:near|short)\s+)?(?:(\w+):)?([A-Za-z_]\w*)\b')
@@ -474,5 +474,121 @@ def main():
     print("os88ovlchk: every return kind matches how the routine is called")
 
 
+# =============================================================================
+# THE APPLICATION PACKAGES, which the walk above does not reach (SPEC.md 68.10)
+#
+# A package that carries an overlay has the same hazard the kernel does and had
+# no guard at all: `section .modc` code gets a CS of its own, so a near call
+# from it to a resident label assembles cleanly - NASM emits a relative
+# displacement, which is legal - and lands at that offset in the WRONG segment
+# at run time. There is no crash to read and no message; the app simply stops.
+#
+# It is checked differently from the kernel half, and better: instead of a map
+# saying which section each %included file lands in, this FOLLOWS the includes
+# and carries the current section across them. That is what NASM actually does,
+# so a file moved from `.text` into `.modc` by editing one %include line is
+# reclassified with no second edit here - which matters, because the whole
+# point of the overlay is that moving a subsystem out is a matter of moving its
+# text.
+#
+# Each package is its own address space, so each gets its own label map: two
+# packages may legitimately define the same wd_* label and neither can call the
+# other's.
+PKGS = ['apps/word/word.asm', 'apps/scribe/scribe.asm']
+
+
+def expand(path, seen):
+    """The package's source with %include inlined, as NASM assembles it."""
+    if path in seen:
+        return
+    seen = seen | {path}
+    here = os.path.dirname(path)
+    for n, raw in enumerate(open(path, errors='replace'), 1):
+        m = re.match(r'\s*%include\s+"([^"]+)"', raw)
+        if m:
+            for cand in (os.path.join(here, m.group(1)),
+                         os.path.join('apps', m.group(1))):
+                if os.path.exists(cand):
+                    for row in expand(cand, seen):
+                        yield row
+                    break
+            continue
+        yield path, n, raw
+
+
+def check_pkgs():
+    bad = []
+    for pkg in PKGS:
+        if not os.path.exists(pkg):
+            continue
+        stream = list(expand(pkg, frozenset()))
+        # one linear pass for the section each line lands in: a `section`
+        # directive inside an include stays in force after it, exactly as it
+        # does for NASM
+        rows, cur = [], '.text'
+        for f, n, raw in stream:
+            line = raw.split(';')[0]
+            m = re.match(r'\s*section\s+(\.\w+)', line)
+            if m:
+                cur = m.group(1)
+                continue
+            rows.append((cur, f, n, line))
+
+        # ONLY `.modc` IS ANOTHER ADDRESS SPACE. A package is one flat binary
+        # (SPEC.md 20.2) and tools/os88ovl.py cuts exactly one section off the
+        # end of it, so `.text`, `.cold` and `.bss` are all the same CS and a
+        # near call between them is correct. apps/os88ui.inc carries `.cold`
+        # directives for the KERNEL's benefit (it is %included into a cold
+        # block there) and those must not be read as a boundary here - without
+        # this fold, 70 correct calls were reported.
+        fold = lambda x: x if x == '.modc' else '.text'
+
+        # A FILE %included TWICE IS ONE FILE. apps/os88img.inc is deliberately
+        # included once for its constants and once for its code, guarded by
+        # OS88IMG_CONSTS_ONLY (SPEC.md 85) - and this does not evaluate
+        # %ifdef, so it would see every label defined in both sections and
+        # report the module calling itself. The code-bearing include is the
+        # LAST one, so that is the copy that counts.
+        last = {}
+        for i, (sect, f, n, line) in enumerate(rows):
+            last[f] = i
+        first_of = {}
+        for i, (sect, f, n, line) in enumerate(rows):
+            first_of.setdefault(f, i)
+        dup = {f for f in last if any(
+            r[1] == f for r in rows[:first_of[f]])}
+        keep = []
+        seenfile = {}
+        for sect, f, n, line in rows:
+            seenfile.setdefault((f, n), []).append(sect)
+        for sect, f, n, line in rows:
+            if len(seenfile[(f, n)]) > 1 and sect != seenfile[(f, n)][-1]:
+                continue                # an earlier, guarded-out inclusion
+            keep.append((sect, f, n, line))
+        rows = keep
+
+        where = {}
+        for sect, f, n, line in rows:
+            m = re.match(r'^([A-Za-z_]\w*):', line)
+            if m:
+                where[m.group(1)] = fold(sect)
+        for sect, f, n, line in rows:
+            for m in CALL.finditer(line):
+                seg, tgt = m.group(1), m.group(2)
+                if seg is not None:
+                    continue            # `call far [vec]` is the way across
+                t = where.get(tgt)
+                if t is not None and t != fold(sect):
+                    bad.append((f, n, '%s -> %s, near' % (fold(sect), t),
+                                tgt, pkg))
+    for f, n, why, tgt, pkg in bad:
+        print("%s:%d: %s: %s  (%s)" % (f, n, why, tgt, pkg), file=sys.stderr)
+    if bad:
+        sys.exit("os88ovlchk: %d package call(s) cross a section boundary near "
+                 "- SPEC.md 68.10 rule 1" % len(bad))
+    print("os88ovlchk: %d package(s) keep every overlay call far" % len(PKGS))
+
+
 if __name__ == '__main__':
     main()
+    check_pkgs()

--- a/tools/os88ovlchk.py
+++ b/tools/os88ovlchk.py
@@ -549,21 +549,17 @@ def check_pkgs():
         # this fold, 70 correct calls were reported.
         fold = lambda x: x if x == '.modc' else '.text'
 
-        # A FILE %included TWICE IS ONE FILE. apps/os88img.inc is deliberately
-        # included once for its constants and once for its code, guarded by
-        # OS88IMG_CONSTS_ONLY (SPEC.md 85) - and this does not evaluate
-        # %ifdef, so it would see every label defined in both sections and
-        # report the module calling itself. The code-bearing include is the
-        # LAST one, so that is the copy that counts.
-        keep = []
-        seenfile = {}
-        for sect, f, n, line in rows:
-            seenfile.setdefault((f, n), []).append(sect)
-        for sect, f, n, line in rows:
-            if len(seenfile[(f, n)]) > 1 and sect != seenfile[(f, n)][-1]:
-                continue                # an earlier, guarded-out inclusion
-            keep.append((sect, f, n, line))
-        rows = keep
+        # A FILE %included TWICE was deduped here by keeping the LAST copy, on
+        # the reasoning that the code-bearing include comes last. It does not
+        # survive being tested: a file included into `.modc` FIRST and `.text`
+        # second had its `.modc` rows dropped, and a real `.modc -> .text` near
+        # call inside such a file was reported clean - a false negative, which
+        # is the exact failure this whole walk exists to prevent. Nothing in
+        # the tree needed it either: no file in a package's expansion is
+        # included twice at all. So there is no dedup, and both copies of a
+        # doubly-included file are judged in the section they actually land in.
+        # If one is ever wanted again it must keep the `.modc` copy, not the
+        # last one.
 
         where = {}
         for sect, f, n, line in rows:
@@ -584,6 +580,9 @@ def check_pkgs():
     if bad:
         sys.exit("os88ovlchk: %d package call(s) cross a section boundary near "
                  "- SPEC.md 68.10 rule 1" % len(bad))
+    if PKGS and not walked:
+        sys.exit("os88ovlchk: none of the %d package(s) in PKGS is in the tree "
+                 "- the package half of this gate checked nothing" % len(PKGS))
     print("os88ovlchk: %d package(s) keep every overlay call far" % walked)
 
 

--- a/tools/os88pix.py
+++ b/tools/os88pix.py
@@ -33,6 +33,7 @@ installs.
 """
 import argparse
 import os
+import shutil
 import struct
 import subprocess
 import sys
@@ -154,15 +155,27 @@ def load_image(path):
         data = fh.read()
     if data[:8] == b"\x89PNG\r\n\x1a\n":
         return png_decode(data)
-    # Anything else goes through sips, which every macOS has. The temp PNG is
-    # deleted; nothing non-deterministic reaches the archive.
+    # Anything else goes through sips on macOS, or Pillow where sips is not on
+    # PATH (e.g. Linux). The temp PNG is deleted; nothing non-deterministic
+    # reaches the archive.
+    if shutil.which("sips"):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = os.path.join(td, "conv.png")
+            r = subprocess.run(["sips", "-s", "format", "png", path, "--out", tmp],
+                               capture_output=True)
+            if r.returncode != 0 or not os.path.exists(tmp):
+                fail(f"cannot read {path}: not a PNG, and sips could not convert it\n"
+                     f"  {r.stderr.decode(errors='replace').strip()}")
+            with open(tmp, "rb") as fh:
+                return png_decode(fh.read())
+    try:
+        from PIL import Image
+    except ImportError:
+        fail(f"cannot read {path}: not a PNG, and neither sips nor Pillow "
+             f"is available to convert it")
     with tempfile.TemporaryDirectory() as td:
         tmp = os.path.join(td, "conv.png")
-        r = subprocess.run(["sips", "-s", "format", "png", path, "--out", tmp],
-                           capture_output=True)
-        if r.returncode != 0 or not os.path.exists(tmp):
-            fail(f"cannot read {path}: not a PNG, and sips could not convert it\n"
-                 f"  {r.stderr.decode(errors='replace').strip()}")
+        Image.open(path).convert("RGB").save(tmp, "PNG")
         with open(tmp, "rb") as fh:
             return png_decode(fh.read())
 

--- a/tools/os88pix.py
+++ b/tools/os88pix.py
@@ -156,8 +156,15 @@ def load_image(path):
     if data[:8] == b"\x89PNG\r\n\x1a\n":
         return png_decode(data)
     # Anything else goes through sips on macOS, or Pillow where sips is not on
-    # PATH (e.g. Linux). The temp PNG is deleted; nothing non-deterministic
-    # reaches the archive.
+    # PATH (e.g. Linux). The temp PNG is deleted, and neither decoder is
+    # non-deterministic - but they are not identical to each other. Flat
+    # colour, paletted GIF and TIFF quantise to the same bytes either way; a
+    # photographic JPEG does not, because the chroma upsampling difference
+    # survives the 16-colour reduction. The one archive that reaches is
+    # BRONZE.PIX, whose source is Bronze.zblorb's JPEG cover, and it is
+    # therefore reproducible per host rather than across hosts. Nothing
+    # compares those bytes today: it lands only on build/zork2.img, built on
+    # demand from stories that are never committed.
     if shutil.which("sips"):
         with tempfile.TemporaryDirectory() as td:
             tmp = os.path.join(td, "conv.png")


### PR DESCRIPTION
Four host-side changes, no guest code touched. Two are gates that catch a defect class nothing checked before; two are portability fixes to tools that only worked on one platform.

## `os88ovlchk`: the package overlay boundary

§68.10 rule 1 — *no near call across the boundary* — was enforced for the kernel and not for packages. A package's `.modc` is a different segment at run time, so a near `call` from module code into a resident routine lands at that offset **inside the module** and runs whatever is there. It assembles cleanly and there is no error anywhere; the symptom is a feature that silently stops working.

The walk now inlines a package's `%include`s the way NASM does, tracks which section each line lands in, and reports any `call`/`jmp` whose target is on the other side. `call far [vec]` is the way across and is not flagged.

Mutation-tested on this tree: a near `call wd_entry` inside WORD's `.modc` is reported; without it the row passes.

A package listed and not present is **skipped** rather than an error — a fork may carry one `main` does not — and the count printed is what was actually walked, so a skipped package cannot read as a checked one.

## `os88index`: the shared-include list is checked against the tree

`INCLUDES` is hand-written, and a hand-written list is exactly what goes quietly stale. `check_includes()` compares it against every `apps/os88*.inc` a package can opt into (`os88api.inc` excluded — it is not opted into, it *is* the API).

Mutation-tested: dropping an unlisted `apps/os88*.inc` into the tree fails the row with *"is in the tree and not in INCLUDES"*.

Worth saying that this gate fired on its own author. The change arrived from a fork carrying a ninth include; on `main`, where that file does not exist, it immediately reported its own list as stale. The row for the fork-only file is dropped here and the gate stays.

## `os88pix`: read a non-PNG on Linux too

The converter shelled out to `sips`, which is macOS-only, so any input that was not already a PNG failed on Linux with a missing-binary error rather than a useful message. Falls back to Pillow when `sips` is absent.

## `zpic`: find the Inform 6 compiler by either of its names

The Z-machine picture fixture looked for `inform` only. Debian and Fedora both ship it as `inform6`, so `make zpic` failed on a machine that had the compiler installed under the other name.

## Checks

`make test-fast`: 30 passed. No guest binary changes — `build/` untouched, nothing under it tracked (§16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159LErbVPudCzAZfW9BtbAX
