### PR TITLE
1.2MB disks for every application floppy, not just the shipped pair

### DIFF
--- a/.claude/skills/release-os8088/SKILL.md
+++ b/.claude/skills/release-os8088/SKILL.md
@@ -152,11 +152,14 @@ to a fresh branch off `main` and would otherwise sweep unrelated work into it.
 ```bash
 cd "$OS_REPO"
 make clean && make
-ls -l build/os8088.img build/os8088-720.img build/os8088-360.img \
-      build/apps.img build/apps720.img build/apps360.img build/media360.img
+ls -l build/os8088.img build/os8088-120.img build/os8088-720.img \
+      build/os8088-360.img \
+      build/apps.img build/apps120.img build/apps720.img build/apps360.img \
+      build/media360.img
 ```
 
-All seven must exist -- step 3a refuses to pack without them. The build
+All nine must exist -- step 3a refuses to pack without them. (Four geometries
+of each pair since SPEC.md 19's 1.2MB disk, plus the 360KB-only media disk.) The build
 enforces its own invariants -- a 512-byte boot sector and a kernel that fits
 under offset 0xA000 -- so a build failure here is a real problem, not
 something to work around. Report the kernel size; if it has
@@ -172,6 +175,9 @@ make allapps                          # apps-all.img -- every program, one disk
 make worddisk cworddisk               # word*.img, cword*.img
 make c64disk                          # c64*.img
 make weavedisk                        # weave*.img -- the Weave family's disk
+make loomdisk                         # loom*.img -- the same family's IDE disk,
+                                      # with the demo SOURCES instead of the
+                                      # compiled bundles
 make runcpm-src && make runcpmdisk    # runcpm*.img
 make live                             # os8088-usb.img + os8088.iso -- the live
                                       # USB image and the live CD (SPEC.md 80).
@@ -180,7 +186,7 @@ make live                             # os8088-usb.img + os8088.iso -- the live
 ```
 
 Offer these, do not assume them. If `tools/setup-cc.sh` cannot run -- no
-network, no host toolchain -- **release the seven and say which on-demand disks
+network, no host toolchain -- **release the nine and say which on-demand disks
 were skipped**; they are a convenience, and a release that waits on one is a
 release that does not happen. `mkzip.py` prints the ones it did not find, so
 that list is generated rather than remembered. Boot any that were built in step

--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -19,10 +19,12 @@ invisible in the zip listing until it is public.
 
 It does not build anything. Run `make` (and any on-demand target you want in
 the zip) first; a missing REQUIRED image stops the script, and a missing
-optional one is reported and skipped. That split is the point -- the seven
-images `make` produces are the release, and `apps-all`/`word`/`cword`/
-`runcpm` and the live media (`make live`, SPEC.md 80) are on-demand targets
-that a tree without the C toolchain cannot build at all.
+optional one is reported and skipped. That split is the point -- the nine
+images `make` produces are the release (four geometries of each pair since
+SPEC.md 19's 1.2MB disk, plus the 360KB-only media disk), and
+`apps-all`/`word`/`cword`/`runcpm`/`c64`/`weave`/`loom` and the live media
+(`make live`, SPEC.md 80) are on-demand targets that a tree without the C
+toolchain cannot build at all.
 
 The zip is byte-for-byte reproducible: entries are written in manifest order,
 every timestamp is the date in the version string, and permissions are fixed.
@@ -44,6 +46,11 @@ MANIFEST = [
     ("apps.img",       True,  "Software disk, 1.44MB. Goes in drive B."),
     ("os8088-720.img", True,  "System disk, 720KB."),
     ("apps720.img",    True,  "Software disk, 720KB."),
+    ("os8088-120.img", True,  "System disk, 1.2MB. The 5.25-inch high-density size -- "
+                              "for an AT-class machine whose only drive is 5.25-inch, "
+                              "which reads neither 3.5-inch disk."),
+    ("apps120.img",    True,  "Software disk, 1.2MB. Carries everything the 1.44MB one "
+                              "does, the music module included."),
     ("os8088-360.img", True,  "System disk, 360KB. This is the one a real IBM PC/XT reads."),
     ("apps360.img",    True,  "Software disk, 360KB."),
     ("media360.img",   True,  "Music disk, 360KB. The music module does not fit beside the "
@@ -63,21 +70,30 @@ MANIFEST = [
                               "Commodore 64 and the Weave programs and their editor. Use "
                               "this instead of apps.img if you would rather swap one disk "
                               "than seven."),
+    ("apps-all-120.img", False, "The same everything-disk at 1.2MB. There is no 720KB or "
+                              "360KB version -- the programs do not fit at those sizes."),
     ("word.img",       False, "Word processor disk, 1.44MB."),
     ("word720.img",    False, "Word processor disk, 720KB."),
+    ("word120.img",    False, "Word processor disk, 1.2MB."),
     ("word360.img",    False, "Word processor disk, 360KB."),
     ("cword.img",      False, "Word processor disk built by the C compiler, 1.44MB."),
     ("cword720.img",   False, "Word processor disk built by the C compiler, 720KB."),
+    ("cword120.img",   False, "Word processor disk built by the C compiler, 1.2MB."),
     ("cword360.img",   False, "Word processor disk built by the C compiler, 360KB."),
     ("runcpm.img",     False, "CP/M emulator disk, 1.44MB. Carries the emulator and the "
                               "CP/M programs that run under it."),
     ("runcpm720.img",  False, "CP/M emulator disk, 720KB. Carries the emulator and the "
                               "arcade games only."),
+    ("runcpm120.img",  False, "CP/M emulator disk, 1.2MB. Carries the emulator, four of "
+                              "the five program areas the 1.44MB disk has -- the word "
+                              "processor comes off, being the largest -- and more of "
+                              "CP/M's own disk than the 1.44MB one holds."),
     ("runcpm360.img",  False, "CP/M emulator disk, 360KB. Carries the emulator and no "
                               "programs -- there is no room for them at this size."),
     ("c64.img",        False, "Commodore 64 disk, 1.44MB. Carries the emulator, the three "
                               "Commodore ROM images it reads at launch, and COPYING."),
     ("c64720.img",     False, "Commodore 64 disk, 720KB."),
+    ("c64120.img",     False, "Commodore 64 disk, 1.2MB."),
     ("c64360.img",     False, "Commodore 64 disk, 360KB."),
     ("weave.img",      False, "Weave disk, 1.44MB. Web-style programs - markup, script "
                               "and formulas - compiled into one bundle file and run "
@@ -85,7 +101,16 @@ MANIFEST = [
                               "editor that builds them and the sources they were built "
                               "from."),
     ("weave720.img",   False, "Weave disk, 720KB."),
+    ("weave120.img",   False, "Weave disk, 1.2MB."),
     ("weave360.img",   False, "Weave disk, 360KB."),
+    ("loom.img",       False, "Weave editor disk, 1.44MB. The same editor and runtime as "
+                              "the Weave disk, with the demo programs' SOURCES to open "
+                              "rather than the finished bundles. Use this one if you want "
+                              "to change a program; the Weave disk if you want to run "
+                              "one."),
+    ("loom720.img",    False, "Weave editor disk, 720KB."),
+    ("loom120.img",    False, "Weave editor disk, 1.2MB."),
+    ("loom360.img",    False, "Weave editor disk, 360KB."),
 ]
 
 # Files packed beside the images, when the image they belong to is here.
@@ -115,6 +140,7 @@ You need two images: a system disk for drive A and a software disk for drive B.
 Pick the pair that matches the disk size your machine or emulator uses.
 
   1.44MB   os8088.img       and  apps.img
+  1.2MB    os8088-120.img   and  apps120.img   (5.25-inch high density)
   720KB    os8088-720.img   and  apps720.img
   360KB    os8088-360.img   and  apps360.img  (and media360.img, see below)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,11 @@ exactly like the feature being broken.
 and hibernate on; `build/mfm20.img` is created blank and kept),
 `xt-cga`, `xt-hercules`, `xt-ega`, `xt-multimon`, `xt-sound`,
 `xt-sound-1.44`, `286`,
-`286-sound`,
+`286-sound`, the eight `286-525-*` application machines (`-z`, `-word`,
+`-cword`, `-runcpm`, `-c64`, `-weave`, `-loom`, `-all` — `vm/286-525` with a
+1.2MB app disk in B: instead of the apps floppy, and the only machines in the
+tree that read that geometry at all: a 1.2MB drive wants the AT's 500 kbps
+controller, so no XT profile can host one),
 `386sx`, `386`, `386-sound`, `486`, `pentium`, `xt-z`, `386-z`, `xt-word`,
 `386-word`, `386-c-word`, `xt-runcpm`, `286-runcpm`, `386-runcpm`, `xt-c64`,
 `286-c64`, `386-c64`, `xt-weave`, `386-weave`, `xt-weave-256`;
@@ -604,13 +608,17 @@ There is **no relocation of any kind**, so `os88pkg.py` is a validator rather
 than a generator. Both disks are standard FAT12 volumes (§19) that any host OS
 mounts — and every byte read off one is still treated as hostile.
 
-**Every image is built in three geometries** — 1.44MB and 720KB (QEMU), 360KB
-(86Box / a real XT). Changing the boot path, the FAT driver or the disk layout
-means checking all three.
+**Every image is built in FOUR geometries** — 1.44MB and 720KB (QEMU), 360KB
+(86Box / a real XT) and 1.2MB 5.25" HD (§19, the AT-class machine with no 3.5"
+drive). Changing the boot path, the FAT driver or the disk layout means
+checking all four. This is the rule for the on-demand APPLICATION floppies too
+— `zdisk`, `worddisk`, `cworddisk`, `runcpmdisk`, `c64disk`, `weavedisk`,
+`loomdisk`, `allapps` — which were three-geometry until 1.2MB reached them.
 
-**Seven images, not six.** The system and apps disks in three geometries each,
+**Nine images, not seven.** The system and apps disks in four geometries each,
 plus `build/media360.img` — `BEVERLY.MOD` is 114 of a 360KB disk's 354 clusters
 and is data rather than software, so at that geometry alone it rides a disk of
-its own (§24.4). The **core packages** ship on the system disk too, a second
+its own (§24.4); every other apps disk carries it in `MEDIA/`, which is why
+there is no 720KB or 1.2MB media disk to go with it. The **core packages** ship on the system disk too, a second
 copy and never a move (§24.3), and an application's own state goes in
 `SYSTEM/APPDATA/` rather than beside the user's documents (§19.9).

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,37 @@ VM286 := $(CURDIR)/vm/286
 # all: every other AT-class profile is `fdd_type = 35_2hd`, and a 5.25" HD
 # drive is what the 1.2MB pair exists for.
 VM286525 := $(CURDIR)/vm/286-525
+# ...and one per APPLICATION disk at that geometry, which is the same shape
+# `vm/xt-z`, `vm/386-word`, `vm/xt-runcpm`, `vm/386-c64` and `vm/386-weave`
+# already have at theirs: the machine with the app's own floppy in B: instead
+# of the shipped apps disk. Each is a copy of `vm/286-525` WITH TWO LINES
+# CHANGED - `fdd_02_fn` and the uuid - and nothing else, which is the rule the
+# C64 and RUNCPM blocks below state and the reason for it is theirs: 86Box
+# silently substitutes an unrecognised `cpu_family` at that family's default
+# speed and rewrites the config on the way out, so a hand-written profile is a
+# machine nobody has checked the clock of.
+#
+# It is ONE machine class and not three, where the RUNCPM and C64 families
+# have an XT, a 286 and a 386 - and that is the geometry's own doing rather
+# than a gap. A 1.2MB drive needs a 500 kbps controller, which is the AT's
+# (SPEC.md 19): an XT cannot read one of these disks at all, and every other
+# AT-class profile in this tree is fitted with 3.5" drives. `vm/286-525` is
+# the only 5.25" HD machine there is, so its copies are the only machines
+# these disks have.
+#
+# `286-525-loom` and `286-525-all` are the first machines their disks have had
+# at ANY geometry - LOOM has always been looked at through the Weave disk,
+# which carries it, and the everything disk only ever rode `xt-sound-1.44`.
+# They are here because 1.2MB is otherwise the one geometry whose disks no
+# period machine can open.
+VM286525Z := $(CURDIR)/vm/286-525-z
+VM286525WORD := $(CURDIR)/vm/286-525-word
+VM286525CWORD := $(CURDIR)/vm/286-525-cword
+VM286525RUNCPM := $(CURDIR)/vm/286-525-runcpm
+VM286525C64 := $(CURDIR)/vm/286-525-c64
+VM286525WEAVE := $(CURDIR)/vm/286-525-weave
+VM286525LOOM := $(CURDIR)/vm/286-525-loom
+VM286525ALL := $(CURDIR)/vm/286-525-all
 VM386SX := $(CURDIR)/vm/386sx
 VM386DX := $(CURDIR)/vm/386dx
 # ...and the SAME 386DX with 4MB in it, for the store above 1MB (SPEC.md 41).
@@ -1574,6 +1605,8 @@ KERNEL_INC := $(wildcard kernel/*.inc) apps/os88ui.inc boot/boot2.asm
 
 .PHONY: stkdiag small kernsplit all run run-640 run-720 run-120 debug test test-snd xt xt-640 xt-mfm xt-cga \
         xt-hercules xt-ega xt-multimon 286 286-525 386sx 386 386-xms 386-ps2 xt-sound xt-sound-1.44 \
+        286-525-z 286-525-word 286-525-cword 286-525-runcpm 286-525-c64 \
+        286-525-weave 286-525-loom 286-525-all \
         286-sound 386-sound 486 pentium \
         bench field combo combo144 combo720 stackprobe trklog trkscrl npbench clicktest marty \
         comscan lptlink calcref \
@@ -4328,11 +4361,14 @@ $(BUILD)/cword.bin: apps/cword/cwmove.inc
 
 cword: $(BUILD)/cword.o88
 
-# All three geometries an APPLICATION's own floppy is built in (CLAUDE.md):
-# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one. The shipped
-# system and apps pair gained a fourth, 1.2MB 5.25" (SPEC.md 19), and these did
-# not: an on-demand disk is for a machine somebody already has, and the machine
-# that wanted that geometry reads the 360KB disk in the same drive.
+# ALL FOUR geometries an APPLICATION's own floppy is built in (CLAUDE.md):
+# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one, and 1.2MB
+# 5.25" HD (SPEC.md 19) for the AT-class machine. The fourth used to be the
+# shipped system and apps pair's alone, on the argument that such a machine
+# reads the 360KB disk in the same drive - true, and it costs the user the
+# 1.2MB disk's other 831KB and makes them write DD media in an HD drive,
+# which is this project's one combination known to be marginal (the note at
+# $(IMG120)). So every on-demand application floppy is built in it too.
 # The C toolchain has been booted from a 360KB floppy once, on chello, and
 # that is the geometry a 20KB image most wants re-checked on.
 #
@@ -4351,7 +4387,8 @@ cword: $(BUILD)/cword.o88
 $(BUILD)/WELCOME.RTF: tools/os88rtf.py tools/os88doc.py apps/cword/welcome.wtx | $(BUILD)
 	python3 tools/os88rtf.py apps/cword/welcome.wtx -o $@
 
-cworddisk: $(BUILD)/cword.img $(BUILD)/cword720.img $(BUILD)/cword360.img
+cworddisk: $(BUILD)/cword.img $(BUILD)/cword720.img $(BUILD)/cword120.img \
+           $(BUILD)/cword360.img
 
 CWORDDISK := $(BUILD)/cword.o88 $(BUILD)/CWORD.OVL $(BUILD)/WELCOME.RTF
 
@@ -4361,6 +4398,10 @@ $(BUILD)/cword.img: $(CWORDDISK) tools/os88disk.py
 
 $(BUILD)/cword720.img: $(CWORDDISK) tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 720 $(CWORDDISK) --folder DOCS
+	@python3 tools/os88disk.py --verify $@
+
+$(BUILD)/cword120.img: $(CWORDDISK) tools/os88disk.py
+	python3 tools/os88disk.py -o $@ --size 1200 $(CWORDDISK) --folder DOCS
 	@python3 tools/os88disk.py --verify $@
 
 $(BUILD)/cword360.img: $(CWORDDISK) tools/os88disk.py
@@ -4507,7 +4548,8 @@ sel="$$(python3 tools/getruncpm.py -o $(RUNCPMDIR) --select $(2) --dir-slots $(R
 python3 tools/os88disk.py -o $(1) --size $(2) --deep-folders --dir-slots A/0=$(RUNCPMSLOTS) $$gslot $(RUNCPMDISK) $(3) $$sel $$gsel $(CPMSW)
 endef
 
-runcpmdisk: $(BUILD)/runcpm.img $(BUILD)/runcpm720.img $(BUILD)/runcpm360.img
+runcpmdisk: $(BUILD)/runcpm.img $(BUILD)/runcpm720.img \
+            $(BUILD)/runcpm120.img $(BUILD)/runcpm360.img
 
 $(BUILD)/runcpm.img: $(RUNCPMDEPS)
 	$(call RUNCPMIMG,$@,1440)
@@ -4515,6 +4557,10 @@ $(BUILD)/runcpm.img: $(RUNCPMDEPS)
 
 $(BUILD)/runcpm720.img: $(RUNCPMDEPS)
 	$(call RUNCPMIMG,$@,720)
+	@python3 tools/os88disk.py --verify $@
+
+$(BUILD)/runcpm120.img: $(RUNCPMDEPS)
+	$(call RUNCPMIMG,$@,1200)
 	@python3 tools/os88disk.py --verify $@
 
 $(BUILD)/runcpm360.img: $(RUNCPMDEPS)
@@ -4641,7 +4687,8 @@ C64DISK := $(BUILD)/c64.o88 $(BUILD)/C64.OVL \
 C64IMG = python3 tools/os88disk.py -o $(1) --size $(2) \
 	    C64:$(BUILD)/c64.o88 C64:$(BUILD)/C64.OVL \
 	    C64:apps/c64/README.TXT C64:apps/c64/COPYING
-c64disk: $(BUILD)/c64.img $(BUILD)/c64720.img $(BUILD)/c64360.img
+c64disk: $(BUILD)/c64.img $(BUILD)/c64720.img $(BUILD)/c64120.img \
+         $(BUILD)/c64360.img
 
 $(BUILD)/c64.img: $(C64DISK)
 	$(call C64IMG,$@,1440)
@@ -4649,6 +4696,10 @@ $(BUILD)/c64.img: $(C64DISK)
 
 $(BUILD)/c64720.img: $(C64DISK)
 	$(call C64IMG,$@,720)
+	@python3 tools/os88disk.py --verify $@
+
+$(BUILD)/c64120.img: $(C64DISK)
+	$(call C64IMG,$@,1200)
 	@python3 tools/os88disk.py --verify $@
 
 $(BUILD)/c64360.img: $(C64DISK)
@@ -4796,11 +4847,14 @@ $(BUILD)/wsmsize.inc: $(BUILD)/WEAVE.WSM
 
 weave: $(BUILD)/weave.o88 $(BUILD)/WEAVE.WSM
 
-# All three geometries an APPLICATION's own floppy is built in (CLAUDE.md):
-# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one. The shipped
-# system and apps pair gained a fourth, 1.2MB 5.25" (SPEC.md 19), and these did
-# not: an on-demand disk is for a machine somebody already has, and the machine
-# that wanted that geometry reads the 360KB disk in the same drive.
+# ALL FOUR geometries an APPLICATION's own floppy is built in (CLAUDE.md):
+# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one, and 1.2MB
+# 5.25" HD (SPEC.md 19) for the AT-class machine. The fourth used to be the
+# shipped system and apps pair's alone, on the argument that such a machine
+# reads the 360KB disk in the same drive - true, and it costs the user the
+# 1.2MB disk's other 831KB and makes them write DD media in an HD drive,
+# which is this project's one combination known to be marginal (the note at
+# $(IMG120)). So every on-demand application floppy is built in it too.
 # --verify is a standalone structural fsck of what came out and it is in the
 # recipe rather than in a target of its own because it costs milliseconds and
 # catches the class of defect - a bad FAT chain, a directory entry pointing at
@@ -4817,7 +4871,8 @@ weave: $(BUILD)/weave.o88 $(BUILD)/WEAVE.WSM
 # rides beside CWORD.OVL two hundred lines up. The layout itself - what the
 # two folders are and why LOOM/ carries a second copy of the runtime - is the
 # block below WEAVEDISK, and WEAVE-SPEC 11.2 is its record.
-weavedisk: $(BUILD)/weave.img $(BUILD)/weave720.img $(BUILD)/weave360.img
+weavedisk: $(BUILD)/weave.img $(BUILD)/weave720.img $(BUILD)/weave120.img \
+           $(BUILD)/weave360.img
 
 # --- THE BOOT-SECTOR GATE (WEAVE-SPEC 12.3, 12.1.1) --------------------------
 # The SHIPPING apps/weave/wvm.inc, %included by a boot sector and run in raw
@@ -4960,6 +5015,9 @@ $(BUILD)/wcat/360/CATALOG.TXT: tools/weavesim.py
 $(BUILD)/wcat/720/CATALOG.TXT: tools/weavesim.py
 	@mkdir -p $(dir $@)
 	python3 tools/weavesim.py --catalog $@ --geometry 720 --with-loom
+$(BUILD)/wcat/1200/CATALOG.TXT: tools/weavesim.py
+	@mkdir -p $(dir $@)
+	python3 tools/weavesim.py --catalog $@ --geometry 1200 --with-loom
 $(BUILD)/wcat/1440/CATALOG.TXT: tools/weavesim.py
 	@mkdir -p $(dir $@)
 	python3 tools/weavesim.py --catalog $@ --geometry 1440 --with-loom
@@ -4997,6 +5055,12 @@ $(BUILD)/weave720.img: $(WEAVEDISK) $(WEAVELOOM) $(BUILD)/wcat/720/CATALOG.TXT \
                        $(LOOMSRCS) tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 720 $(WEAVEDISKOPTS) \
 		$(WEAVEFOLDER) $(LOOMFOLDER) $(BUILD)/wcat/720/CATALOG.TXT
+	@python3 tools/os88disk.py --verify $@
+
+$(BUILD)/weave120.img: $(WEAVEDISK) $(WEAVELOOM) $(BUILD)/wcat/1200/CATALOG.TXT \
+                       $(LOOMSRCS) tools/os88disk.py
+	python3 tools/os88disk.py -o $@ --size 1200 $(WEAVEDISKOPTS) \
+		$(WEAVEFOLDER) $(LOOMFOLDER) $(BUILD)/wcat/1200/CATALOG.TXT
 	@python3 tools/os88disk.py --verify $@
 
 $(BUILD)/weave360.img: $(WEAVEDISK) $(WEAVELOOM) $(BUILD)/wcat/360/CATALOG.TXT \
@@ -5195,11 +5259,14 @@ $(BUILD)/wpvsize.inc: $(BUILD)/LOOM.WPV
 loom: $(BUILD)/loom.o88 $(BUILD)/LOOM.WPV
 
 # --- the LOOM floppy ---------------------------------------------------------
-# All three geometries an APPLICATION's own floppy is built in (CLAUDE.md):
-# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one. The shipped
-# system and apps pair gained a fourth, 1.2MB 5.25" (SPEC.md 19), and these did
-# not: an on-demand disk is for a machine somebody already has, and the machine
-# that wanted that geometry reads the 360KB disk in the same drive.
+# ALL FOUR geometries an APPLICATION's own floppy is built in (CLAUDE.md):
+# 1.44MB and 720KB for QEMU, 360KB for an 86Box XT or a real one, and 1.2MB
+# 5.25" HD (SPEC.md 19) for the AT-class machine. The fourth used to be the
+# shipped system and apps pair's alone, on the argument that such a machine
+# reads the 360KB disk in the same drive - true, and it costs the user the
+# 1.2MB disk's other 831KB and makes them write DD media in an HD drive,
+# which is this project's one combination known to be marginal (the note at
+# $(IMG120)). So every on-demand application floppy is built in it too.
 # --verify is a standalone structural fsck of what came out.
 #
 # WHAT IS ON IT, AND WHY EACH FILE IS THERE:
@@ -5247,7 +5314,8 @@ loom: $(BUILD)/loom.o88 $(BUILD)/LOOM.WPV
 
 LOOMDISK := $(WEAVELOOM) $(LOOMRUN) $(WEAVEDISK) $(LOOMSRCS)
 
-loomdisk: $(BUILD)/loom.img $(BUILD)/loom720.img $(BUILD)/loom360.img
+loomdisk: $(BUILD)/loom.img $(BUILD)/loom720.img $(BUILD)/loom120.img \
+          $(BUILD)/loom360.img
 
 # --folder SYSTEM/APPDATA IS NOT DECORATION (SPEC.md 19.9): LOOM.CFG - the last
 # project's folder and the last file slot - goes there, on the volume the
@@ -5265,6 +5333,11 @@ $(BUILD)/loom.img: $(LOOMDISK) tools/os88disk.py
 
 $(BUILD)/loom720.img: $(LOOMDISK) tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 720 --folder SYSTEM/APPDATA \
+		--dir-slots LOOM=32 $(WEAVEFOLDER) $(LOOMFOLDER)
+	@python3 tools/os88disk.py --verify $@
+
+$(BUILD)/loom120.img: $(LOOMDISK) tools/os88disk.py
+	python3 tools/os88disk.py -o $@ --size 1200 --folder SYSTEM/APPDATA \
 		--dir-slots LOOM=32 $(WEAVEFOLDER) $(LOOMFOLDER)
 	@python3 tools/os88disk.py --verify $@
 
@@ -5327,12 +5400,26 @@ stories: $(BUILD)/stories.stamp
 #
 #   360KB   what a 256KB XT can also RUN: the v3 stories (SPEC.md 61.4)
 #   720KB   the xt-z disk
+#   1.2MB   the 5.25" HD disk (SPEC.md 19), and the one list here that is a
+#           CUT rather than a fill: its clusters are 512 bytes like the
+#           1.44MB disk's, but it has 2,371 of them against 2,847, and the
+#           1.44MB story set alone is 2,519 - over before the interpreter is
+#           priced. So two titles come off, chosen so that no TITLE is lost
+#           and every folder keeps more than one story: ADVENT5.Z5, which is
+#           the v5 re-release of an ADVENT.Z3 that stays, and 905.Z5, the
+#           smallest of MODERN's three. That leaves ~118KB free, which is
+#           the 1.44MB disk's own proportion of room to save into
 #   1.44MB  the 386-z disk, plus a second library disk you swap in
 ZS_360  := INFOCOM:$(STORYDIR)/MINIZORK.Z3 CLASSIC:$(STORYDIR)/ADVENT.Z3 \
            CLASSIC:$(STORYDIR)/ZORK285.Z5 CLASSIC:$(STORYDIR)/BALANCES.Z5
 ZS_720  := INFOCOM:$(STORYDIR)/MINIZORK.Z3 INFOCOM:$(STORYDIR)/ZTUU.Z5 \
            CLASSIC:$(STORYDIR)/ADVENT.Z3 CLASSIC:$(STORYDIR)/ZORK285.Z5 \
            MODERN:$(STORYDIR)/PHOTOPIA.Z5
+ZS_1200 := INFOCOM:$(STORYDIR)/MINIZORK.Z3 INFOCOM:$(STORYDIR)/SAMPLER1.Z3 \
+           INFOCOM:$(STORYDIR)/SAMPLER2.Z3 INFOCOM:$(STORYDIR)/ZTUU.Z5 \
+           CLASSIC:$(STORYDIR)/ADVENT.Z3 CLASSIC:$(STORYDIR)/ZORK285.Z5 \
+           CLASSIC:$(STORYDIR)/BALANCES.Z5 MODERN:$(STORYDIR)/PHOTOPIA.Z5 \
+           MODERN:$(STORYDIR)/BEAR.Z5
 ZS_1440 := INFOCOM:$(STORYDIR)/MINIZORK.Z3 INFOCOM:$(STORYDIR)/SAMPLER1.Z3 \
            INFOCOM:$(STORYDIR)/SAMPLER2.Z3 INFOCOM:$(STORYDIR)/ZTUU.Z5 \
            CLASSIC:$(STORYDIR)/ADVENT.Z3 CLASSIC:$(STORYDIR)/ADVENT5.Z5 \
@@ -5347,8 +5434,8 @@ ZS_DISK2 := MODERN:$(STORYDIR)/BRONZE.Z8 MODERN:$(STORYDIR)/DREAMHLD.Z8 \
 
 STORIES ?=
 
-zdisk: $(BUILD)/zork.img $(BUILD)/zork720.img $(BUILD)/zork360.img \
-       $(BUILD)/zork2.img
+zdisk: $(BUILD)/zork.img $(BUILD)/zork720.img $(BUILD)/zork120.img \
+       $(BUILD)/zork360.img $(BUILD)/zork2.img
 
 # The catalogue is CATALOG.TXT on every disk - os88disk.py takes the 8.3 name
 # from the file's BASENAME, so the four of them need four directories rather
@@ -5359,6 +5446,10 @@ $(BUILD)/zcat/360/CATALOG.TXT: tools/getstories.py
 $(BUILD)/zcat/720/CATALOG.TXT: tools/getstories.py
 	@mkdir -p $(dir $@)
 	python3 tools/getstories.py --catalog $@ MINIZORK.Z3 ZTUU.Z5 ADVENT.Z3 ZORK285.Z5 PHOTOPIA.Z5
+$(BUILD)/zcat/1200/CATALOG.TXT: tools/getstories.py
+	@mkdir -p $(dir $@)
+	python3 tools/getstories.py --catalog $@ MINIZORK.Z3 SAMPLER1.Z3 SAMPLER2.Z3 ZTUU.Z5 \
+		ADVENT.Z3 ZORK285.Z5 BALANCES.Z5 PHOTOPIA.Z5 BEAR.Z5
 $(BUILD)/zcat/1440/CATALOG.TXT: tools/getstories.py
 	@mkdir -p $(dir $@)
 	python3 tools/getstories.py --catalog $@ MINIZORK.Z3 SAMPLER1.Z3 SAMPLER2.Z3 ZTUU.Z5 \
@@ -5378,6 +5469,12 @@ $(BUILD)/zork720.img: $(BUILD)/frotz.o88 $(BUILD)/stories.stamp $(BUILD)/zcat/72
 	python3 tools/os88disk.py -o $@ --size 720 \
 		$(BUILD)/frotz.o88 $(BUILD)/zcat/720/CATALOG.TXT $(ZS_720) $(STORIES) \
 		--folder SAVES
+
+$(BUILD)/zork120.img: $(BUILD)/frotz.o88 $(BUILD)/stories.stamp $(BUILD)/zcat/1200/CATALOG.TXT \
+                      tools/os88disk.py
+	python3 tools/os88disk.py -o $@ --size 1200 \
+		$(BUILD)/frotz.o88 $(BUILD)/zcat/1200/CATALOG.TXT $(ZS_1200) $(STORIES) \
+		--folder SAVES --folder ART
 
 $(BUILD)/zork360.img: $(BUILD)/frotz.o88 $(BUILD)/stories.stamp $(BUILD)/zcat/360/CATALOG.TXT \
                       tools/os88disk.py
@@ -5445,13 +5542,17 @@ $(BUILD)/word.o88: $(BUILD)/word.bin tools/os88ovl.py tools/os88pkg.py
 
 $(BUILD)/WORD.OVL: $(BUILD)/word.o88 ;
 
-worddisk: $(BUILD)/word.img $(BUILD)/word720.img $(BUILD)/word360.img
+worddisk: $(BUILD)/word.img $(BUILD)/word720.img $(BUILD)/word120.img \
+          $(BUILD)/word360.img
 
 $(BUILD)/word.img: $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 1440 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC --folder DOCS
 
 $(BUILD)/word720.img: $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 720 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC --folder DOCS
+
+$(BUILD)/word120.img: $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC tools/os88disk.py
+	python3 tools/os88disk.py -o $@ --size 1200 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC --folder DOCS
 
 $(BUILD)/word360.img: $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 360 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC --folder DOCS
@@ -7209,6 +7310,15 @@ $(APPSIMG360): $(APPS360) tools/os88disk.py
 # there is nothing here to double-click and nothing for os88disk.py to
 # validate as one: it is data, on a disk whose whole job is to be swapped into
 # B: when the module is what you came for.
+#
+# AND THERE IS NO 1.2MB ONE, WHICH IS NOT AN OMISSION. This disk exists
+# because BEVERLY.MOD is 114 of a 360KB volume's 354 clusters and the apps
+# disk cannot spare them - so 24.4 splits it off AT THAT GEOMETRY ALONE. The
+# 1.2MB apps disk above is built from the FULL $(APPSARGS), the same list the
+# 1.44MB one uses, so it already carries the module in MEDIA/ and a second
+# disk to swap in would be a disk with a file the user already has. The rule
+# is the geometry's, not the disk's: a media disk exists exactly where the
+# apps disk had to drop the module, and 1.2MB is not such a geometry.
 $(MEDIAIMG360): $(MEDIA_DISK_DATA) tools/os88disk.py
 	python3 tools/os88disk.py -o $@ --size 360 $(MEDIAARGS360)
 
@@ -7229,11 +7339,22 @@ $(MEDIAIMG360): $(MEDIA_DISK_DATA) tools/os88disk.py
 # (SPEC.md 73.1). A clone with nasm and python3 builds every SHIPPED floppy;
 # this one target is the exception, so it is on demand exactly like cworddisk.
 #
-# WHY 1.44MB AND ONLY 1.44MB. The contents are ~1,050KB with RUNCPM's drive
-# on it (~430KB before). That is not a geometry choice made to be generous - a
-# 720KB or 360KB build of this list simply does not fit, and the shipped disks
-# already cover those machines. So there is one size here and no --size
-# variants to keep in step.
+# TWO GEOMETRIES, 1.44MB AND 1.2MB. The contents are ~1,050KB with RUNCPM's
+# drive on it (~430KB before). That is not a geometry choice made to be
+# generous - a 720KB or 360KB build of this list simply does not fit, and the
+# shipped disks already cover those machines. The 1.2MB 5.25" HD disk
+# (SPEC.md 19) does: its clusters are 512 bytes like the 1.44MB disk's rather
+# than 1,024 like the two DD disks', so it holds 2,371 of them - 1,185KB -
+# against 1,423KB, and the payload has room to spare.
+#
+# The two builds share ONE payload list (ALLAPPSARGS) and differ in the
+# --size and in the RunCPM drive-A --select that is priced against it, which
+# is the only part of this disk that re-shapes itself per geometry: it fills
+# the master disk until the clusters run out, so the 1.2MB disk's A\0 is the
+# 1.44MB one minus whatever the ranked fill reached last, and its own
+# LEFT-OFF.TXT names it. Nothing else here is a per-size list to keep in
+# step - which is the point, because two hand-maintained everything-lists is
+# exactly how they drift.
 #
 # THE TREE: each Word gets a FOLDER OF ITS OWN rather than a place in APPS/,
 # and that is a correctness requirement and not tidiness. Both carry an
@@ -7283,6 +7404,7 @@ $(MEDIAIMG360): $(MEDIA_DISK_DATA) tools/os88disk.py
 # taken (the tree nests one deep); a DIR/SUB/SUB2: entry would need its
 # grandparent added by hand.
 ALLAPPSIMG := $(BUILD)/apps-all.img
+ALLAPPSIMG120 := $(BUILD)/apps-all-120.img
 
 ALLAPPSFILES := $(APPS) $(BUILD)/frotz.o88 \
                 $(BUILD)/word.o88 $(BUILD)/WORD.OVL $(BUILD)/WELCOME.DOC \
@@ -7329,15 +7451,31 @@ ALLAPPSDIRS := $(sort $(ALLAPPSDIRS) \
                       $(patsubst %/,%,$(filter-out ./,$(dir $(ALLAPPSDIRS)))))
 ALLAPPSFOLDERS := $(words $(ALLAPPSDIRS))
 
-allapps: $(ALLAPPSIMG)
+allapps: $(ALLAPPSIMG) $(ALLAPPSIMG120)
+
+# One recipe body for both, because the two disks differ in a --size and in
+# the geometry the RunCPM selection is priced in, and nothing else. $(1) is
+# the image, $(2) the geometry. The empty-selection guard is RUNCPMIMG's and
+# is here for its reason: a --select that fails prints nothing on stdout, and
+# without this the disk would build with an empty A\0 and verify clean -
+# which reads exactly like a working disk.
+define ALLAPPSIMGRULE
+sel="$$(python3 tools/getruncpm.py -o $(RUNCPMDIR) --select $(2) --dir-slots $(RUNCPMSLOTS) --folders $(ALLAPPSFOLDERS) --reserve-clusters $(ALLAPPSEXTRA) --reserve $(ALLAPPSFILES) | sed 's,^,RUNCPM/A/0:,')"; \
+[ -n "$$sel" ] || { echo "allapps: getruncpm.py --select $(2) chose nothing"; exit 1; }; \
+python3 tools/os88disk.py -o $(1) --size $(2) --deep-folders --dir-slots RUNCPM/A/0=$(RUNCPMSLOTS) --dir-slots LOOM=32 --folder DOCS $(APPDATAFOLDER) $(ALLAPPSARGS) $$sel
+endef
 
 $(ALLAPPSIMG): $(ALLAPPS) tools/os88disk.py
-	sel="$$(python3 tools/getruncpm.py -o $(RUNCPMDIR) --select 1440 --dir-slots $(RUNCPMSLOTS) --folders $(ALLAPPSFOLDERS) --reserve-clusters $(ALLAPPSEXTRA) --reserve $(ALLAPPSFILES) | sed 's,^,RUNCPM/A/0:,')"; \
-	[ -n "$$sel" ] || { echo "allapps: getruncpm.py --select 1440 chose nothing"; exit 1; }; \
-	python3 tools/os88disk.py -o $@ --size 1440 --deep-folders --dir-slots RUNCPM/A/0=$(RUNCPMSLOTS) --dir-slots LOOM=32 --folder DOCS $(APPDATAFOLDER) $(ALLAPPSARGS) $$sel
+	$(call ALLAPPSIMGRULE,$@,1440)
 	@python3 tools/os88disk.py --verify $@
 	@echo "allapps: $@ - every app on one 1.44MB floppy; boot the system"
 	@echo "         disk with it in B: (make run RUNAPPS=$@)"
+
+$(ALLAPPSIMG120): $(ALLAPPS) tools/os88disk.py
+	$(call ALLAPPSIMGRULE,$@,1200)
+	@python3 tools/os88disk.py --verify $@
+	@echo 'allapps: $@ - the same disk at 1.2MB, for the 5.25" HD machine'
+	@echo "         (make run-120 RUNAPPS120=$@)"
 
 # =============================================================================
 # THE LIVE MEDIA (ON DEMAND: `make usb` / `make iso` / `make live`) - SPEC.md 80
@@ -7730,9 +7868,16 @@ run-640: $(IMG) $(APPSIMG)
 # QEMU picks a floppy's geometry from the image SIZE, and 1,228,800 bytes is a
 # standard one (2 heads x 80 cyl x 15 spt), so naming the images is the whole
 # recipe - and an image the BIOS reads as some other shape fails right here.
-run-120: $(IMG120) $(APPSIMG120)
+# RUNAPPS120 is RUNAPPS one geometry along: what goes in B: when the machine
+# is the 5.25" HD one, so a 1.2MB disk built on demand can be LOOKED at
+# rather than only listed.
+#   make zdisk && make run-120 RUNAPPS120=build/zork120.img
+#   make allapps && make run-120 RUNAPPS120=build/apps-all-120.img
+RUNAPPS120 ?= $(APPSIMG120)
+
+run-120: $(IMG120) $(RUNAPPS120)
 	$(QEMU) $(QEMUMACH) -drive file=$(IMG120),format=raw,if=floppy -boot a $(MOUSE) \
-		-drive file=$(APPSIMG120),format=raw,if=floppy,index=1 $(DEVCARD)
+		-drive file=$(RUNAPPS120),format=raw,if=floppy,index=1 $(DEVCARD)
 
 run-720: $(IMG720) $(APPSIMG720)
 	$(QEMU) $(QEMUMACH) -drive file=$(IMG720),format=raw,if=floppy -boot a $(MOUSE) \
@@ -8028,6 +8173,54 @@ xt-multimon: $(IMG360) $(APPSIMG360)
 286-525: $(IMG120) $(APPSIMG120)
 	@$(UNPROTECT) $(VM286525)/86box.cfg
 	$(BOX) -P $(VM286525) -N
+
+# ...and the same machine with an APPLICATION disk in B: instead of the apps
+# floppy - the pairing `xt-z`, `386-word`, `386-c-word`, `386-runcpm`,
+# `386-c64` and `386-weave` already are at their geometries, and the block
+# above VM286525Z says why there is one machine class here and not three.
+# Each is MANUAL EVIDENCE and never a gate: 86Box has no automation socket, so
+# a session can start one of these and cannot read the result
+# (docs/TESTING.md). Every one stops in BIOS setup on its FIRST launch, its
+# CMOS being empty - pick EXIT FOR BOOT once (the note above `286`).
+286-525-z: $(IMG120) $(BUILD)/zork120.img
+	@$(UNPROTECT) $(VM286525Z)/86box.cfg
+	$(BOX) -P $(VM286525Z) -N
+
+286-525-word: $(IMG120) $(BUILD)/word120.img
+	@$(UNPROTECT) $(VM286525WORD)/86box.cfg
+	$(BOX) -P $(VM286525WORD) -N
+
+286-525-cword: $(IMG120) $(BUILD)/cword120.img
+	@$(UNPROTECT) $(VM286525CWORD)/86box.cfg
+	$(BOX) -P $(VM286525CWORD) -N
+
+# The CP/M machine, and the geometry is the PLAY SPEED here as much as the
+# capacity (SPEC.md 74.6): nothing throttles the emulated Z80, so an arcade
+# game runs at whatever the host machine is. 12.5MHz is between `286-runcpm`'s
+# 720KB disk and `386-runcpm`'s 1.44MB one - which is the same 286, so this
+# and that machine differ in the DISK and not the clock.
+286-525-runcpm: $(IMG120) $(BUILD)/runcpm120.img
+	@$(UNPROTECT) $(VM286525RUNCPM)/86box.cfg
+	$(BOX) -P $(VM286525RUNCPM) -N
+
+286-525-c64: $(IMG120) $(BUILD)/c64120.img
+	@$(UNPROTECT) $(VM286525C64)/86box.cfg
+	$(BOX) -P $(VM286525C64) -N
+
+286-525-weave: $(IMG120) $(BUILD)/weave120.img
+	@$(UNPROTECT) $(VM286525WEAVE)/86box.cfg
+	$(BOX) -P $(VM286525WEAVE) -N
+
+286-525-loom: $(IMG120) $(BUILD)/loom120.img
+	@$(UNPROTECT) $(VM286525LOOM)/86box.cfg
+	$(BOX) -P $(VM286525LOOM) -N
+
+# The everything disk on period hardware. `xt-sound-1.44` is the only other
+# machine in the tree that boots one, and it is a 3.5" XT - so this is where
+# a 5.25" machine sees every program at once.
+286-525-all: $(IMG120) $(ALLAPPSIMG120)
+	@$(UNPROTECT) $(VM286525ALL)/86box.cfg
+	$(BOX) -P $(VM286525ALL) -N
 
 386sx: $(IMG) $(APPSIMG)
 	@$(UNPROTECT) $(VM386SX)/86box.cfg

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ make          # build all nine floppy images
 make run      # boot it in QEMU (with an emulated serial mouse)
 make run-640  # the same, on a 640KB machine
 make run-720  # the same, off the 720KB pair
-make run-120  # the same, off the 1.2MB 5.25" HD pair
+make run-120  # the same, off the 1.2MB 5.25" HD pair. RUNAPPS120=<img>
+              # swaps the B: floppy, so any 1.2MB app disk can be looked at
 make xt       # boot the 360KB image on an emulated IBM PC/XT in 86Box
 make xt-640   # the same XT with a full 640KB of RAM
 make xt-mfm   # ...and a 20MB MFM hard disk on IBM's Fixed Disk Adapter
@@ -75,7 +76,7 @@ make xt-sound # the 640KB XT with a Sound Blaster 2.0 (OPL2 + DSP)
 make xt-sound-1.44 # the 640KB XT with SB 1.0 and every app on a 1.44MB B:
 make 286-sound  # 86Box: the 286, with a Sound Blaster 16
 make 386-sound  # 86Box: the 386DX, with a Sound Blaster 16
-make worddisk # build the Microsoft Word floppy, all three geometries
+make worddisk # build the Microsoft Word floppy, all four geometries
 make xt-word  # 86Box: the 640KB XT with the Word disk in B:
 make 386-word # 86Box: the 386DX with the Word disk in B:
 make zdisk    # build the Frotz story floppies (fetches the stories first)
@@ -86,7 +87,7 @@ make 386-c-word # 86Box: the 386DX with that disk in B:
 make runcpmdisk # build the RunCPM floppies - the CP/M 2.2 emulator, its
                 # overlay, DR's CCP, the master disk as CP/M drive A, and
                 # the CP/M games and applications beside it (make cpmsw
-                # fetches those; the 1.44MB disk carries the most)
+                # fetches those; the 1.44MB and 1.2MB disks carry the most)
 make xt-runcpm  # 86Box: the 4.77MHz XT with the 360KB RunCPM disk in B:
 make 286-runcpm # 86Box: the 12.5MHz 286 with the 720KB one - arcade games
 make 386-runcpm # 86Box: the 386DX with the 1.44MB one - everything
@@ -94,7 +95,8 @@ make c64disk  # build the C64 floppy - a Commodore 64: the package, its
               # overlay; the KERNAL/BASIC/CHARGEN ROM rides INSIDE the
               # package as an embedded part (SPEC.md 20.12)
               # (make c64rom builds that from the ROMs in apps/c64/rom/)
-              # ...in all three geometries: c64.img, c64720.img, c64360.img
+              # ...in all four geometries: c64.img, c64720.img, c64120.img,
+              # c64360.img
 make xt-c64   # 86Box: the 4.77MHz XT with the 360KB C64 disk in B: - where
               # the speed figure on the status row is the one that matters
 make 286-c64  # 86Box: the 12.5MHz 286 with the 720KB one
@@ -104,7 +106,7 @@ make weavedisk # build the Weave floppy - web-style apps compiled to a .WAB
               # modules, three demo bundles, LOOM (the in-OS IDE that edits
               # and packs them), the sources they were built from and a
               # CATALOG.TXT saying what is on it. One folder, which the
-              # catalogue explains. All three geometries.
+              # catalogue explains. All four geometries.
               # BUNDLES='path/to/MYAPP.WAB' adds your own
 make xt-weave # 86Box: the 640KB 4.77MHz XT with the 360KB Weave disk in B:
 make 386-weave # 86Box: the 386DX with the 1.44MB one
@@ -112,10 +114,15 @@ make xt-weave-256 # ...and the 256KB XT, which holds exactly ONE Weave app:
               # the second one refuses before it touches the disk, with the
               # arithmetic on the glass
 make loomdisk # the IDE's own floppy: LOOM and the runtime beside it, with
-              # the demo sources flat, in all three geometries
-make allapps  # one 1.44MB floppy with every program on it - both word
-              # processors, Frotz, RunCPM, the Commodore 64 and the Weave
-              # family included
+              # the demo sources flat, in all four geometries
+make 286-525-z    # 86Box: the 1.2MB 5.25" 286 with a 1.2MB app disk in B:
+make 286-525-word #   instead of the apps floppy - one per application disk:
+make 286-525-cword#   -z -word -cword -runcpm -c64 -weave -loom -all. The
+make 286-525-all  #   ONLY machines that read a 1.2MB disk (an XT cannot)
+make allapps  # one floppy with every program on it - both word processors,
+              # Frotz, RunCPM, the Commodore 64 and the Weave family
+              # included. 1.44MB and 1.2MB; the two DD geometries cannot
+              # hold the payload at all
 make live     # the live media (docs/LIVE-MEDIA.md): os8088-usb.img, a
               # bootable hard-disk image for a USB stick, and os8088.iso,
               # the same image as a live CD - the whole OS and every app
@@ -442,7 +449,7 @@ segment, `RUNCPM.OVL`, split by frequency: what a record, a console byte or a
 keystroke touches stays resident, and the per-command half of the disk layer
 goes out. Nothing of RunCPM's is committed: `tools/getruncpm.py` fetches the
 CCP and the master disk at a pinned commit and `make runcpmdisk` builds the
-three floppies from them (the 360KB one curated to the programs and texts,
+four floppies from them (the 360KB one curated to the programs and texts,
 with a `LEFT-OFF.TXT` naming what it leaves off).
 
 **And there is software to run on it.** `tools/getcpmsw.py` fetches CP/M
@@ -455,6 +462,7 @@ that the emulator's own icon stays on the first screen of the Disk window:
 | disk | machine | CP/M software |
 |---|---|---|
 | `build/runcpm.img` (1.44MB) | `make 386-runcpm` — 386DX/25 | **all of it**, in drive A's user areas: `USER 5` LADDER, CATCHUM, PM · `USER 6` Nemesis, Dungeon Master, Castle · `USER 7` GAINA · `USER 8` Turbo Pascal 3.01A · `USER 9` WordStar 3.30 — beside 59 files of the master disk |
+| `build/runcpm120.img` (1.2MB) | no 86Box machine yet — `make run-120 RUNAPPS120=build/runcpm120.img` | **four of the five**: `USER 5` · `USER 6` · `USER 7` · `USER 8` Turbo Pascal — WordStar comes off, being the largest area, so that the master disk keeps its programs — beside 63 files of it, which is more than the 1.44MB disk holds |
 | `build/runcpm720.img` (720KB) | `make 286-runcpm` — 286 at 12.5MHz | `USER 5`, the arcade games, beside 70 files of the master disk |
 | `build/runcpm360.img` (360KB) | `make xt-runcpm` — 4.77MHz XT | no room for games: the master disk's programs and texts, and a `GAMES.TXT` saying where they are |
 
@@ -530,15 +538,16 @@ cleanly and runs wrong when C meets this machine.
 | `build/apps120.img`    | 1.2MB FAT12              | 5.25" HD software floppy        |
 | `build/apps720.img`    | 720KB FAT12              | 3.5" DD software floppy         |
 | `build/apps360.img`    | 360KB FAT12              | 86Box / real XT software floppy |
-| `build/media360.img`   | 360KB FAT12              | 360KB media floppy — the shipped module, which the 360KB apps disk has no room for |
-| `build/zork*.img`      | 1.44MB / 720KB / 360KB   | Frotz story floppies (`make zdisk`) |
-| `build/word*.img`      | 1.44MB / 720KB / 360KB   | Microsoft Word floppies (`make worddisk`) |
-| `build/cword*.img`     | 1.44MB / 720KB / 360KB   | Word in C, package + `CWORD.OVL` (`make cworddisk`) |
-| `build/runcpm*.img`    | 1.44MB / 720KB / 360KB   | RunCPM, package + `RUNCPM.OVL` + CP/M drive A + the games and applications each holds (`make runcpmdisk`) |
-| `build/c64*.img`       | 1.44MB / 720KB / 360KB   | Commodore 64, package + `C64.OVL` + the `C64.ROM` sidecar (`make c64disk`) |
-| `build/weave*.img`     | 1.44MB / 720KB / 360KB   | Weave: the runtime and its two modules, the demo bundles, LOOM, the demo sources and `CATALOG.TXT` (`make weavedisk`) |
-| `build/loom*.img`      | 1.44MB / 720KB / 360KB   | the Weave IDE's own disk, with the demo sources flat (`make loomdisk`) |
+| `build/media360.img`   | 360KB FAT12              | 360KB media floppy — the shipped module, which the 360KB apps disk has no room for. It exists at that geometry **alone**: every other apps disk, the 1.2MB one included, carries `BEVERLY.MOD` in `MEDIA/` itself |
+| `build/zork*.img`      | 1.44MB / 720KB / 1.2MB / 360KB | Frotz story floppies (`make zdisk`). The 1.2MB one is the only list here that is a cut rather than a fill — the 1.44MB story set alone overruns it, so `ADVENT5.Z5` and `905.Z5` come off and nine of the eleven stay |
+| `build/word*.img`      | 1.44MB / 720KB / 1.2MB / 360KB | Microsoft Word floppies (`make worddisk`) |
+| `build/cword*.img`     | 1.44MB / 720KB / 1.2MB / 360KB | Word in C, package + `CWORD.OVL` (`make cworddisk`) |
+| `build/runcpm*.img`    | 1.44MB / 720KB / 1.2MB / 360KB | RunCPM, package + `RUNCPM.OVL` + CP/M drive A + the games and applications each holds (`make runcpmdisk`). What drive A carries is chosen per geometry at build time, so the 1.2MB disk fills itself and names what it left off in its own `LEFT-OFF.TXT` |
+| `build/c64*.img`       | 1.44MB / 720KB / 1.2MB / 360KB | Commodore 64, package + `C64.OVL` + the `C64.ROM` sidecar (`make c64disk`) |
+| `build/weave*.img`     | 1.44MB / 720KB / 1.2MB / 360KB | Weave: the runtime and its two modules, the demo bundles, LOOM, the demo sources and `CATALOG.TXT` (`make weavedisk`) |
+| `build/loom*.img`      | 1.44MB / 720KB / 1.2MB / 360KB | the Weave IDE's own disk, with the demo sources flat (`make loomdisk`) |
 | `build/apps-all.img`   | 1.44MB FAT12             | every program on one floppy, the seven above included (`make allapps`) |
+| `build/apps-all-120.img` | 1.2MB FAT12            | the same disk for the 5.25" HD machine. There is no 720KB or 360KB build: the payload does not fit either |
 
 The boot sector takes its geometry from `-DSPT` / `-DHEADS` at assembly
 time and reads exactly as many sectors as the measured kernel occupies.
@@ -567,7 +576,21 @@ later, or a late XT with an HD controller — whose only drive is 5.25" reads
 neither 3.5" disk. It *can* boot the 360KB one, because a 1.2MB drive reads
 360KB media, and that is what it had to do; it then got 354 clusters of
 software in a drive with 2,371, and had to swap the media disk in for
-`BEVERLY.MOD`. The 1.2MB pair carries the full 1.44MB payload instead. It is
+`BEVERLY.MOD`. The 1.2MB pair carries the full 1.44MB payload instead, and so
+does every application floppy: the seven on-demand disks above are built in
+this geometry too, and so is the everything disk.
+
+Its clusters are 512 bytes like the 1.44MB disk's rather than 1,024 like the
+two DD disks', so it has 2,371 of them — 1,185KB against 1,423KB — and that
+ratio, not the raw one, is what each disk is measured against. Four of the
+seven (Word, cword, the C64, Weave/LOOM) are small enough that every geometry
+carries the identical payload. Three are not, and each answers it in its own
+way: the **story disk** is a straight cut, because the 1.44MB story list alone
+is 2,519 clusters and two titles have to come off; the **RunCPM disk** drops
+its largest CP/M software area so that the master disk keeps its programs, and
+ends up with more of that disk than the 1.44MB one holds; the **everything
+disk** re-prices RunCPM's drive A automatically and fills what is left. Only
+the first is a hand-written list. It is
 also the safer disk to write: a 1.2MB drive's head is narrower than a 360KB
 drive's, so a 360KB disk written in one is often unreadable in a real 360KB
 drive afterwards — and the OS writes its settings to the boot disk. It is the
@@ -680,13 +703,30 @@ All targets, at a glance:
 | `xt-weave` | XT, 1986 board | 8088 @ 4.77MHz | 640KB | OTI-067 VGA | — |
 | `386-weave` | Micronics 386 | 386DX @ 25MHz | 2MB | OTI-067 VGA | — |
 | `xt-weave-256` | IBM PC/XT | 8088 @ 4.77MHz | **256KB** | OTI-067 VGA | — |
+| `286-525-z` | AMI 286 clone, two 1.2MB **5.25"** drives | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-word` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-cword` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-runcpm` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-c64` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-weave` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-loom` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
+| `286-525-all` | " | 286 @ 12.5MHz | 1MB | OTI-067 VGA | — |
 
 The XT-class machines boot the 360KB system disk; most pair it with the 360KB
 apps disk, while `xt-sound-1.44` mounts the everything disk in a 1.44MB B:
-drive. The AT-class machines boot the 1.44MB pair — all but `286-525`, which
-is the same AMI 286 fitted with two **5.25" HD** drives and boots the 1.2MB
-pair. It is the only profile here with those drives, so it is the only place
-that geometry runs on period hardware.
+drive. The AT-class machines boot the 1.44MB pair — all but the
+`286-525` family, which is the same AMI 286 fitted with two **5.25" HD**
+drives and boots the 1.2MB pair. Those are the only profiles here with those
+drives, so they are the only place that geometry runs on period hardware.
+
+`286-525` itself carries the apps floppy; the eight `286-525-*` machines swap
+B: for an application disk, the way `xt-z`, `386-word` and `386-c64` do at
+their geometries. There is **one** machine class here rather than the three
+RunCPM and the C64 have, and that is the geometry's doing: a 1.2MB drive needs
+a 500 kbps controller, which is the AT's, so no XT can read one of these disks
+at all. `286-525-loom` and `286-525-all` are the first machines their disks
+have had at any geometry — LOOM has always been reached through the Weave
+disk that carries it, and the everything disk only ever rode `xt-sound-1.44`.
 
 `xt-multimon` is the **two-card** XT — a CGA and a Hercules, a monitor window
 each — and the only 86Box machine that can show the extended desktop. It boots

--- a/SPEC.md
+++ b/SPEC.md
@@ -27889,6 +27889,39 @@ swapping the media disk in (§24.4), and `OS88NET.COM` competing with the games
 for room. `build/os8088-120.img` and `build/apps120.img` carry the **same
 payload as the 1.44MB pair** instead.
 
+**And so does every application floppy.** The shipped pair got this geometry
+first and the on-demand disks did not, on the argument that such a machine can
+read the 360KB disk in the same drive — which is true, and which spends the
+paragraph above twice: the 831KB it leaves on the floor, and the DD-media-in-
+an-HD-drive write this section is otherwise about avoiding. So `make zdisk`,
+`worddisk`, `cworddisk`, `runcpmdisk`, `c64disk`, `weavedisk`, `loomdisk` and
+`allapps` all build a 1.2MB image beside the others, and the payload is the
+**1.44MB one** wherever it fits, which is everywhere but the story disk.
+
+Two disks are the exceptions, in opposite directions:
+
+- **The story floppy is a CUT, not a fill** (§61.4). 1.2MB has 512-byte
+  clusters like the 1.44MB disk but 2,371 of them against 2,847, and the
+  1.44MB story list alone is 2,519 — over before `FROTZ.O88` is priced. Two
+  titles come off, chosen so no *title* is lost and every folder keeps more
+  than one story: `ADVENT5.Z5`, the v5 re-release of an `ADVENT.Z3` that
+  stays, and `905.Z5`, the smallest of MODERN's three. Nine of eleven ship,
+  at 2,139 of 2,371 clusters.
+- **There is no 1.2MB media disk, and that is not an omission** (§24.4). That
+  disk exists because `BEVERLY.MOD` is 114 of a 360KB volume's 354 clusters
+  and the apps disk cannot spare them — a split made AT THAT GEOMETRY ALONE.
+  `build/apps120.img` is built from the full apps list and already carries the
+  module in `MEDIA/`, so a second disk to swap in would carry a file the user
+  has. A media disk exists exactly where the apps disk had to drop the module,
+  and this is not such a geometry.
+
+The everything disk (§19.10) gains the geometry and keeps its floor: 1.44MB
+and 1.2MB build, 720KB and 360KB still cannot hold the payload at all. What
+re-shapes itself there is RunCPM's drive A, which is chosen by cluster budget
+at recipe time (§74.5) rather than listed — so the 1.2MB disk fills itself and
+names what it left off in its own `LEFT-OFF.TXT`, and there is no second
+hand-maintained everything-list to drift.
+
 There is a second reason, and it is about writing rather than room. A 1.2MB
 drive's head is narrower than a 360KB drive's, so a 360KB disk written in one
 is often unreadable in a real 360KB drive afterwards — the one combination of
@@ -29200,15 +29233,26 @@ two, **WEAVE** and **LOOM** (`WEAVE-SPEC 1.2`). That is right for
 the machines this runs on and awkward for a person downloading it, who wants to
 try the software rather than curate a shelf of floppies.
 
-`make allapps` builds **`build/apps-all.img`**: one 1.44MB volume with every
-application on it, offered beside the shipped images on a release page. It is a
-convenience and nothing in the tree boots it by default.
+`make allapps` builds **`build/apps-all.img`** and **`build/apps-all-120.img`**:
+one volume with every application on it, at 1.44MB and at 1.2MB, offered beside
+the shipped images on a release page. It is a convenience and nothing in the
+tree boots it by default.
 
-**It is 1.44MB and has no smaller variants.** The contents are ~1,360KB with
-RUNCPM's drive A and the C64's ROM sidecar on it, so a
-720KB or 360KB build of this list does not exist rather than being declined —
-and the machines those geometries are for are already served by the shipped
-disks. One size means no set of variants to keep in step.
+**Two geometries, and the two DD ones are a refusal rather than an omission.**
+The fixed payload is ~950KB before RUNCPM's drive A, so a 720KB or 360KB build
+of this list does not exist — and the machines those geometries are for are
+already served by the shipped disks. 1.2MB holds it: its clusters are 512 bytes
+like the 1.44MB disk's rather than 1,024 like the two DD disks', so it has
+2,371 of them — 1,185KB — against 1,423KB.
+
+**The two builds share one payload list and differ in two things**: the
+`--size`, and the RUNCPM drive-A `--select` that is priced against it. That
+selection is the only part of this disk that re-shapes itself per geometry
+(§74.5): it fills the master disk until the clusters run out, so the 1.2MB
+disk's `A\0` is 33 files where the 1.44MB one's is 66, and each names what it
+left off in its own `LEFT-OFF.TXT`. Nothing else here is a per-size list to
+keep in step, which is the point — two hand-maintained everything-lists is how
+they drift.
 
 **It is not in `all`, because `cword` needs a compiler this tree does not
 contain** (§70.1). A clone with `nasm` and `python3` builds every *shipped*
@@ -81029,7 +81073,7 @@ embedding, ABDOS, the alternate cores, and the three master-disk files above
 ### 74.5 Names, disks, targets
 
 Package `RUNCPM`, directory `apps/runcpm/`, images `build/runcpm.img` /
-`runcpm720.img` / `runcpm360.img` (each `--verify`'d), 86Box machine
+`runcpm720.img` / `runcpm120.img` / `runcpm360.img` (each `--verify`'d), 86Box machine
 `vm/386-runcpm` (a copy of `vm/386-c-word` with the B: image and uuid
 changed), on `apps-all.img` as a folder of its own `RUNCPM\` (§19.10 — the
 CCP, the `.OVL` and drive `A\0` must sit beside the package, below). **Nothing
@@ -81080,9 +81124,19 @@ directory and a disk full to its last cluster, which is how wave 4's 360KB
 build shipped, cannot take a `$$$.SUB`, an MBASIC program or TE's file);
 the 720KB and 1.44MB disks carry the whole master disk **when nothing else
 is on them** — since §74.6 put games and applications beside it they carry
-59 and 70 of the 77, the ranked fill dropping the sources for want of room
-(`apps-all.img`'s `RUNCPM\` folder, which carries no games, still carries
-all 77). **Whatever a
+59 and 70 of the 77, the ranked fill dropping the sources for want of room.
+**The 1.2MB disk is where that trade had to be made explicitly, and it is
+made in §74.6 rather than here** (`getcpmsw.py`'s `POLICY`, not
+`getruncpm.py`'s `CURATED`): it has 2,371 clusters against the 1.44MB disk's
+2,847, all five software areas cost 1,997, and taking all five leaves `A/0`
+136 clusters — at which the ranked fill stops halfway through the `.COM`s at
+`SUBMITD`, with no MBASIC, PIP, STAT, TE, Z80ASM or ZEXDOC. That is precisely
+the alphabetical-fill failure the 360KB curation exists to prevent, reached
+from the other end, so the LARGEST AREA comes off instead of the programs.
+At four areas `A/0` gets 660 clusters and carries **63 of the 77** — every
+`.COM`, both `.DOC`s, four `.LIB`s and four `.Z80` sources, more master-disk
+files than the 1.44MB disk's 59 — at 162 files and 2,246 of 2,371 clusters.
+**Whatever a
 geometry leaves off is named ON THAT DISK:** `--select` writes the
 geometry's own `LEFT-OFF.TXT` (`build/runcpm-disk/left-off/<kb>/`) in place
 of `A/0`'s — the three files above 65,535 bytes, every submit file whose
@@ -81118,9 +81172,12 @@ and libraries filled it to the last cluster and no session could save —
 and wave 2's 24,848-byte package left it 62 files: `--reserve` re-shaped
 the selection by itself each time). **`apps-all.img` (§19.10) carries the
 same package as a folder of its own, `RUNCPM\`** — the package, the
-`.OVL`, the CCP, LICENSE, 1STREAD.ME and `A\0` below it, the 1.44MB
-selection (all 77) chosen at recipe time exactly as `build/runcpm.img`'s
-is — `--reserve` names every file on the disk (`ALLAPPSFILES`, the files
+`.OVL`, the CCP, LICENSE, 1STREAD.ME and `A\0` below it, the geometry's own
+selection chosen at recipe time exactly as `build/runcpm.img`'s is. That
+folder carries no games, so what it holds is whatever the rest of the disk
+leaves: **66 files at 1.44MB and 33 at 1.2MB** (re-measured against the
+current payload; the figure below it was taken when this disk was smaller and
+`A\0` took all 77) — `--reserve` names every file on the disk (`ALLAPPSFILES`, the files
 behind the disk's arguments, not the prerequisite list) and `--folders`
 the folder directories the tree has besides `RUNCPM\A\0`, a cluster each
 — `ALLAPPSFOLDERS`, counted by make from the disk's arguments (every `DIR:`
@@ -81205,6 +81262,22 @@ itself (`getruncpm.py --select --reserve-clusters`, which the Makefile hands
   `apps-all.img`, whose `RUNCPM\` folder carries no games and still holds all
   77. **213 files in 7 folders, 2,722 of 2,847 clusters** — 125 clusters,
   62KB, free to save into (the Disk window says `Free 64K`).
+* **1.2MB**: **four of the five**, and the one that comes off is the
+  LARGEST — `H/3`, WordStar 3.30, 519 clusters. This is the geometry where
+  the pricing order has to be overruled, and the arithmetic is why: 2,371
+  clusters against 1.44MB's 2,847, five areas costing 1,997, so all five
+  leave `A/0` 136 and the ranked fill stops halfway through the `.COM`s at
+  `SUBMITD` — no MBASIC, no PIP, no STAT, no TE, no Z80ASM, no ZEXDOC. A
+  RunCPM disk without its programs is not RunCPM's disk, which is the 360KB
+  bullet's argument arrived at from the opposite end, so an AREA comes off
+  rather than the programs. At four areas the games are 1,473 clusters,
+  `A/0` gets 660 and carries **63 of the 77** — every `.COM`, both `.DOC`s,
+  four `.LIB`s and four `.Z80` sources, which is MORE master disk than the
+  1.44MB disk holds. Turbo Pascal (`D/0`) stays and WordStar goes because
+  the choice is by size; `GAMES.TXT` names it, under the heading that says
+  it is on the 1.44MB disk. **162 files in 6 folders, 2,246 of 2,371
+  clusters** — 125 clusters, 62KB, free to save into, the same headroom the
+  1.44MB disk ships with.
 * **720KB**: the arcade area only, beside 70 files of the master disk (the
   fill drops sources first, by rank). **89 files, 698 of 713 clusters.**
 * **360KB**: **no games** — 297 clusters cannot hold 206KB of arcade *and*
@@ -81221,7 +81294,9 @@ with no SPEC.md. Every game area ships **16 spare directory slots**
 file, LADDER and CATCHUM rewrite a score file, `TERMDEF` writes `TERM.DEF` —
 and the kernel does not grow a directory (§18.5). For the same reason
 `getruncpm.py` now holds **`SAVE_ROOM_KB`** back from `A/0`'s fill (64KB on
-1.44MB, 16KB on 720KB, 0 on 360KB, whose curation is its own guard): the
+1.44MB and on 1.2MB, which carries the same software area on the AT-class
+machine this section's timing note is least worried about; 16KB on 720KB, 0
+on 360KB, whose curation is its own guard): the
 first build with games on it filled the 720KB disk to 713 of 713 clusters,
 which is exactly what §74.5 says a disk must not ship as. **In KB and not in
 clusters**, which is how it was first written — 16 clusters is 16KB on the

--- a/docs/C64-SPEC.md
+++ b/docs/C64-SPEC.md
@@ -3455,7 +3455,7 @@ C64's own RAM (§3.5).
 | shipped files | `C64.O88` (with the ROM as part 0, §1.4), `C64.OVL` |
 | window title | `VICE (C64)` |
 | menu-set `AM_NAME` | `VICE` |
-| images | `build/c64.img` (1.44MB), `build/c64720.img` (720KB), `build/c64360.img` (360KB) |
+| images | `build/c64.img` (1.44MB), `build/c64720.img` (720KB), `build/c64120.img` (1.2MB), `build/c64360.img` (360KB) |
 | tools | `tools/c64rom.py` (builds the ROM the packer appends, §1.4), `tools/c64prg.py` (writes `.PRG` fixtures, §14.4), `tools/c64ref.py` (the reference compositor, §14.5) |
 
 The name is checked against `apps/`, `vm/`, the Makefile and `build/` before
@@ -3463,7 +3463,10 @@ wave 1 (LESSONS 1's rule about two programs sharing an ambition).
 
 ### 14.2 Disks
 
-Three geometries, each `os88disk.py --verify`'d in the recipe. Each carries
+Four geometries, each `os88disk.py --verify`'d in the recipe — the fourth,
+1.2MB 5.25" HD, is SPEC.md §19's and carries exactly what the other three do:
+this disk is ~62KB, so even 360KB holds it whole and no geometry here has ever
+had to choose. Each carries
 **`C64.O88` + `C64.OVL` in one folder**, plus a `README.TXT` naming the licence
 and carrying the ROM copyright line (§1.2, §1.3). The ROM is inside `C64.O88`
 (§1.4), so the byte count is unchanged and the file count is one lower.

--- a/docs/WEAVE-SPEC.md
+++ b/docs/WEAVE-SPEC.md
@@ -4284,7 +4284,7 @@ the demos in `all`.
 package in this tree to declare a file association (which took a `CC_ASSOC`
 path in `apps/cc/crt0.asm`, since no C package had ever needed one), the
 accept idiom, the §10 refusals, the flow walk and the static components —
-plus `make weavedisk` in three geometries and `tests/weavesmoke.py`. A
+plus `make weavedisk` in four geometries and `tests/weavesmoke.py`. A
 wave-1 fix pass preceded it: 21 defects in this document and in `weavesim`,
 of which the load-bearing one was §7.1.1's Hercules grid, wrong at 89×36
 because it had been inherited from the browser's viewport rather than
@@ -4468,8 +4468,10 @@ wave 5 closed at. `loom.o88` is **54,966 + 6,212 = 61,178, 262 under**, with
 
 **The distribution row is `make weavedisk` carrying the whole family** — the
 runtime, its two modules, the three bundles, LOOM and its three, the demo
-sources and a per-geometry `CATALOG.TXT` — in all three geometries, 206 of 354
-clusters at 360KB. Wave 7 shipped it as ONE FLAT FOLDER, and §11.2 records
+sources and a per-geometry `CATALOG.TXT` — in all four geometries (SPEC.md
+§19 added 1.2MB 5.25" HD to the family's three), 206 of 354 clusters at 360KB
+and 567 of 2,371 at 1.2MB, the same payload on each: the family is ~285KB, so
+the smallest geometry is the only one that ever had to be argued. Wave 7 shipped it as ONE FLAT FOLDER, and §11.2 records
 why: the wave built `PROJECTS/` a folder per project first, opened it on the
 machine, and found that SPEC.md §73.14's overlay fence makes a project in a
 subfolder unopenable by both routes. **It ships as TWO folders now** —
@@ -4500,7 +4502,7 @@ The rest, each gated before the next begins:
 | 5 | ~~`<canvas>`/`<sprite>`~~ **SHIPPED**, above — and in `WEAVE.WSM`, a second RESIDENT segment (§1.2.2), which is the decision the wave turns on | `weavecanvas` FIRST (§12.1.3), then `weavegame`; the field run is COMMISSIONED and pending (WEAVE-PLAN §4.2) |
 | 6 | ~~Loom~~ **SHIPPED**, above — except Preview's PICTURE (§1.7.1), which needs the shared paint stack in a segment LOOM has not got | `weavepack` byte-identity on all templates and demos, in the OS |
 | 7 | ~~Preview's picture~~ **SHIPPED**, above — `LOOM.WPV` (§1.2.4), a second RESIDENT segment carrying `wflow.c` and `wpaint.c` themselves, which is the decision the wave turns on | `weaveprev`: the pane against `weavesim --render --preview`, three demo projects, both 1bpp adapters |
-| 7 | ~~distribution~~ **SHIPPED**, above — the family's disk in three geometries with `WEAVE/` and `LOOM/` (§11.2 — first shipped flat, and as two folders since #132), `CATALOG.TXT` and `BUNDLES=`; SPEC.md §19.10's `WEAVE/` and `LOOM/` folders on the everything disk and the live media; the Weave disks in the release zip; and §1.4's 256KB arithmetic corrected against the machine | the release checklist, and `weaveone` |
+| 7 | ~~distribution~~ **SHIPPED**, above — the family's disk in four geometries (1.2MB added with SPEC.md §19's) with `WEAVE/` and `LOOM/` (§11.2 — first shipped flat, and as two folders since #132), `CATALOG.TXT` and `BUNDLES=`; SPEC.md §19.10's `WEAVE/` and `LOOM/` folders on the everything disk and the live media; the Weave disks in the release zip; and §1.4's 256KB arithmetic corrected against the machine | the release checklist, and `weaveone` |
 | 8 | ~~the canvas PALETTE~~ **SHIPPED** — §6.10.7's `paper`/`ink`/`color`, §9.2.1's amendment to the exclusion, PONG in four colours | `weavecanvas` FIRST again (six new cases and a third negative control), then the two packers on the coloured `PONG.WAB` |
 
 Wave order within a wave follows the size line: `os88pkg.py`'s resident

--- a/tools/getcpmsw.py
+++ b/tools/getcpmsw.py
@@ -101,13 +101,28 @@ SPARE_SLOTS = 16
 
 # What each geometry carries (SPEC.md §74.6). A DECISION per geometry, in the
 # shape SPEC.md §74.5's CURATED already has: 1.44MB has room for all three
-# areas beside the whole master disk; the 720KB disk carries the arcade area
+# areas beside the whole master disk; the 1.2MB disk carries FOUR of the five
+# and drops the largest, H/3 (WordStar, 519 clusters), which is a DECISION and
+# not the fill's leftovers - its clusters are 512 bytes like the 1.44MB one's
+# rather than 1,024 like the two DD disks', but it has 2,371 of them against
+# 2,847, and all five areas cost 1,997. Taking all five leaves A/0 136
+# clusters, and the ranked fill then stops halfway through the .COMs at
+# SUBMITD - no MBASIC, no PIP, no STAT, no TE, no Z80ASM, no ZEXDOC. That is
+# the alphabetical-.COM-fill failure the docstring above warns about, arrived
+# at from the other end, and it is why an area comes off rather than the
+# programs: at four areas the games are 1,473 clusters, A/0 gets 660 and the
+# fill reaches past every .COM into the documentation and the first sources -
+# 63 of the 77, which is MORE master disk than the 1.44MB disk holds. Turbo
+# Pascal (D/0) stays and WordStar goes because the choice is by SIZE, and
+# GAMES.TXT names it under the heading that says it is on the 1.44MB disk;
+# the 720KB disk carries the arcade area
 # and pays for it out of the master disk's SOURCES, which is the trade the
 # 360KB disk already makes for room to save; the 360KB disk carries no games
 # at all - 297 clusters cannot hold 206KB of arcade AND the programs, and a
 # disk that dropped the programs for games would not be RunCPM's disk any
 # more. GAMES.TXT says so on the disk itself.
 POLICY = {1440: ["A/5", "N/0", "G/4", "D/0", "H/3"],
+          1200: ["A/5", "N/0", "G/4", "D/0"],
           720: ["A/5"],
           360: []}
 
@@ -792,9 +807,11 @@ def area_cost(sizes, cbytes):
 def select(out, geometry):
     """The areas a geometry carries (POLICY), and what they cost in its own
     clusters. Answers (chosen, dropped, used, sizes)."""
-    cbytes = {360: 1024, 720: 1024, 1440: 512}.get(geometry)
+    cbytes = {360: 1024, 720: 1024, 1200: 512, 1440: 512}.get(geometry)
     if cbytes is None:
-        fail(f"--select wants 360, 720 or 1440, not {geometry}")
+        fail("--select wants one of "
+             + ", ".join(str(g) for g in sorted(POLICY))
+             + f", not {geometry}")
     sizes = {}
     for area, _, _, _, _ in AREAS:
         d = os.path.join(out, *area.split("/"))
@@ -904,7 +921,7 @@ def main():
                     help="verify what is cached; never download")
     ap.add_argument("--list", action="store_true", help="print what is shipped and exit")
     ap.add_argument("--select", type=int, metavar="KB",
-                    help="print the files a 360/720/1440 disk carries, "
+                    help="print the files a 360/720/1200/1440 disk carries, "
                          "'<DRIVE>/<USER>:<path>' a line")
     ap.add_argument("--cost", type=int, metavar="KB",
                     help="print what --select would spend, in that geometry's clusters")

--- a/tools/getruncpm.py
+++ b/tools/getruncpm.py
@@ -6,7 +6,7 @@
     python3 tools/getruncpm.py -o build/runcpm-disk --list     # what is shipped
     python3 tools/getruncpm.py -o build/runcpm-disk --select 360 \
                              --reserve build/runcpm.o88 ...   # the A/0 files
-                             # a 360KB / 720KB / 1440KB disk carries beside
+                             # a 360/720/1200/1440KB disk carries beside
                              # the root files named (--folders N: how many
                              # other folders the disk has; apps-all's ten)
     python3 tools/getruncpm.py -o build/runcpm-disk --from DIR # take the files
@@ -73,9 +73,11 @@ a cluster each; the folder A by default), A/0's own directory (32 bytes an
 entry, counted as files are chosen) and ASSOC.DAT, which is priced by
 os88disk.py's own build_assoc on the packages --reserve names (one cluster
 here, four on apps-all's 22 packages). Measured at the pin: a
-720KB disk and a 1.44MB disk carry all of it; the 360KB one carries every
-.COM, .SUB, .TXT and .ME and nothing else (52 files, 350/354 clusters;
-SPEC.md 74.5).
+720KB and 1.44MB disk carry all of it when nothing else is on them; the 360KB
+one carries every .COM, .SUB, .TXT and .ME and nothing else (52 files, 350/354
+clusters; SPEC.md 74.5). The 1.2MB disk is never in that case - getcpmsw.py's
+POLICY puts four software areas beside it (SPEC.md 74.6), so this fill runs
+against a 1,473-cluster reserve and takes 63 of the 77.
 """
 import argparse
 import hashlib
@@ -108,8 +110,8 @@ MAX_FILE = 65535          # a whole file must fit a 16-bit count (SPEC.md 74.3)
 # alphabetical .COM fill did to the 360KB disk once.
 CATEGORY = [".TXT", ".ME", ".SUB", ".COM", ".DOC", ".LIB", ".Z80", ".ASM"]
 # ...and the 360KB disk stops after the programs (SPEC.md 74.5): the sources,
-# libraries and documentation stay on the 720KB/1.44MB disks, so the XT disk
-# ships with room to save into instead of full to the last cluster (which is
+# libraries and documentation stay on the 720KB/1.2MB/1.44MB disks, so the XT
+# disk ships with room to save into instead of full to the last cluster (which is
 # how the wave-4 build shipped - and no session could save on it)
 # The 1.44MB disk needs no rule of its own once it carries games (SPEC.md
 # 71.6): the games are priced first (--reserve-clusters) and this RANKED fill
@@ -120,19 +122,23 @@ CATEGORY = [".TXT", ".ME", ".SUB", ".COM", ".DOC", ".LIB", ".Z80", ".ASM"]
 # whose RUNCPM folder carries no games and has room for all 77.
 CURATED = {360: CATEGORY[:4]}
 # a geometry's cluster size and its DATA clusters (tools/os88disk.py's
-# layouts: 354 / 713 / 2,847). What A/0 may take is that minus the root files
+# layouts: 354 / 713 / 2,371 / 2,847 - and note that the 1.2MB disk's clusters
+# are 512 bytes like the 1.44MB one's, not 1,024 like the two DD disks', so it
+# holds 1,185KB of the 1,423KB the 1.44MB disk does rather than the 83% of its
+# raw size). What A/0 may take is that minus the root files
 # --reserve names, priced in these clusters, minus the directory arithmetic
 # os88disk.py does (below) - derived from the files, so a bigger package or
 # an .OVL beside it re-selects the disk instead of overflowing it. Checked
 # against the built images: the arithmetic below reproduces --verify's
 # 'in use' exactly (353 / 672 / 1,294 with the 24,848-byte package)
-GEOMETRY = {360: (1024, 354), 720: (1024, 713), 1440: (512, 2847)}
+GEOMETRY = {360: (1024, 354), 720: (1024, 713), 1200: (512, 2371),
+            1440: (512, 2847)}
 DIR_ENTRY = 32            # a FAT directory entry
 # ROOM TO SAVE IN KB, held back from A/0's fill (SPEC.md 71.5): a disk full to its
 # last cluster cannot take a $$$.SUB, an MBASIC program or TE's file, which is
 # how wave 4's 360KB disk shipped. The 360KB disk's own CURATION is its guard
 # - it stops after the programs and never reaches the budget - so it needs no
-# reserve; the 720KB and 1.44MB disks fill until the budget stops them, and
+# reserve; the 720KB, 1.2MB and 1.44MB disks fill until the budget stops them, and
 # once the games are priced beside them (SPEC.md 71.6) that is exactly what
 # the 720KB one did: 713 of 713 clusters, no room for a single save. The fill
 # is RANKED, so what this holds back is the last thing chosen - a source or a
@@ -141,8 +147,10 @@ DIR_ENTRY = 32            # a FAT directory entry
 # 8KB on the 1.44MB one, whose clusters are 512 bytes - the geometry with the
 # most room got the least. The 1.44MB disk holds back 64KB because it is the
 # one a session actually works on (SPEC.md 71.6: WordStar and Turbo Pascal
-# are on it, and both write files).
-SAVE_ROOM_KB = {360: 0, 720: 16, 1440: 64}
+# are on it, and both write files) - and the 1.2MB disk holds back the same
+# 64KB for the same reason: it carries the same software area, on the AT-class
+# machine 74.6's timing note is least worried about.
+SAVE_ROOM_KB = {360: 0, 720: 16, 1200: 64, 1440: 64}
 # ASSOC.DAT, the icon/association cache os88disk.py writes in the root beside
 # the packages (SPEC.md 54.7), is priced by asking os88disk.py itself
 # (assoc_clusters below): one cluster on the RUNCPM disks, whose only package
@@ -302,7 +310,7 @@ def left_off_text(out, kept, left, geometry=None, by_policy=(), no_room=()):
         text += (f"\r\nThis is the {geometry}KB disk: it carries the programs and\r\n"
                  "the texts and leaves room to save. The rest of the master\r\n"
                  "disk - sources, libraries, documentation and the ABDOS\r\n"
-                 "images - is on the 720KB and 1.44MB disks:\r\n")
+                 "images - is on the 720KB, 1.2MB and 1.44MB disks:\r\n")
         for base, size in by_policy:
             text += f"  {base:<12} {size:>7} bytes\r\n"
     if no_room:
@@ -364,7 +372,9 @@ def select(out, geometry, reserve, slots=0, folders=1, reserve_clusters=0):
     OWN - written to <out>/left-off/<KB>/LEFT-OFF.TXT, naming what this
     disk leaves off - and is priced at its real size."""
     if geometry not in GEOMETRY:
-        fail(f"--select wants 360, 720 or 1440, not {geometry}")
+        fail("--select wants one of "
+             + ", ".join(str(g) for g in sorted(GEOMETRY))
+             + f", not {geometry}")
     cbytes, total = GEOMETRY[geometry]
     rows = read_list(out)
     kept = [(b, s) for b, s in rows if b != "LEFT-OFF.TXT"]
@@ -435,7 +445,8 @@ def main():
                     help="verify what is cached; never download")
     ap.add_argument("--list", action="store_true", help="print what is shipped and exit")
     ap.add_argument("--select", type=int, metavar="KB",
-                    help="print the A/0 files a 360/720/1440 disk carries, one path per line")
+                    help="print the A/0 files a 360/720/1200/1440 disk carries, "
+                         "one path per line")
     ap.add_argument("--reserve", nargs="*", default=[], metavar="FILE",
                     help="with --select: the root files that ride beside A/0, priced first")
     ap.add_argument("--dir-slots", type=int, default=0, metavar="N",

--- a/tools/os88disk.py
+++ b/tools/os88disk.py
@@ -367,8 +367,17 @@ def build_assoc(groups):
     # survives inside each half and a rebuild is byte-identical
     cand.sort(key=lambda c: c[0])
     if len(cand) > ASC_NAPP:
+        # ON STDERR, and that is not a style choice. assoc_clusters() is
+        # IMPORTED by tools/getruncpm.py to price the cache, and getruncpm's
+        # --select output is read by a `sel="$(...)"` shell substitution in
+        # the Makefile - so a note on stdout becomes a FILE NAME in the
+        # argument list. It arrives as `'OS88DISK:' is not a valid 8.3 name`,
+        # from the disk builder, about a disk that is fine. It went unseen
+        # while the everything disk had 32 packages or fewer, and fired the
+        # day AUDIO.O88 made it 33.
         print(f"os88disk: assoc: {len(cand)} packages, caching "
-              f"{ASC_NAPP} - {len(cand) - ASC_NAPP} harvested the slow way")
+              f"{ASC_NAPP} - {len(cand) - ASC_NAPP} harvested the slow way",
+              file=sys.stderr)
         cand = cand[:ASC_NAPP]
     apps, rowdirs = [], []
     for _, stem, size, icon, decl, key in cand:

--- a/tools/weavesim.py
+++ b/tools/weavesim.py
@@ -6634,10 +6634,10 @@ def catalog_text(geometry, loom):
     else:
         o.append("THE EDITOR IS NOT ON THIS DISK")
         o.append("-" * 28)
-        o.append("  LOOM and the demo sources are on the 720KB and 1.44MB")
-        o.append("  builds of this disk; this geometry has no room for them.")
-        o.append("  `make loomdisk` builds a disk of the editor's own in all")
-        o.append("  three sizes.")
+        o.append("  LOOM and the demo sources are on the 720KB, 1.2MB and")
+        o.append("  1.44MB builds of this disk; this geometry has no room")
+        o.append("  for them. `make loomdisk` builds a disk of the editor's")
+        o.append("  own in all four sizes.")
         o.append("")
     o.append("YOUR OWN BUNDLES")
     o.append("-" * 28)
@@ -6695,7 +6695,7 @@ def main():
                     help="write the Weave disk's CATALOG.TXT (CRLF) and exit; "
                          "needs --geometry, and --with-loom when the IDE "
                          "rides that geometry")
-    ap.add_argument("--geometry", type=int, choices=(360, 720, 1440),
+    ap.add_argument("--geometry", type=int, choices=(360, 720, 1200, 1440),
                     help="which disk --catalog is describing")
     ap.add_argument("--with-loom", action="store_true",
                     help="--catalog: this geometry carries LOOM and PROJECTS")
@@ -6741,7 +6741,7 @@ def main():
     try:
         if args.catalog:
             if not args.geometry:
-                raise SystemExit("--catalog needs --geometry 360|720|1440")
+                raise SystemExit("--catalog needs --geometry 360|720|1200|1440")
             write_catalog(args.catalog, args.geometry, args.with_loom)
             return 0
         if args.selfcheck:

--- a/vm/286-525-all/86box.cfg
+++ b/vm/286-525-all/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 965eb07e-503a-5d25-8053-d02b0096dd51
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/apps-all-120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-c64/86box.cfg
+++ b/vm/286-525-c64/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = dd48d9b4-3aed-5494-b33e-27da89055d8b
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/c64120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-cword/86box.cfg
+++ b/vm/286-525-cword/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 269b2760-0a53-5196-a58a-a58c623ad6e3
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/cword120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-loom/86box.cfg
+++ b/vm/286-525-loom/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 2fdf4956-f734-51e9-b0b5-4289ef2fca76
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/loom120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-runcpm/86box.cfg
+++ b/vm/286-525-runcpm/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 545c3839-1a45-520a-af9a-d9b5a1c2d1b7
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/runcpm120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-weave/86box.cfg
+++ b/vm/286-525-weave/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 4b2c53d4-0baf-5e85-8aba-0ec72d1e27e8
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/weave120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-word/86box.cfg
+++ b/vm/286-525-word/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = cde80442-c791-55fe-97f8-8fc463a3a790
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/word120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1

--- a/vm/286-525-z/86box.cfg
+++ b/vm/286-525-z/86box.cfg
@@ -1,0 +1,34 @@
+[General]
+confirm_exit = 0
+confirm_reset = 0
+confirm_save = 0
+emu_build_num = 9001
+host_cpu = machdep.cpu.brand_string: Apple M1
+scale = 2
+uuid = 65d0e5c0-8969-535e-b658-5d4546ab9d63
+vid_renderer = qt_opengl3
+video_fullscreen_scale = 0
+
+[Machine]
+cpu_family = 286
+cpu_multi = 1
+cpu_speed = 12500000
+cpu_use_dynarec = 0
+machine = ami286
+mem_size = 1024
+pit_mode = 0
+
+[Video]
+gfxcard = oti067
+video_fullscreen_scale_maximized = 1
+
+[Input devices]
+keyboard_type = keyboard_at
+mouse_type = msserial
+
+[Floppy and CD-ROM drives]
+fdd_01_fn = ../../build/os8088-120.img
+fdd_01_type = 525_2hd
+fdd_02_fn = ../../build/zork120.img
+fdd_02_type = 525_2hd
+fdd_host_buffering = 1


### PR DESCRIPTION
SPEC.md §19 gave the **system and apps** disks a fourth geometry. The on-demand **application** floppies kept three, on the argument — recorded in three places in the Makefile — that an AT-class machine reads the 360KB disk in the same drive. That is true, and it spends §19's own argument twice: it costs the user the 1.2MB disk's other 831KB, and it means writing DD media in an HD drive, the one media/drive combination this project records as marginal.

So `zdisk`, `worddisk`, `cworddisk`, `runcpmdisk`, `c64disk`, `weavedisk`, `loomdisk` and `allapps` each build a 1.2MB image beside the others.

## What each disk holds

1.2MB has **512-byte clusters** like the 1.44MB disk rather than 1,024 like the two DD disks, so it holds 2,371 of them — 1,185KB against 1,423KB. That ratio, not the raw one, is what each disk is measured against.

| disk | payload | clusters |
|---|---|---|
| `word120.img` | 1.44MB list verbatim | 105 / 2,371 |
| `cword120.img` | 1.44MB list verbatim | 115 |
| `c64120.img` | 1.44MB list verbatim | 171 |
| `weave120.img` | 1.44MB list verbatim (+ its own `CATALOG.TXT`) | 567 |
| `loom120.img` | 1.44MB list verbatim | 562 |
| `zork120.img` | **cut** — 9 of 11 stories | 2,139 |
| `runcpm120.img` | **cut** — 4 of 5 CP/M areas, 63 of 77 master-disk files | 2,246 |
| `apps-all-120.img` | full payload, RunCPM drive A re-priced | 2,244 |

Three needed a decision rather than a bigger `--size`:

- **`zork120`** — the 1.44MB story list alone is 2,519 clusters, over before `FROTZ.O88` is priced. `ADVENT5.Z5` (the v5 re-release of an `ADVENT.Z3` that stays) and `905.Z5` come off, so no *title* is lost and every folder keeps more than one story.
- **`runcpm120`** — all five CP/M software areas cost 1,997 clusters and "fit", leaving `A/0` 136 — at which the ranked fill stops halfway through the `.COM`s at `SUBMITD`: no MBASIC, PIP, STAT, TE, Z80ASM or ZEXDOC. That is the alphabetical-fill failure the 360KB curation exists to prevent, reached from the other end, so an **area** comes off rather than the programs. Dropping the largest (`H/3`, WordStar) gives `A/0` 660 clusters and 63 of 77 files — **more master disk than the 1.44MB disk holds**.
- **`apps-all-120`** — RunCPM's drive A re-prices itself per geometry, so the two everything-disks share one payload list and differ only in a `--size`. No second hand-maintained everything-list to drift.

**No 1.2MB media disk, and that is not an omission.** `media360.img` exists only because `BEVERLY.MOD` is 114 of a 360KB volume's 354 clusters — a split made at that geometry alone. `apps120.img` is built from the full apps list and already carries it in `MEDIA/`.

## 86Box

Eight machines, `vm/286-525-<app>`, each `vm/286-525` with `fdd_02_fn` and the uuid changed and nothing else — the tree's own copy rule, for its stated reason (86Box silently substitutes an unrecognised `cpu_family` and rewrites the config on the way out).

**One machine class rather than the three RUNCPM and the C64 have**, and that is the geometry's doing: a 1.2MB drive wants the AT's 500 kbps controller, so no XT profile can host one, and every other AT-class profile here is fitted with 3.5" drives. `-loom` and `-all` are the first machines their disks have had at any geometry.

## Two bugs found on the way

- **`make allapps` was broken on `main`.** `os88disk.py`'s "N packages, caching 32" note printed to **stdout**, and `getruncpm.py` imports that function while its own stdout is read by a `sel="$(…)"` substitution in the Makefile — so the note became a filename and the build died with `'OS88DISK:' is not a valid 8.3 name`, from the disk builder, about a disk that was fine. Unseen while the everything disk had 32 packages or fewer; fired the day `AUDIO.O88` made it 33. On stderr now, with the reason at the call site.
- **The release zip carried no 1.2MB images at all** — not even the shipped system pair — and **no `loom` disk at any geometry**. Both are in `mkzip.py`'s manifest now (35 images, up from 22), and `make loomdisk` is in the skill's build steps.

## Verification

- `make test-full`: **56 passed, 0 failed**, 517s of a 600s budget, run after the commit.
- All nine images `make` builds are **byte-identical to `main`** — hashed against a pristine build of the stashed tree.
- **On the glass, QEMU**: booted with `weave120.img` in B: — mounts, shows the 1200-geometry `CATALOG.TXT`, both folders, `Free 902K` (2,371 − 567 clusters × 512B), and `WEAVE/` whole with icons resolved.
- **On the glass, 86Box**: `make 286-525-weave` reaches the desktop with both drives on the AMI 286 with two 5.25" HD drives.
- `mkzip.py` packs all 35 images.

Docs: SPEC.md §19 / §19.10 / §74.5 / §74.6, C64-SPEC §14.1–14.2, WEAVE-SPEC §13.1, README, CLAUDE.md — including the three stale "these did not gain 1.2MB" blocks and CLAUDE.md's "Seven images, not six", which was already wrong at nine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBw7W9b28rhYH15Ww9aqmn
