### PR TITLE
Release zip README: the C64 ROMs are inside C64.O88, not beside it

### DIFF
--- a/.claude/skills/release-os8088/mkzip.py
+++ b/.claude/skills/release-os8088/mkzip.py
@@ -90,8 +90,8 @@ MANIFEST = [
                               "CP/M's own disk than the 1.44MB one holds."),
     ("runcpm360.img",  False, "CP/M emulator disk, 360KB. Carries the emulator and no "
                               "programs -- there is no room for them at this size."),
-    ("c64.img",        False, "Commodore 64 disk, 1.44MB. Carries the emulator, the three "
-                              "Commodore ROM images it reads at launch, and COPYING."),
+    ("c64.img",        False, "Commodore 64 disk, 1.44MB. Carries the emulator, with the three "
+                              "Commodore ROM images inside it, and COPYING."),
     ("c64720.img",     False, "Commodore 64 disk, 720KB."),
     ("c64120.img",     False, "Commodore 64 disk, 1.2MB."),
     ("c64360.img",     False, "Commodore 64 disk, 360KB."),


### PR DESCRIPTION
One line in `mkzip.py`'s manifest. The zip's README described `c64.img` as carrying "the three Commodore ROM images it reads at launch", which was true until #147 moved them inside `C64.O88` as part 0. The disk's `C64/` folder now holds `C64.O88`, `C64.OVL`, `README.TXT` and `COPYING`, and the line says so.

Found while reading the README for v1.0.20260904, which was packed with this wording. No image changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbpzZ78QpTUuzhmEbE7WcM