### PR TITLE
Pac-Man: full screen is a 53 bracket, and on VGA and CGA it changes the mode

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -92569,5 +92569,138 @@ VGA and Hercules use 320 by 176 pixels, CGA 320 by 88 (every other source row,
 with a doubled source stride). Frame preferences are 338 by 222, 338 by 222,
 and 338 by 140 respectively; content geometry determines which layout fits.
 The board is centered in the current content, including full screen. All
-self-initiated drawing arms the window clip. The status strip uses opaque
-FONT_RUN and changes only when its values change.
+self-initiated drawing arms the window clip. The status strip uses opaque text
+and each of its four fields changes only when its own value does (89.3.3).
+
+### 89.3 Full screen is a 53 bracket, and on VGA and CGA it changes the mode
+
+**F takes the machine, not just the screen.** The 11.2 surface it used to take
+is still taken first — the window loses its chrome and fronts, exactly as
+11.2.1 binds — and then `OSAPI_FSX_RUN` (53.1) runs `pm_fsx_main` with every
+other task frozen and the graphics lock held for the whole session. F and Esc
+leave it, which is the same binding seen from inside. **The bracket is an
+optimisation and not the feature**: `OSAPI_FSX_RUN` answering CF=1 leaves the
+game on the 11.2 surface with its worker, which is what it had before.
+
+Which mode is `OSAPI_FSX_CAPS` asked **about this window's display** (39.18.2),
+at the moment F is pressed rather than at launch, and the lowest resolution
+offered wins:
+
+| adapter | mode | board | why |
+|---|---|---|---|
+| VGA | `FSXM_VGA13` — 320x200x256 | 320x176, sixteen colours | a pixel is a byte, so a band is a copy |
+| EGA | `FSXM_CGA320` — 320x200x4 | 320x176, four colours | 53.4 offers the EGA the CGA-compatible modes only |
+| CGA | `FSXM_CGA320` | 320x176, four colours | **full height in colour**, where the desktop's 640x200x1bpp gets 320x88 monochrome |
+| Hercules | same-mode (no `fsx_mode`) | 320x176, as before | nothing below 720x348 exists on that card; what the bracket buys is exclusivity |
+
+The board sits at y = 16 in either 320x200 mode, the score/lives/level row at
+y = 4 and the message row at y = 192 — 200 rows exactly. Nothing above the
+band blitters changes: the map, the 4bpp canvas, the dirty bands, the tile
+composer and the sprite composer are one body on every path, and a render
+target byte picks the twelve instructions that put a band on the glass.
+
+**A mode-setting bracket takes NO 11.2 surface** (42.7's measured reason, and
+here it is seconds): that surface's own `W_PAINT` is a whole board through
+`OSAPI_GFX_BLIT4` — 56,320 pixels, ~2.8 s on a 4.77MHz 8088 — and the mode set
+two calls later throws every one of them away. The same-mode bracket does take
+it, because it draws through the window's own geometry and 53.7.1 is then
+answered by the window record rather than by `fsx_surf`. A refused
+`OSAPI_FSX_RUN` falls back to the 11.2 surface either way.
+
+**Measured on a cycle-accurate 4.77MHz 8088**, the board held in play so a
+death hold cannot flatter the count (`tests/pacman.py` asserts the last
+column, which is the whole point of the bracket):
+
+| adapter | windowed, before | windowed, now | full screen |
+|---|---|---|---|
+| VGA | 4.73 fps | 4.77 fps | **18.20** — the tick rate |
+| CGA | 18.20 fps | 18.20 fps | **18.20**, and the board is now full height in colour |
+| Hercules | 10.47 fps | 14.07 fps | **18.20** — the tick rate |
+
+The windowed VGA column is the honest one: 89.3.4 is why it does not move.
+
+#### 89.3.1 The two foreign backends
+
+**Mode 13h is `mov ah, al`.** A canvas byte is two identical 4bpp pixels (89.2)
+and a mode 13h byte is one pixel, so a band converts with no transpose, no run
+scan and no clip test — provided the byte is already the palette index it
+means. It is: `pm_pal13` writes the desktop's sixteen colours into DAC entries
+`0x11 * c`, which is exactly what a doubled nibble holds. 53.7 hands the DAC to
+the app inside a foreign mode and the exit mode set puts it back.
+
+**CGA mode 4 is two lookups and an OR.** Two canvas bytes are four screen
+pixels in one byte; `pm_c4hi`/`pm_c4lo` are built at entry from `pm_c4`'s
+sixteen-entry colour map and hold each byte's contribution already shifted into
+place. Rows alternate the card's two banks (`FSI_BANKS` = 2), so a row adds
+`FSI_BSTEP` or `FSI_STRIDE - FSI_BSTEP` rather than a stride. `pm_palc4` puts
+3D9h on palette 1 at high intensity — black, cyan, magenta, white — because the
+BIOS mode set leaves it on green/red/yellow, which is not a maze. Walls are
+cyan, dots and the player white, the ghosts magenta; a frightened ghost is
+white, which is the flash it already has.
+
+#### 89.3.2 Letters without a drawing slot
+
+After the first `fsx_mode` every drawing slot is off limits (53.7) — including
+`OSAPI_FONT_RUN`, which renders desktop geometry. What stays legal is
+`OSAPI_FONT_GLYPHS`, the bitmaps themselves, and that is the whole reason that
+slot exists. `pm_fstext` letters opaque 8x8 cells from them, so the strip is
+the same typeface it is on the desktop, through a per-target cell writer:
+four bytes a nibble in mode 13h, one 2bpp byte a nibble on the CGA.
+
+#### 89.3.3 The status strip is four fields, and the score is its digits
+
+One dirty bit over four fields meant eating a dot lettered all 74 cells. At
+~0.9 ms a cell on a 4.77MHz 8088 that is ~67 ms — more than a whole frame's
+budget — for two digits that moved. Each field now carries its own bit
+(`PM_SD_SCORE`/`LIVES`/`LEVEL`/`MSG`), and the score, the one that changes
+every few frames, is drawn from the first digit that actually differs against
+a kept copy of the previous text. A full paint clears that copy, because the
+screen it agreed with is gone.
+
+#### 89.3.4 Why the windowed VGA path is what it is
+
+Measured on a cycle-accurate 4.77MHz 8088 with a VGA, windowed: **4.7 frames
+a second against the 18.2 the worker asks for, and 81% of the frame is
+`OSAPI_GFX_BLIT4`** — nine bands, 3,648 dirty pixels, 180 ms of a 222 ms
+frame. That primitive is priced per **colour change**, not per pixel (5.4.1):
+this art runs ~6.6 runs a row and a run is ~1,800 clocks, which is ~235 clocks
+a pixel.
+
+Two package-side attempts on that number were measured and **both lost**, and
+they are written down so they are not tried again:
+
+- **Widening a band to reach 5.4.1.3's planar row decoder**, whose 64-pixel
+  floor Pac-Man's 24-to-88-pixel bands fall under. Widening to 64 gave 3.67 fps
+  and to 128 gave 2.50, because the extra pixels are extra runs and the row
+  keeps the run path either way.
+- **Lowering that floor in the kernel** to 16 with the `W/32` threshold floored
+  at one run. The blits went from 180 ms to 222 ms: the decoder's per-row fixed
+  cost is real and 64 is where it stops mattering. The gate stands.
+
+What would fix it is `gfx_blitp` (5.4.3) — a canvas held as four planes, where
+a repaint is a copy — and it is **refused for this package**, not overlooked: a
+package that arms its own clip region through `OSAPI_WM_CLIP_SET` meets a
+region that is binding rather than advisory (5.4.3.3), and a worker painting
+under a window that is not the one it thinks it is under has to. Pac-Man's
+worker arms one on every self-initiated frame (89.2). So the windowed VGA
+picture on a 4.77MHz machine stays what it is, and **F is the answer**: the
+same board in mode 13h is a copy per band.
+
+#### 89.3.5 What the composition work bought, on every path
+
+Four changes below the blit, and they cost no picture:
+
+- **The band's two bases come out of a 22-entry table** (`pm_bandmap`,
+  `pm_bandcv`) rather than a 16-bit `MUL` per **tile**. An 8088 charges ~124
+  clocks for one and the tile loop ran two. The blit loop's own per-band `MUL`
+  goes the same way.
+- **The tile's row loop is unrolled**, eight rows of four bytes with no counter.
+- **The sprite row is unrolled**, so it no longer spends `loop`'s 17 clocks
+  eight times a row, five actors and a fruit a frame.
+- **The strip is four fields** (89.3.3), which is the largest of them whenever
+  a dot is eaten.
+
+Measured on the same frame: tile composition **22.7 ms → 12.1**, sprite
+composition **6.6 → 4.8**. That is ~3% of a windowed VGA frame, where the blit
+is 81% of it — and **34% of a Hercules one** (10.47 → 14.07 fps), where the
+blit is cheap and this was most of what was left.

