### PR TITLE
Fix the build: OSAPI_XCELL/OSAPI_NCELL must jump STRICT near

### DIFF
--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -2677,14 +2677,14 @@ dbg_reg_at:                     ; 0060:000E - THE DEBUG REGISTRY (SPEC.md 57)
 %macro OSAPI_XCELL 1                ; 8 bytes exactly
     push bp                         ; 55        the CALLER's, under the frame
     mov bp, %1                      ; BD lo hi
-    jmp near api_x                  ; E9 lo hi
+    jmp strict near api_x           ; E9 lo hi
     db 0
 %endmacro
 
 %macro OSAPI_NCELL 1                ; 8 bytes exactly
     push bp
     mov bp, %1
-    jmp near api_n
+    jmp strict near api_n
     db 0
 %endmacro
 

--- a/tools/stkbalance.py
+++ b/tools/stkbalance.py
@@ -98,7 +98,7 @@ POP = re.compile(r"^(pop|popa|popf)\b", re.I)
 RET = re.compile(r"^(ret|retn|retf|iret)\b", re.I)
 RETF = re.compile(r"^retf\b", re.I)
 PUSHF = re.compile(r"^pushf\b", re.I)
-JMP = re.compile(r"^jmp\s+(?:short\s+|near\s+|word\s+)?(\S+)", re.I)
+JMP = re.compile(r"^jmp\s+(?:strict\s+)?(?:short\s+|near\s+|word\s+)?(\S+)", re.I)
 JCC = re.compile(r"^(j[a-z]{1,3}|loop|loope|loopne|loopz|loopnz)\s+"
                  r"(?:short\s+)?(\S+)$", re.I)
 SPADD = re.compile(r"^(add|sub)\s+sp\s*,\s*(\S+)$", re.I)
@@ -118,7 +118,7 @@ MACDEF = re.compile(r"^%macro\s+([A-Za-z_][A-Za-z0-9_]*)\s+(\d+)", re.I)
 MACEND = re.compile(r"^%endmacro\b", re.I)
 # `jmp %1` / `call %1` inside a macro body: the macro's ARGUMENT is a branch
 # target, so an invocation is control flow and not an address being taken.
-MACJMP = re.compile(r"^(?:jmp|j[a-z]{1,3})\s+(?:short\s+)?%1\s*$", re.I)
+MACJMP = re.compile(r"^(?:jmp|j[a-z]{1,3})\s+(?:strict\s+)?(?:short\s+|near\s+)?%1\s*$", re.I)
 MACCALL = re.compile(r"^call\s+%1\s*$", re.I)
 # `jmp short $+2` and friends: a jump to the very next instruction, used all
 # over this tree to let an I/O port settle.  It is not a tail call.


### PR DESCRIPTION
**This is latent on nasm 2.x, which is what CONTRIBUTING targets and what you build with. It bites on nasm 3.x.** Nothing is on fire; the argument for taking it is that the code currently depends on an optimiser choice rather than on the assembler being told what to emit.

## What happens

`OSAPI_XCELL` and `OSAPI_NCELL` end in `jmp near api_x` / `jmp near api_n`. nasm 3.x shortens those to `EB rel8` when the target is close enough, so the cell emits **7 bytes instead of 8**. Five cells do it, the table comes out 5 bytes short, and `kernel.asm`'s own assertion fires:

```
kernel/kernel.asm:3805: error: os8088 API jump table must be exactly 159 8-byte slots
```

nasm 2.x does not shorten them, so the same tree builds and the table is exactly 159 slots.

**`OSAPI_JSLOT` already documents this and guards against it**, three macros up:

> Without it NASM shortens the jump to `EB rel8` whenever the target is within 127 bytes … every slot after the shortened one slides down a byte and answers at the wrong address. That is the whole reason the length assertion below exists, and it is what caught this.

It uses `jmp strict near`. The two newer macros do not. `api_x`/`api_n` and `OSAPI_NCELL` came in with #147; `OSAPI_XCELL` with #151.

The assertion is doing its job either way — without it, a build that shortened a cell would ship a kernel where every slot past `0x0498` answers at the wrong address, silently. What `strict` buys is that the emitted size stops depending on which nasm is installed.

## The second half is version-independent

`tools/stkbalance.py`'s `JMP` pattern accepts `short|near|word` but not `strict`, and `MACJMP` only `short`. So `jmp strict near api_x` parses **"strict"** as the target and the edge is lost — `api_x` then walks from zero and reports `ret at depth -1`.

That hole predates this PR: `OSAPI_JSLOT`'s existing `jmp strict near %1` has been mis-parsed the same way since #123, on every nasm version, so those five tail jumps were never followed.

## Verified against `783a322` (#166)

| | |
|---|---|
| tip, nasm 2.15.05 | builds; table is 113 `SLOT` + 41 near cells + 5 `JSLOT` = 159 slots, 1,272 bytes, none shortened |
| tip, nasm 3.01 | 5 cells emit `EB rel8`; assertion fires |
| tip + this PR, nasm 3.01 | `make` exit 0, **48 passed, 0 failed** |

Cherry-picks onto the tip with no conflict. Under nasm 3.01, `682988b` (#146) builds and `b9bb040` (#147) does not.

*(Earlier revisions of this description said "main has not built since #147" and that #147 moved existing cells into range. Both were wrong: it builds fine on 2.x, and #147 introduced the macros rather than moving anything. Corrected here so the description stands on its own.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159LErbVPudCzAZfW9BtbAX