--- a/apps/pacman/README.md
+++ b/apps/pacman/README.md
@@ -6,7 +6,10 @@ the software disk, or install Pac-Man from The Wire.
 
 - Arrow keys or WASD steer; turns are buffered until a legal junction.
 - P or Space pauses. N starts a new game.
-- F enters or leaves full screen; Esc leaves it.
+- F enters or leaves full screen; Esc leaves it. Full screen takes the machine
+  (SPEC.md 53) and, where the card has one, drops to a lower-resolution mode:
+  320x200x256 on a VGA, 320x200x4 on a CGA or EGA. A Hercules has nothing
+  below its own 720x348 and keeps the picture it had.
 - The system About menu shows the credits. Dismiss with a click or key,
   then press P to resume. Switching to another window suspends play.
 
@@ -23,13 +26,29 @@ alternating corner/chase phases with distance-based fleeing. The original
 scripted opening and patrol routes, attract screens, two-player swapping,
 difficulty selector and intermission cartoons are not implemented.
 
-VGA and Hercules display a 320 by 176 board. CGA uses a 320 by 88 board,
-sampling alternate source rows. All layouts retain the same maze and game
-coordinates. Dirty tile bands are composed in RAM and blitted once, so
-moving sprites do not erase directly on the display. Monochrome displays
-use packed 1-bit bands; color displays use packed 4bpp bands. Each instance owns its
-state and one 256-byte-stack worker; no kernel changes or extra heap claims
-are required. The packed canvas accounts for 28,160 bytes of the BSS.
+In a window, VGA and Hercules display a 320 by 176 board and CGA a 320 by 88
+one, sampling alternate source rows. In full screen every adapter gets the
+whole 320 by 176 board, the CGA in four colours. All layouts retain the same
+maze and game coordinates. Dirty tile bands are composed in RAM and blitted
+once, so moving sprites do not erase directly on the display. Monochrome
+displays use packed 1-bit bands; color displays use packed 4bpp bands; the two
+full-screen modes take the canvas byte for byte, which is why they are fast.
+Each instance owns its state and one 256-byte-stack worker; no kernel changes
+or extra heap claims are required. The packed canvas accounts for 28,160 bytes
+of the BSS.
+
+Frames a second on a cycle-accurate 4.77 MHz 8088, the board held in play:
+
+| adapter | in a window | full screen |
+|---|---|---|
+| VGA | 4.8 | **18.2** — the tick rate |
+| CGA | 18.2 | 18.2, and the board is full height in colour |
+| Hercules | 14.1 | **18.2** |
+
+A windowed VGA frame is 81% one call, `OSAPI_GFX_BLIT4`, which is priced per
+colour change and a maze is nothing else; SPEC.md 89.3.4 records the two
+attempts on that number that were measured and lost. Full screen is the
+answer, and it is what the F key does.
 
 Build with `make build/pacman.o88`, or `make` for every software floppy.
 The port's contract is [SPEC.md §89](../../SPEC.md#89-pac-man-appspacmanpacmanasm).

--- a/apps/pacman/pacman.asm
+++ b/apps/pacman/pacman.asm
@@ -23,6 +23,32 @@ PM_LEVEL equ 3
 PM_OVER equ 4
 ; Actors 0..3 ghosts, 4 player. Positions are Atari HPOS / VPOS.
 
+; Render targets (89.3). PM_TGT_WIN is every kernel drawing slot - the window,
+; the 11.2 surface and a SAME-MODE 53 bracket alike; the other two are the
+; foreign framebuffers a bracket sets, which this package writes itself.
+PM_TGT_WIN equ 0
+PM_TGT_V13 equ 1                 ; FSXM_VGA13:  320x200x256, chunky, A000
+PM_TGT_C4  equ 2                 ; FSXM_CGA320: 320x200x4, two banks, B800
+PM_FS_TOP  equ 16                ; board top in either 320x200 foreign mode
+PM_FS_MSG  equ 192               ; ...and the message row under it
+
+; The status strip is four independent fields, so eating a dot letters the
+; score and not the other 58 cells (89.3.3).
+PM_SD_SCORE equ 1
+PM_SD_LIVES equ 2
+PM_SD_LEVEL equ 4
+PM_SD_MSG   equ 8
+PM_SD_ALL   equ 15
+
+; One sprite pixel. Unrolled by its caller so the row costs no `loop`.
+%macro PM_SPX 0
+    shl al, 1
+    jnc %%s
+    mov [di], dl
+%%s:
+    inc di
+%endmacro
+
 pm_entry:
     call OSAPI_VIDEO
     cmp bx, 250
@@ -116,7 +142,7 @@ pm_reset_actors:
     mov byte [pm_chase], 0
     mov byte [pm_mode], PM_READY
     mov word [pm_hold], 36
-    mov byte [pm_status_dirty], 1
+    mov byte [pm_status_dirty], PM_SD_ALL
     ret
 
 ; Public callbacks preserve the dispatcher registers. Internal routines use
@@ -199,24 +225,268 @@ pm_key_body:
     jmp pm_paint
 .pause:
     xor byte [pm_pause], 1
-    mov byte [pm_status_dirty], 1
+    or byte [pm_status_dirty], PM_SD_MSG
     jmp pm_redraw
 .fs:
-    mov al, [pm_fs]
-    xor al, 1
-    jmp short .fullscreen
+    cmp byte [pm_fs], 0
+    jne .exitfs                  ; F leaves fullscreen as well as entering it,
+    call pm_fs_enter             ; and Esc is the escape hatch (SPEC.md 11.2.1)
+    ret
 .exitfs:
+    cmp byte [pm_fs], 0
+    je .out
     xor al, al
-.fullscreen:
     mov bx, [pm_win]
-    push ax
     call OSAPI_FULLSCREEN
-    pop ax
     jc .out
-    mov [pm_fs], al
+    mov byte [pm_fs], 0
     call pm_paint
 .out:
     ret
+
+; ---------------------------------------------------------------------------
+; pm_fs_enter - the 11.2 surface, and then the machine (SPEC.md 53)
+; in:  gfx lock held (key or menu context); preserves all registers
+;
+; Missile Command's shape (SPEC.md 48), with one difference that is the whole
+; point of it here: this bracket SETS A MODE where Missile's F does not. A
+; 4.77MHz 8088 cannot letter this board through OSAPI_GFX_BLIT4 at 18.2 Hz -
+; the desktop's 4bpp blit is priced per colour change and the maze is nothing
+; but colour changes - so fullscreen drops to a mode whose pixels are BYTES
+; and the band becomes a copy (89.3). The bracket is an optimisation and not
+; the feature: a refusal leaves the game on the 11.2 surface it already has.
+; ---------------------------------------------------------------------------
+pm_fs_enter:
+    push ax
+    push bx
+    push cx
+    call pm_pick_mode
+    cmp byte [pm_fsxm], 0FFh
+    jne .bracket                 ; A MODE-SETTING BRACKET TAKES NO 11.2 SURFACE
+                                 ; (SPEC.md 42.7's measured reason). That
+                                 ; surface's own W_PAINT is a whole board
+                                 ; through OSAPI_GFX_BLIT4 - 56,320 pixels,
+                                 ; ~2.8 s on a 4.77MHz 8088 - and every one of
+                                 ; them is thrown away by the mode set two
+                                 ; calls later. The same-mode bracket below
+                                 ; does want it: it draws through the window's
+                                 ; own geometry and there is nothing else for
+                                 ; the window to be.
+    mov al, 1
+    mov bx, [pm_win]
+    call OSAPI_FULLSCREEN        ; fronts and repaints us, so the layout
+    jc .out                      ; re-derives itself; no second paint here
+    mov byte [pm_fs], 1
+.bracket:
+    mov ax, pm_fsx_main
+    mov bx, [pm_win]
+    xor cx, cx                   ; no KEEPWORKER: the worker freezes and the
+    call OSAPI_FSX_RUN           ; bracket's own loop replaces it
+    jnc .left
+    cmp byte [pm_fs], 0
+    jne .out                     ; refused with the 11.2 surface already up:
+                                 ; stay on it, which is what F did before
+    mov al, 1                    ; refused before we had any surface: give the
+    mov bx, [pm_win]             ; user the one the bracket was an optimisation
+    call OSAPI_FULLSCREEN        ; over
+    jc .out
+    mov byte [pm_fs], 1
+    jmp short .out
+.left:
+    cmp byte [pm_fs], 0
+    je .out                      ; we never took a surface: 53.6 has already
+    mov byte [pm_fs], 0          ; repainted the desktop whole
+    xor al, al
+    mov bx, [pm_win]
+    call OSAPI_FULLSCREEN
+.out:
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; ---------------------------------------------------------------------------
+; pm_pick_mode - the lowest-resolution mode this display will give us
+; out: [pm_fsxm] = an FSXM_* id, or 0FFh for a same-mode bracket
+;
+; ASKED ABOUT OUR WINDOW'S DISPLAY, not the primary (SPEC.md 39.18.2): on a
+; two-monitor desktop the answer differs per card and the window moves. A
+; Hercules offers nothing below its own 720x348, so it takes the same-mode
+; bracket and keeps the picture it had - what it gains there is exclusivity.
+; ---------------------------------------------------------------------------
+pm_pick_mode:
+    push ax
+    push bx
+    push dx
+    mov byte [pm_fsxm], 0FFh
+    mov bx, [pm_win]
+    call OSAPI_FSX_CAPS
+    test ax, 1 << FSXM_VGA13
+    jz .cga
+    mov byte [pm_fsxm], FSXM_VGA13
+    jmp short .out
+.cga:
+    test ax, 1 << FSXM_CGA320
+    jz .out
+    mov byte [pm_fsxm], FSXM_CGA320
+.out:
+    pop dx
+    pop bx
+    pop ax
+    ret
+
+; ---------------------------------------------------------------------------
+; pm_fsx_main - the exclusive main (SPEC.md 53.1)
+; in:  SI = our window, ES = KERNEL_SEG, DS = CS = ours, the gfx lock held for
+;      the whole session and every other task frozen
+; out: a near ret leaves the bracket; the kernel restores the desktop
+;
+; The worker's loop rewritten for a machine we own: no lock to take and give
+; back, no clip region to arm, no events - keys are polled through int 16h,
+; which is legal because this IS the UI task - and one frame per tick, the
+; worker's own pace. After OSAPI_FSX_MODE every drawing slot is off limits
+; (SPEC.md 53.7), so from there on the band blitters and the letterer below
+; are the only things that write a pixel.
+; ---------------------------------------------------------------------------
+pm_fsx_main:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    push es
+    call OSAPI_FONT_GLYPHS       ; DX:SI = the kernel's 8x8 bitmaps, AL/AH the
+    mov [pm_gtab], si            ; range they cover: how an app letters a
+    mov [pm_gseg], dx            ; foreign mode without a second typeface
+    mov [pm_gfirst], al
+    mov [pm_glast], ah
+    push ds
+    pop es                       ; ES = ours, which is what fsx_mode wants
+    mov al, [pm_fsxm]
+    cmp al, 0FFh
+    je .ready                    ; same-mode: the kernel's slots stay legal and
+    mov di, pm_fsi               ; every path below is the one the desktop uses
+    call OSAPI_FSX_MODE
+    jc .home                     ; refused, and nothing was changed
+    mov ax, [pm_fsi+FSI_SEG]
+    mov [pm_fseg], ax
+    mov ax, [pm_fsi+FSI_STRIDE]
+    mov [pm_fstride], ax
+    mov ax, [pm_fsi+FSI_BSTEP]
+    mov [pm_fbstep], ax
+    cmp byte [pm_fsi+FSI_MODE], FSXM_VGA13
+    jne .c4
+    mov byte [pm_tgt], PM_TGT_V13
+    call pm_pal13
+    jmp short .ready
+.c4:
+    mov byte [pm_tgt], PM_TGT_C4
+    call pm_palc4
+    call pm_c4build
+.ready:
+    mov byte [pm_full], 1
+    mov byte [pm_status_dirty], PM_SD_ALL
+    call pm_redraw
+.loop:
+.keys:
+    mov ah, 1                    ; poll: no events are dispatched in a bracket
+    int 0x16
+    jz .nokey
+    xor ah, ah
+    int 0x16
+    cmp al, 27
+    je .done
+    cmp al, 'f'
+    je .done
+    cmp al, 'F'
+    je .done
+    call pm_fsx_key
+    jmp short .keys
+.nokey:
+    call pm_fsx_frame
+    xor al, al                   ; FSXW_TICK: one frame a tick, and it halts
+    call OSAPI_FSX_WAIT          ; between polls rather than spinning
+    jmp .loop
+.done:
+    mov byte [pm_full], 1        ; the desktop's picture is owed a whole one
+.home:
+    mov byte [pm_tgt], PM_TGT_WIN
+    pop es
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; One frame inside the bracket. pm_frame's body without the two questions that
+; cannot be true here: nothing else can be the top window, and the About box
+; needs an event to appear.
+pm_fsx_frame:
+    cmp byte [pm_pause], 0
+    jne .status
+    cmp byte [pm_mode], PM_OVER
+    je .status
+    cmp byte [pm_mode], PM_PLAY
+    je .move
+    cmp word [pm_hold], 1
+    jbe .move
+    dec word [pm_hold]
+    jmp short .status
+.move:
+    call pm_mark_actors
+    call pm_step
+    call pm_mark_actors
+    call pm_redraw
+    ret
+.status:
+    cmp byte [pm_status_dirty], 0
+    je .out                      ; a pause message still has to reach the glass
+    call pm_redraw
+.out:
+    ret
+
+; The bracket's keyboard: the windowed bindings minus the ones its caller has
+; already taken (F and Esc), and minus the ones that need a window.
+pm_fsx_key:
+    cmp al, 'n'
+    je .win
+    cmp al, 'N'
+    je .win
+    cmp al, 'p'
+    je .win
+    cmp al, 'P'
+    je .win
+    cmp al, ' '
+    je .win
+    cmp ah, KSC_LEFT
+    je .win
+    cmp ah, KSC_RIGHT
+    je .win
+    cmp ah, KSC_UP
+    je .win
+    cmp ah, KSC_DOWN
+    je .win
+    push ax
+    or al, 20h
+    cmp al, 'a'
+    je .pop
+    cmp al, 'd'
+    je .pop
+    cmp al, 'w'
+    je .pop
+    cmp al, 's'
+    je .pop
+    pop ax
+    ret
+.pop:
+    pop ax
+.win:
+    jmp pm_key                   ; the windowed handler, register-preserving
 
 pm_command_body:
     cmp al, 0
@@ -318,7 +588,7 @@ pm_step:
     ret
 .ready:
     mov byte [pm_mode], PM_PLAY
-    mov byte [pm_status_dirty], 1
+    or byte [pm_status_dirty], PM_SD_MSG
     ret
 .play:
     cmp word [pm_fright], 0
@@ -675,7 +945,7 @@ pm_eat:
     jne .spawn
     mov byte [pm_mode], PM_LEVEL
     mov word [pm_hold], 36
-    mov byte [pm_status_dirty], 1
+    or byte [pm_status_dirty], PM_SD_MSG
     ret
 .spawn:
     cmp word [pm_eaten], 80
@@ -755,7 +1025,7 @@ pm_collide:
     jne .dead
     mov byte [pm_mode], PM_OVER
 .dead:
-    mov byte [pm_status_dirty], 1
+    or byte [pm_status_dirty], PM_SD_MSG | PM_SD_LIVES
     mov ax, 180
     call pm_tone
     ret
@@ -764,7 +1034,7 @@ pm_collide:
 pm_addscore:
     add [pm_score], ax
     adc word [pm_score+2], 0
-    mov byte [pm_status_dirty], 1
+    or byte [pm_status_dirty], PM_SD_SCORE
     cmp byte [pm_bonus], 0
     jne .out
     cmp word [pm_score+2], 0
@@ -774,6 +1044,7 @@ pm_addscore:
 .bonus:
     mov byte [pm_bonus], 1
     inc byte [pm_lives]
+    or byte [pm_status_dirty], PM_SD_LIVES
 .out:
     ret
 pm_tone:
@@ -848,6 +1119,21 @@ pm_mark:
     ret
 
 pm_track:
+    cmp byte [pm_tgt], PM_TGT_WIN
+    je .win
+    mov byte [pm_bpp], 4         ; the foreign surface: 320x200 either way, the
+    mov byte [pm_half], 0        ; board whole, and no window to read it off
+    xor ax, ax
+    mov [pm_cx], ax
+    mov [pm_cy], ax
+    mov [pm_ox], ax
+    mov ax, [pm_fsi+FSI_W]
+    mov [pm_cw], ax
+    mov ax, [pm_fsi+FSI_H]
+    mov [pm_ch], ax
+    mov word [pm_oy], PM_FS_TOP
+    ret
+.win:
     mov bx, [pm_win]
     call OSAPI_WM_DISPLAY
     mov [pm_bpp], dh
@@ -886,7 +1172,7 @@ pm_paint_body:
     mov byte [pm_hired], 1
 .draw:
     mov byte [pm_full], 1
-    mov byte [pm_status_dirty], 1
+    mov byte [pm_status_dirty], PM_SD_ALL
     call pm_redraw
     cmp byte [pm_abon], 0
     je .out
@@ -898,13 +1184,20 @@ pm_paint_body:
 
 pm_redraw:
     push es
-    mov bx, [pm_win]
-    call OSAPI_WM_CLIP_SET
+    cmp byte [pm_tgt], PM_TGT_WIN
+    jne .own                     ; a foreign framebuffer is ours whole: there
+    mov bx, [pm_win]             ; is no window above it to clip against, and
+    call OSAPI_WM_CLIP_SET       ; wm_clip_set is a desktop question anyway
     jc .out
+.own:
     call pm_track
     cmp byte [pm_full], 0
     je .compose
     mov byte [pm_full], 0
+    mov byte [pm_score_prev], 0  ; the strip is gone with the rest of it
+    cmp byte [pm_tgt], PM_TGT_WIN
+    jne .marked                  ; the mode set already cleared, and every band
+                                 ; below is about to be written again
     xor al, al
     call OSAPI_SET_COLOR
     mov ax, [pm_cx]
@@ -916,6 +1209,7 @@ pm_redraw:
     add dx, [pm_ch]
     dec dx
     call OSAPI_GFX_FILL
+.marked:
     xor bx, bx
 .all:
     mov byte [pm_min+bx], 0
@@ -923,7 +1217,7 @@ pm_redraw:
     inc bx
     cmp bx, 22
     jb .all
-    mov byte [pm_status_dirty], 1
+    mov byte [pm_status_dirty], PM_SD_ALL
 .compose:
     push ds
     pop es
@@ -936,34 +1230,30 @@ pm_redraw:
     cmp al, [pm_max+bx]
     ja .nextband
     mov [pm_col], ax
+    shl bx, 1                    ; the band's two bases, once a band: both were
+    mov ax, [pm_bandmap+bx]      ; a 16-bit MUL per TILE, and an 8088 charges
+    mov [pm_mapb], ax            ; ~124 clocks for one (PERFORMANCE.md Part 2)
+    mov ax, [pm_bandcv+bx]
+    mov [pm_cvb], ax
 .tile:
-    mov ax, bp
-    mov cx, 40
-    mul cx
-    add ax, [pm_col]
-    mov bx, ax
+    mov bx, [pm_col]
+    add bx, [pm_mapb]
     xor ax, ax
     mov al, [pm_map+bx]
     shl ax, 1
     mov bx, ax
     mov si, [pm_tile_offsets+bx]
     add si, pm_tiles
-    mov ax, bp
-    mov cx, 1280
-    mul cx
-    mov di, pm_canvas
-    add di, ax
-    mov ax, [pm_col]
-    shl ax, 1
-    shl ax, 1
-    add di, ax
-    mov dx, 8
-.row:
-    movsw
+    mov di, [pm_col]
+    shl di, 1
+    shl di, 1
+    add di, [pm_cvb]
+    add di, pm_canvas
+%rep 8                           ; unrolled: the row counter was 19 clocks a
+    movsw                        ; row on a tile that copies four bytes
     movsw
     add di, 156
-    dec dx
-    jnz .row
+%endrep
     inc word [pm_col]
     mov bx, bp
     xor ax, ax
@@ -985,16 +1275,9 @@ pm_redraw:
     cmp al, [pm_max+di]
     ja .clean
     mov bx, bp
-    mov cl, 3
-    shl bx, cl
-    push bx
-    push ax
-    mov ax, bx
-    mov cx, 160
-    mul cx
-    mov si, pm_canvas
-    add si, ax
-    pop ax
+    shl bx, 1
+    mov si, [pm_bandcv+bx]
+    add si, pm_canvas
     mov bx, ax
     shl bx, 1
     shl bx, 1
@@ -1010,7 +1293,10 @@ pm_redraw:
     shl ax, 1
     shl ax, 1
     add ax, [pm_ox]
-    pop bx
+    mov bx, bp
+    shl bx, 1
+    shl bx, 1
+    shl bx, 1
     mov dx, 8
     push bp
     mov bp, 160
@@ -1038,6 +1324,10 @@ pm_redraw:
 ; two identical pixels, so four table lookups compose eight output pixels.
 ; This avoids the software BLIT4 renderer's per-pixel color/clip work on XT.
 pm_blit:
+    cmp byte [pm_tgt], PM_TGT_V13
+    je pm_blit13
+    cmp byte [pm_tgt], PM_TGT_C4
+    je pm_blitc4
     cmp byte [pm_bpp], 1
     jne .packed
     call pm_packmono
@@ -1098,6 +1388,465 @@ pm_packmono:
     dec dx
     jnz .row
     pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+
+; ===========================================================================
+; THE FOREIGN-MODE BACKENDS (SPEC.md 89.3)
+;
+; Everything below runs only inside a SPEC.md 53 bracket that set a mode, and
+; nothing above it changes. The canvas, the tile composer, the sprite composer
+; and the dirty bands are the same on every path; what differs is the twelve
+; instructions that put a band on the glass.
+; ===========================================================================
+
+; ---------------------------------------------------------------------------
+; pm_blit13 - one band into 320x200x256 (FSXM_VGA13)
+; in:  DS:SI = the band's first canvas byte, BP = the canvas stride, AX = x,
+;      BX = y, CX = width in pixels, DX = rows. All registers preserved.
+;
+; A canvas byte is TWO IDENTICAL 4bpp pixels (89.2) and a mode 13h byte is one
+; pixel, so the whole conversion is `mov ah, al` - and pm_pal13 has put colour
+; c in DAC entry c|c<<4, which is exactly what a canvas byte holds. No
+; transpose, no run scan, no clip test, no per-call arrival: ~18 clocks a
+; pixel where the desktop's own OSAPI_GFX_BLIT4 measures ~235 on this art,
+; because that primitive is priced per COLOUR CHANGE and a maze is nothing
+; else (89.3.4).
+; ---------------------------------------------------------------------------
+pm_blit13:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    push es
+    mov [pm_bw], cx
+    mov [pm_bh], dx
+    mov [pm_bsk], bp
+    mov [pm_bx], ax              ; x goes to MEMORY: the `mul` below writes DX
+    mov ax, bx                   ; and a register would not survive it
+    mov bx, 320
+    mul bx
+    add ax, [pm_bx]
+    mov di, ax                   ; ES:DI = the first destination byte
+    mov es, [pm_fseg]
+    mov cx, [pm_bw]
+    shr cx, 1                    ; canvas bytes a row
+    mov ax, [pm_bsk]
+    sub ax, cx
+    mov [pm_bsk], ax
+    shr cx, 1
+    shr cx, 1                    ; ...in groups of four: a tile column is eight
+    mov [pm_bc], cx              ; pixels, so this always divides (89.2)
+    mov ax, 320
+    sub ax, [pm_bw]
+    mov [pm_bdk], ax
+    cld
+.row:
+    mov cx, [pm_bc]
+.grp:
+%rep 4
+    lodsb
+    mov ah, al
+    stosw
+%endrep
+    loop .grp
+    add si, [pm_bsk]
+    add di, [pm_bdk]
+    dec word [pm_bh]
+    jnz .row
+    pop es
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; ---------------------------------------------------------------------------
+; pm_blitc4 - one band into 320x200x4 (FSXM_CGA320)
+; Same contract as pm_blit13.
+;
+; Two canvas bytes are four screen pixels in one byte. pm_c4hi/pm_c4lo hold
+; each byte's contribution already shifted into place, so packing is two
+; lookups and an OR - and the CGA's two banks (FSI_BANKS = 2) mean a row
+; alternates between +FSI_BSTEP and +FSI_STRIDE-FSI_BSTEP rather than adding a
+; stride, which is why the row base is carried rather than computed.
+; ---------------------------------------------------------------------------
+pm_blitc4:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    push es
+    mov [pm_bw], cx
+    mov [pm_bh], dx
+    mov [pm_by], bx
+    mov [pm_bsp], bp
+    mov [pm_bx], ax
+    mov ax, bx
+    call pm_c4off                ; DI = that row's first byte
+    mov ax, [pm_bx]
+    shr ax, 1
+    shr ax, 1
+    add di, ax
+    mov es, [pm_fseg]
+    mov ax, [pm_bw]
+    shr ax, 1
+    shr ax, 1
+    mov [pm_bc], ax              ; screen bytes a row
+    mov ax, [pm_bsp]
+    mov dx, [pm_bw]
+    shr dx, 1
+    sub ax, dx
+    mov [pm_bsk], ax             ; canvas bytes to skip after one
+    xor bh, bh
+    cld
+.row:
+    mov cx, [pm_bc]
+    mov [pm_bdi], di
+.byte:
+    mov bl, [si]
+    mov al, [bx+pm_c4hi]
+    mov bl, [si+1]
+    or al, [bx+pm_c4lo]
+    add si, 2
+    stosb
+    loop .byte
+    add si, [pm_bsk]
+    mov di, [pm_bdi]
+    test byte [pm_by], 1
+    jnz .odd
+    add di, [pm_fbstep]          ; even row -> the odd bank, same line
+    jmp short .next
+.odd:
+    add di, [pm_fstride]         ; odd row -> the even bank, one line down
+    sub di, [pm_fbstep]
+.next:
+    inc word [pm_by]
+    dec word [pm_bh]
+    jnz .row
+    pop es
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AX = a screen row -> DI = its first byte in the CGA's interleaved banks.
+pm_c4off:
+    push ax
+    push dx
+    mov dx, ax
+    shr ax, 1
+    push dx
+    mov dx, [pm_fstride]
+    mul dx
+    mov di, ax
+    pop dx
+    test dl, 1
+    jz .out
+    add di, [pm_fbstep]
+.out:
+    pop dx
+    pop ax
+    ret
+
+; Build the two packing tables. Every canvas byte is c|c<<4, so only sixteen
+; entries carry meaning; indexing by the whole byte is what makes the inner
+; loop two lookups with no shift in it.
+pm_c4build:
+    push ax
+    push bx
+    push cx
+    xor bx, bx
+.b:
+    mov al, bl
+    mov cl, 4
+    shr al, cl
+    push bx
+    xor ah, ah
+    mov bx, ax
+    mov al, [bx+pm_c4]
+    pop bx
+    mov ah, al
+    shl ah, 1
+    shl ah, 1
+    or al, ah                    ; the byte's two pixels, 2bpp
+    mov [bx+pm_c4lo], al
+    mov cl, 4
+    shl al, cl
+    mov [bx+pm_c4hi], al
+    inc bx
+    cmp bx, 256
+    jb .b
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; ---------------------------------------------------------------------------
+; pm_pal13 - the desktop's sixteen colours into DAC entries 0x11*c
+;
+; This is what makes pm_blit13's `mov ah, al` legal: a canvas byte is c|c<<4,
+; so if entry c|c<<4 holds colour c the byte IS the pixel. SPEC.md 53.7 hands
+; the DAC to the app inside a foreign mode, and the exit mode set puts it back.
+; ---------------------------------------------------------------------------
+pm_pal13:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    xor bx, bx
+.c:
+    mov dx, 0x3C8
+    mov al, bl
+    mov ah, bl
+    mov cl, 4
+    shl ah, cl
+    or al, ah
+    out dx, al
+    inc dx
+    mov si, bx
+    add si, bx
+    add si, bx
+    add si, pm_dac
+    mov al, [si]
+    out dx, al
+    mov al, [si+1]
+    out dx, al
+    mov al, [si+2]
+    out dx, al
+    inc bx
+    cmp bx, 16
+    jb .c
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; CGA palette 1 at high intensity - black, cyan, magenta, white - with a black
+; border. The BIOS mode set leaves it on palette 0 (green/red/yellow), which is
+; not a maze.
+;
+; BOTH WAYS ROUND, and the second is for the EGA. 3D9h is the CGA's colour
+; select and an EGA does not decode it at all - that card keeps its palette in
+; the attribute controller - so the direct write alone would leave an EGA on
+; green and red. int 10h AH=0Bh is not a mode set (SPEC.md 53.7 forbids only
+; those) and both BIOSes implement it, so the call is asked first and the port
+; write, which carries the intensity bit a real CGA needs, lands over it on the
+; card that has one.
+pm_palc4:
+    push ax
+    push bx
+    push dx
+    mov ax, 0x0B01               ; BH=01 select palette, BL=01 palette 1
+    mov bx, 0x0101
+    int 0x10
+    mov dx, 0x3D9
+    mov al, 0x30                 ; palette 1, high intensity, black border
+    out dx, al
+    pop dx
+    pop bx
+    pop ax
+    ret
+
+; ---------------------------------------------------------------------------
+; pm_fstext - a NUL-terminated string in opaque 8x8 cells, straight into the
+;             foreign framebuffer
+; in:  SI = the string, CX = x (a multiple of 8), DX = y. All registers kept.
+;
+; OSAPI_FONT_RUN is a drawing slot and renders DESKTOP geometry, so after
+; OSAPI_FSX_MODE it is off limits (SPEC.md 53.7). What is legal is
+; OSAPI_FONT_GLYPHS - the bitmaps themselves - which is the whole reason that
+; slot exists, and it means the strip is the same typeface it always was.
+; ---------------------------------------------------------------------------
+pm_fstext:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    push es
+    mov [pm_penx], cx
+    mov [pm_peny], dx
+    cld
+.char:
+    mov al, [si]
+    inc si
+    or al, al
+    jz .done
+    push si
+    call pm_fsglyph
+    call pm_fscell
+    pop si
+    add word [pm_penx], 8
+    jmp short .char
+.done:
+    pop es
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; AL = a character -> its eight rows in pm_gbuf. Anything outside the table's
+; range letters as a space, which is what a font run does with it too.
+pm_fsglyph:
+    push ax
+    push bx
+    push cx
+    push di
+    push es
+    cmp al, [pm_gfirst]
+    jb .space
+    cmp al, [pm_glast]
+    jbe .have
+.space:
+    mov al, ' '
+.have:
+    sub al, [pm_gfirst]
+    xor ah, ah
+    mov bx, ax
+    shl bx, 1
+    shl bx, 1
+    shl bx, 1
+    add bx, [pm_gtab]
+    mov es, [pm_gseg]            ; the table is NOT in KERNEL_SEG (SPEC.md 20.8)
+    mov di, pm_gbuf
+    mov cx, 8
+.copy:
+    mov al, [es:bx]
+    mov [di], al
+    inc bx
+    inc di
+    loop .copy
+    pop es
+    pop di
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+; pm_gbuf at [pm_penx],[pm_peny], in whichever foreign mode is up.
+pm_fscell:
+    cmp byte [pm_tgt], PM_TGT_C4
+    je pm_fscellc4
+    ; ...and fall through to the chunky one
+
+pm_fscell13:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov ax, [pm_peny]
+    mov dx, 320
+    mul dx
+    add ax, [pm_penx]
+    mov di, ax
+    mov es, [pm_fseg]
+    mov si, pm_gbuf
+    mov byte [pm_rowc], 8
+    cld
+.row:
+    lodsb
+    mov ah, al
+    and ah, 0Fh
+    mov cl, 4
+    shr al, cl
+    mov bl, al                   ; the high nibble is the left four pixels
+    xor bh, bh
+    shl bx, 1
+    shl bx, 1
+    mov dx, [bx+pm_nib13]
+    mov [es:di], dx
+    mov dx, [bx+pm_nib13+2]
+    mov [es:di+2], dx
+    mov bl, ah
+    xor bh, bh
+    shl bx, 1
+    shl bx, 1
+    mov dx, [bx+pm_nib13]
+    mov [es:di+4], dx
+    mov dx, [bx+pm_nib13+2]
+    mov [es:di+6], dx
+    add di, 320
+    dec byte [pm_rowc]
+    jnz .row
+    pop es
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+pm_fscellc4:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push es
+    mov ax, [pm_peny]
+    mov [pm_bdi], ax             ; the pen's row, carried down the cell
+    mov si, pm_gbuf
+    mov es, [pm_fseg]
+    mov byte [pm_rowc], 8
+    cld
+.row:
+    mov ax, [pm_bdi]
+    call pm_c4off
+    mov ax, [pm_penx]
+    shr ax, 1
+    shr ax, 1
+    add di, ax
+    lodsb
+    mov ah, al
+    and ah, 0Fh
+    mov cl, 4
+    shr al, cl
+    mov bl, al
+    xor bh, bh
+    mov dl, [bx+pm_nibc4]
+    mov [es:di], dl
+    mov bl, ah
+    xor bh, bh
+    mov dl, [bx+pm_nibc4]
+    mov [es:di+1], dl
+    inc word [pm_bdi]
+    dec byte [pm_rowc]
+    jnz .row
+    pop es
     pop di
     pop si
     pop dx
@@ -1197,50 +1946,110 @@ pm_sprite:
     mov dh, 10
 .row:
     lodsb
-    mov cx, 8
-.pixel:
-    shl al, 1
-    jnc .skip
-    mov [di], dl
-.skip:
-    inc di
-    loop .pixel
+%rep 8
+    PM_SPX                       ; unrolled: `loop` is 17 clocks an 8088 spends
+%endrep                          ; on nothing, eight times a sprite row
     add di, 152
     dec dh
     jnz .row
 .out:
     ret
 
+; ---------------------------------------------------------------------------
+; pm_status - the strip, one field at a time (89.3.3)
+;
+; It used to be one dirty bit over four fields, so eating a dot lettered all
+; 74 cells: ~67 ms on a 4.77MHz 8088 at ~0.9 ms a cell, more than a whole
+; frame's budget, for two digits that moved. Each field now carries its own
+; bit, and the score - the one that changes every few frames - is drawn from
+; the first digit that actually differs, which for a 10-point dot is two.
+; ---------------------------------------------------------------------------
 pm_status:
-    cmp byte [pm_status_dirty], 0
+    mov al, [pm_status_dirty]
+    or al, al
     je .out
+    mov [pm_sdbits], al
     mov byte [pm_status_dirty], 0
+    mov ax, [pm_ox]              ; where the strip lives: inside the content on
+    mov [pm_sx], ax              ; the desktop, at the screen's own edges in a
+    mov dx, [pm_cy]              ; foreign mode
+    add dx, 3
+    mov bx, [pm_cy]
+    add bx, [pm_ch]
+    sub bx, 11
+    cmp byte [pm_tgt], PM_TGT_WIN
+    je .rows
+    mov word [pm_sx], 0
+    mov dx, 4
+    mov bx, PM_FS_MSG
+.rows:
+    mov [pm_stop], dx
+    mov [pm_sbot], bx
+
+    test byte [pm_sdbits], PM_SD_SCORE
+    jz .lives
     mov ax, [pm_score]
     mov dx, [pm_score+2]
     mov di, pm_score_text+6
     mov cx, 10
     call pm_decimal
+    xor bx, bx                   ; the first cell that moved
+.diff:
+    mov al, [pm_score_text+bx]
+    cmp al, [pm_score_prev+bx]
+    jne .from
+    or al, al
+    jz .lives                    ; identical: nothing to letter
+    inc bx
+    jmp short .diff
+.from:
+    push bx
+.copy:
+    mov al, [pm_score_text+bx]
+    mov [pm_score_prev+bx], al
+    or al, al
+    jz .copied
+    inc bx
+    jmp short .copy
+.copied:
+    pop bx
+    mov cx, bx
+    shl cx, 1
+    shl cx, 1
+    shl cx, 1
+    add cx, [pm_sx]
+    mov si, pm_score_text
+    add si, bx
+    mov dx, [pm_stop]
+    call pm_run
+.lives:
+    test byte [pm_sdbits], PM_SD_LIVES
+    jz .flevel
     mov al, [pm_lives]
     add al, '0'
     mov [pm_lives_text+6], al
+    mov si, pm_lives_text
+    mov cx, [pm_sx]
+    add cx, 144
+    mov dx, [pm_stop]
+    call pm_run
+.flevel:
+    test byte [pm_sdbits], PM_SD_LEVEL
+    jz .msg
     mov ax, [pm_level]
     inc ax
     xor dx, dx
     mov di, pm_level_text+6
     mov cx, 5
     call pm_decimal
-    mov cx, [pm_ox]
-    mov dx, [pm_cy]
-    add dx, 3
-    mov si, pm_score_text
-    mov ax, CWHITE
-    call OSAPI_FONT_RUN
-    add cx, 144
-    mov si, pm_lives_text
-    call OSAPI_FONT_RUN
-    add cx, 88
     mov si, pm_level_text
-    call OSAPI_FONT_RUN
+    mov cx, [pm_sx]
+    add cx, 232
+    mov dx, [pm_stop]
+    call pm_run
+.msg:
+    test byte [pm_sdbits], PM_SD_MSG
+    jz .out
     mov bx, pm_s_play
     cmp byte [pm_mode], PM_READY
     jne .dead
@@ -1267,13 +2076,22 @@ pm_status:
     mov bx, pm_s_wait
 .available:
     mov si, bx
-    mov cx, [pm_ox]
-    mov dx, [pm_cy]
-    add dx, [pm_ch]
-    sub dx, 11
+    mov cx, [pm_sx]
+    mov dx, [pm_sbot]
+    call pm_run
+.out:
+    ret
+
+; One run of text, wherever this frame is going.
+; in: SI = string, CX = x, DX = y. Preserves what its two backends preserve.
+pm_run:
+    cmp byte [pm_tgt], PM_TGT_WIN
+    jne .foreign
     mov ax, CWHITE
     call OSAPI_FONT_RUN
-.out:
+    ret
+.foreign:
+    call pm_fstext
     ret
 
 ; DX:AX -> CX decimal digits at DS:DI; divide the high word first so no
@@ -1331,6 +2149,60 @@ pm_ab3: db 'Original maze, sprites and scoring',0
 pm_ab4: db 'Native 8086 adaptation',0
 pm_ab5: db 'Arrows/WASD move. P pauses. N starts.',0
 align 32, db 0
+
+; A band's two bases, indexed by band (89.3.5): 22 words each, against a
+; 16-bit MUL an 8088 charges ~124 clocks for.
+pm_bandmap:
+%assign pmb 0
+%rep 22
+    dw pmb * 40
+%assign pmb pmb+1
+%endrep
+pm_bandcv:
+%assign pmb 0
+%rep 22
+    dw pmb * 1280
+%assign pmb pmb+1
+%endrep
+
+; The desktop's sixteen colours as 6-bit DAC triples, for FSXM_VGA13.
+pm_dac:
+    db  0, 0, 0,   0, 0,42,   0,42, 0,   0,42,42
+    db 42, 0, 0,  42, 0,42,  42,21, 0,  42,42,42
+    db 21,21,21,  21,21,63,  21,63,21,  21,63,63
+    db 63,21,21,  63,21,63,  63,63,21,  63,63,63
+
+; ...and as CGA palette 1 at high intensity - black, cyan, magenta, white.
+; Walls (9) are cyan, dots and the player (14/15) white, the ghosts magenta;
+; a frightened ghost (7) goes white, which is the flash it already has.
+pm_c4:
+    db 0,1,1,1,2,2,1,3,1,1,3,2,2,2,3,3
+
+; Four pixels of a glyph nibble, one byte each, for FSXM_VGA13's chunky bytes
+; (0xFF is colour 15 in the palette pm_pal13 lays down).
+pm_nib13:
+    db 0x00,0x00,0x00,0x00
+    db 0x00,0x00,0x00,0xFF
+    db 0x00,0x00,0xFF,0x00
+    db 0x00,0x00,0xFF,0xFF
+    db 0x00,0xFF,0x00,0x00
+    db 0x00,0xFF,0x00,0xFF
+    db 0x00,0xFF,0xFF,0x00
+    db 0x00,0xFF,0xFF,0xFF
+    db 0xFF,0x00,0x00,0x00
+    db 0xFF,0x00,0x00,0xFF
+    db 0xFF,0x00,0xFF,0x00
+    db 0xFF,0x00,0xFF,0xFF
+    db 0xFF,0xFF,0x00,0x00
+    db 0xFF,0xFF,0x00,0xFF
+    db 0xFF,0xFF,0xFF,0x00
+    db 0xFF,0xFF,0xFF,0xFF
+
+; ...and the same nibble as one 2bpp byte for FSXM_CGA320, ink 3.
+pm_nibc4:
+    db 0x00,0x03,0x0C,0x0F,0x30,0x33,0x3C,0x3F
+    db 0xC0,0xC3,0xCC,0xCF,0xF0,0xF3,0xFC,0xFF
+
 pm_mono_pairs: db 0,0,0,0,0,0,0,2,2,2,2,2,3,2,3,3
     db 0,0,0,0,0,0,0,1,1,1,1,1,3,1,3,3
 pm_initial_x: db 124,124,116,132,122
@@ -1406,6 +2278,38 @@ pm_license:
     PM_VAR pm_min,22
     PM_VAR pm_max,22
     PM_VAR pm_map,880
+    PM_VAR pm_tgt,1
+    PM_VAR pm_fsxm,1
+    PM_VAR pm_fsi,FSI_SIZE
+    PM_VAR pm_fseg,2
+    PM_VAR pm_fstride,2
+    PM_VAR pm_fbstep,2
+    PM_VAR pm_gtab,2
+    PM_VAR pm_gseg,2
+    PM_VAR pm_gfirst,1
+    PM_VAR pm_glast,1
+    PM_VAR pm_gbuf,8
+    PM_VAR pm_rowc,1
+    PM_VAR pm_penx,2
+    PM_VAR pm_peny,2
+    PM_VAR pm_sdbits,1
+    PM_VAR pm_sx,2
+    PM_VAR pm_stop,2
+    PM_VAR pm_sbot,2
+    PM_VAR pm_score_prev,17
+    PM_VAR pm_bw,2
+    PM_VAR pm_bh,2
+    PM_VAR pm_bc,2
+    PM_VAR pm_bsk,2
+    PM_VAR pm_bdk,2
+    PM_VAR pm_bsp,2
+    PM_VAR pm_bx,2
+    PM_VAR pm_by,2
+    PM_VAR pm_bdi,2
+    PM_VAR pm_mapb,2
+    PM_VAR pm_cvb,2
+    PM_VAR pm_c4hi,256
+    PM_VAR pm_c4lo,256
     PM_VAR pm_canvas,28160
     OS88_BSS PM_BSS
     OS88_IMAGE_END

--- a/tests/pacman.py
+++ b/tests/pacman.py
@@ -23,6 +23,22 @@ import os88geom
 import dispcp
 import dispapps
 
+XT_HZ = 4772727                 # the 8088's own 14.31818/3, for a guest second
+
+# What each adapter's F is: the render target it reaches (SPEC.md 89.3) and
+# the FSXM_* id behind it. A Hercules has nothing below its own 720x348, so it
+# takes a same-mode bracket - 0FFh - and keeps the desktop's mode.
+MODES = {
+    'os8088_xt_vga':        (1, 6),      # PM_TGT_V13, FSXM_VGA13
+    'os8088_5150_cga_gla':  (2, 2),      # PM_TGT_C4,  FSXM_CGA320
+    'os8088_5150_herc_gla': (0, 0xFF),   # same mode
+}
+
+# apps/pacman's own pm_c4: a desktop colour to a CGA palette-1 index. Written
+# out here on purpose - a test that imported the table it is checking would
+# agree with any table at all.
+CGA4 = [0, 1, 1, 1, 2, 2, 1, 3, 1, 1, 3, 2, 2, 2, 3, 3]
+
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
@@ -218,22 +234,98 @@ def main():
 
         # A forced complete reconstruction must equal the incremental canvas.
         # This sees sprite residue and erased pellets even when the glass looks
-        # plausible. Freeze gameplay; full-screen input invokes W_PAINT.
+        # plausible - and it is the assertion that caught the foreign-mode
+        # blitter writing every band at x = 0 (SPEC.md 89.3.1), because the
+        # canvas was right and only the copy out of it was wrong. Freeze
+        # gameplay first; entering full screen redraws whole.
         put('pm_pause', 1)
         canvas = m.read(base + symbols['pm_canvas'], 28160)
+        desktop_mode = m.video()['mode']
+
+        # F is a SPEC.md 53 bracket now, not just the 11.2 surface: the worker
+        # freezes and pm_fsx_frame is the frame, so `boundary` cannot be the
+        # fence here.
+        m.bp_exec(base + symbols['pm_fsx_frame'])
+        m.key('KeyF')
+        m.run()
+        assert m.wait_stop(60) == 'breakpoint', 'F did not reach the bracket'
         m.bp_exec()
-        key('KeyF')
         m.advance(frames=120)
-        boundary()
-        assert read('pm_fs') == 1
+        kind, want = MODES[args.machine]
+        assert read('pm_tgt') == kind, ('render target', read('pm_tgt'), kind)
+        assert read('pm_fsxm') == want, ('fsx mode', read('pm_fsxm'), want)
+        got = m.video()['mode']
+        if kind == 0:
+            assert got == desktop_mode, ('a same-mode bracket changed the mode', got)
+            assert read('pm_fs') == 1, 'the same-mode bracket wants the 11.2 surface'
+        else:
+            assert got != desktop_mode, ('the mode never changed', got)
+            assert read('pm_fs') == 0, 'a mode-setting bracket takes no 11.2 surface'
         assert m.read(base + symbols['pm_canvas'], 28160) == canvas
+
+        # ...and the SCREEN, rebuilt from that canvas on the host. A picture of
+        # a maze looks plausible with the packing wrong; this answers whether
+        # the bytes the blitter wrote are the bytes the canvas says (SPEC.md
+        # 89.3.1), and it is what would have caught the x = 0 defect on its own.
+        if kind:
+            put('pm_full', 1)
+            put('pm_status_dirty', 0x0F)
+            m.advance(frames=300)
+            board = m.read(base + symbols['pm_canvas'], 28160)
+            seg = read('pm_fseg', 2)
+            stride, bstep = read('pm_fstride', 2), read('pm_fbstep', 2)
+            bad = 0
+            if kind == 1:                    # 320x200x256: one byte a pixel
+                vram = m.read(seg * 16, 64000)
+                for row in range(176):
+                    src = board[row * 160:(row + 1) * 160]
+                    want = bytes(b for c in src for b in (c, c))
+                    got = vram[(row + 16) * 320:(row + 16) * 320 + 320]
+                    bad += sum(1 for x, y in zip(want, got) if x != y)
+            else:                            # 320x200x4: two banks, 2bpp
+                vram = m.read(seg * 16, 16384)
+                for row in range(176):
+                    src = board[row * 160:(row + 1) * 160]
+                    want = bytes(((CGA4[src[i] >> 4] * 5) << 4) | (CGA4[src[i+1] >> 4] * 5)
+                                 for i in range(0, 160, 2))
+                    y = row + 16
+                    off = (y >> 1) * stride + (y & 1) * bstep
+                    got = vram[off:off + 80]
+                    bad += sum(1 for x, z in zip(want, got) if x != z)
+            assert bad == 0, ('the foreign-mode blitter and the canvas disagree', bad)
+            canvas = board
+
+        # THE POINT OF THE BRACKET, asserted rather than admired: a 4.77MHz
+        # 8088 must complete a frame per tick. Windowed on a VGA the same board
+        # measures 4.4 fps, all of it in OSAPI_GFX_BLIT4 (SPEC.md 89.3.4), and
+        # the rate is quantised to 18.2/N - so anything at or under 9.1 fails
+        # this and 14 cannot be reached by a machine that missed a tick.
+        put('pm_pause', 0)
+        put('pm_mode', 0)
+        put('pm_hold', 1, 2)
+        put('pm_lives', 9)
+        raw('pm_release', [255] * 4)     # nothing leaves the house, nothing dies
+        m.advance(cycles=XT_HZ // 2)
+        f0 = read('pm_frames', 2)
+        m.advance(cycles=XT_HZ * 4)
+        fps = ((read('pm_frames', 2) - f0) & 0xFFFF) / 4.0
+        assert fps >= 14.0, ('full screen missed the tick rate', fps)
+        put('pm_pause', 1)
+        m.advance(frames=60)
+        canvas = m.read(base + symbols['pm_canvas'], 28160)
+
+        m.bp_exec(base + symbols['pm_frame'])
+        m.key('Escape')
+        m.run()
+        assert m.wait_stop(60) == 'breakpoint', 'Esc did not leave the bracket'
         m.bp_exec()
-        key('Escape')
         m.advance(frames=120)
-        boundary()
+        assert read('pm_tgt') == 0, 'the render target survived the bracket'
         assert read('pm_fs') == 0, (read('pm_fs'), m.regs())
+        assert m.video()['mode'] == desktop_mode, 'the desktop mode was not restored'
         assert m.read(base + symbols['pm_canvas'], 28160) == canvas
-        print('  game over, restart, full-screen round trip and repaint: pass', flush=True)
+        print(f'  game over, restart, full-screen bracket ({fps:.1f} fps) and repaint: pass',
+              flush=True)
 
         # Close through the real window control and watch instance teardown.
         m.bp_exec()

--- a/tests/suite.py
+++ b/tests/suite.py
@@ -670,7 +670,9 @@ FULL = [
 SOAK = [
     Row("pacman", "soak", py("tests/pacman.py"), 100.0,
         "native 8088 Pac-Man movement, score, pellets, fruit, level transitions, "
-        "pause, full-screen repaint and worker teardown", needs=("marty",)),
+        "pause, the SPEC.md 53 full-screen bracket - its mode per adapter, the "
+        "screen rebuilt from the canvas on the host, the tick rate it exists "
+        "for and the desktop restored - and worker teardown", needs=("marty",)),
     Row("weavevm", "soak", py("tests/weavevm.py"), 20.0,
         "WEAVE-SPEC 12.3: the SHIPPING apps/weave/wvm.inc run in a raw-QEMU "
         "BOOT SECTOR with SS != DS and no OS under it at all, diffed case by "


### PR DESCRIPTION
Stacked on #156. Merge that one first.

Windowed on a cycle-accurate 4.77MHz 8088 with a VGA, Pac-Man ran at **4.7 frames a second against the 18.2** its worker asks for, and **81% of the frame was one call**: `OSAPI_GFX_BLIT4`, which is priced per *colour change* rather than per pixel — and a maze is nothing else (~6.6 runs a row, ~1,800 clocks a run, ~235 clocks a pixel).

**F now takes the machine** (SPEC.md §53) and drops to the lowest-resolution mode the window's own display offers. F and Esc still leave it, as §11.2.1 binds.

| adapter | mode F takes | board |
|---|---|---|
| VGA | `FSXM_VGA13` — 320×200×256 | 320×176, sixteen colours |
| CGA / EGA | `FSXM_CGA320` — 320×200×4 | 320×176 **in colour** — where the desktop's 640×200×1bpp gets 320×88 monochrome |
| Hercules | same-mode bracket | as before; what it gains is exclusivity |

### Measured, cycle-accurate 4.77MHz 8088, board held in play

| adapter | windowed before | windowed now | full screen |
|---|---|---|---|
| VGA | 4.73 fps | 4.77 | **18.20 — the tick rate** |
| CGA | 18.20 | 18.20 | 18.20, and full height in colour |
| Hercules | 10.47 | 14.07 | **18.20** |

### How

Nothing above the band blitters changes: the map, the 4bpp canvas, the dirty bands and both composers are one body on every path, and a render-target byte picks the twelve instructions that put a band on the glass.

- **Mode 13h is `mov ah, al`.** A canvas byte is already two identical 4bpp pixels, so `pm_pal13` puts colour *c* in DAC entry `0x11*c` and the byte *is* the pixel — no transpose, no run scan, no clip test.
- **CGA mode 4 is two lookups and an OR**, across the card's two banks. Palette 1 at high intensity: cyan walls, white dots and player, magenta ghosts. The select goes through `int 10h AH=0Bh` as well as port 3D9h, because an EGA does not decode that port.
- **Text is `OSAPI_FONT_GLYPHS`** — the one letterer still legal after a mode set (§53.7).
- **A mode-setting bracket takes no §11.2 surface** (§42.7's reason, and here it is seconds): that surface's own `W_PAINT` is a whole board through `gfx_blit4`, ~2.8 s, thrown away by the mode set two calls later. The same-mode bracket does take it, which is what answers §53.7.1 without `fsx_surf`.

### Below the blit, on every path

Band bases from a 22-entry table instead of two 16-bit `MUL`s per **tile**; unrolled tile and sprite rows; and the status strip split into four fields — eating a dot used to letter all 74 cells, ~67 ms, more than a whole frame, for two digits that moved. Tile composition **22.7 → 12.1 ms**, sprites **6.6 → 4.8**. That is ~3% of a windowed VGA frame and **34% of a Hercules one**.

### The kernel is untouched, and §89.3.4 records why

Two attempts on `gfx_blit4`'s number were measured and **both lost**:

- **Widening a band** to reach §5.4.1.3's planar decoder, whose 64-pixel floor these 24–88 pixel bands fall under: 64px gave 3.67 fps, 128px gave 2.50. The extra pixels are extra runs.
- **Lowering that floor in the kernel** to 16 with the `W/32` threshold floored at one run: the blits went from **180 ms to 222**. The decoder's per-row fixed cost is real and 64 is where it stops mattering.

What *would* fix the windowed case is `gfx_blitp` (§5.4.3), and it is refused rather than overlooked: this package arms its own clip region on every self-initiated frame, and §5.4.3.3 makes that region binding rather than advisory.

### Verification

- `make` 45/45, `make test-full` 58/58.
- `tests/pacman.py` passes on `os8088_xt_vga`, `os8088_5150_cga_gla` and `os8088_5150_herc_gla`, and now asserts the mode each adapter takes, the desktop restored, and the 18.2 fps the bracket exists for.
- New assertion: the full-screen **screen is rebuilt from the canvas on the host** and diffed — 0 differing bytes in both foreign modes. It caught a real defect: `mul` clobbers `DX`, which held the destination x, so every band landed at x = 0 with a canvas that was perfectly correct.
- EGA is the one path with no automated gate — MartyPC has no EGA machine and 86Box can only be looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TjEoDPZVx1TWz2ZNyR2U6