### PR TITLE
Scribe: read SCRIBE.OVL at entry, so a disk swap cannot strand Open and Save

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -107874,6 +107874,41 @@ from `.RTF` (21,541 bytes) and **reduced to one bit** from `.DOC` (4,729),
 which is what §94.7 says each should do. The checksum bullet's `rotate-xor` is
 also `main`'s **LFSR** now (§93.3); the `BCE9` figure is the pre-merge one.
 
+#### 94.8.6 Loaded at entry, not at first use
+
+§68.10 reads a module "the first time one of its features is asked for", and
+for WORD that cost nothing: its module held a picture feature most sessions
+never touch. **§94.8 put Open and Save in this one**, so "first use" became the
+first file operation — and `sc_ovneed` reads the module from the folder
+Scribe was **launched** from (`sc_ovdir`/`sc_ovdrv`). By the time a user
+opens a document off a data disk, or saves a new one onto a blank one, the
+launch drive holds that disk and not `SCRIBE.OVL`. The refusal was the
+ordinary path §68.10 describes — "a disk swapped for one without" the module —
+but for a picture that is a missing feature, and for Open and Save it was a
+Scribe that could neither read a document from a second floppy nor write one
+to it. WORD never had the problem: its formats are resident.
+
+`sc_entry` now calls **`sc_ovload`** after its three claims and before the
+window, which is what §50.3's claims-at-entry asks for. `sc_ovload` is `sc_ovneed` without the
+voice: it returns CF and, on failure, the message in AX rather than posting
+it, and `sc_ovneed` is now the wrapper that posts. The entry call is silent
+and does not read CF — a machine without the heap or a disk without the file
+still runs the editor, and the first file operation retries and says why.
+
+Measured under MartyPC on a 5150, cold launch, no file touched:
+
+| | Scribe's claims | `SCRIBE.OVL` resident | launch floppy traffic |
+|---|---|---|---|
+| before | 3 of 8 | no | 6 reads, 87 sectors |
+| after | 4 of 8 | yes, 12K pinned | 16 reads, 141 sectors |
+
+The cost is those 54 sectors at every launch, **including sessions that never
+open or save**, where before they fell on the first file operation of the
+sessions that did. It is 54 for a 20-sector file because the load navigates
+to the launch folder and back and reads a cluster at a time — the §18.91
+shape, and a property of the module load path every overlaid package shares,
+not of this change. 19 resident bytes.
+
 ### 94.9 Insert ▸ Picture — the document model
 
 Built in WORD first and reverted out of it (§68.15); this is where it

--- a/apps/scribe/scribe.asm
+++ b/apps/scribe/scribe.asm
@@ -816,6 +816,26 @@ sc_entry:
     mov word [sc_papn], 1
     mov word [sc_capkb], SC_KB0
     mov word [sc_cap], SC_KB0 * 1024
+    push ax                         ; SCRIBE.OVL NOW, NOT AT FIRST USE. 68.10
+    call sc_ovload                  ; loads a module "the first time one of its
+    pop ax                          ; features is asked for", which cost WORD
+                                    ; nothing while its module held a picture
+                                    ; feature most sessions never touch. 94.8
+                                    ; put OPEN AND SAVE in this one, so first
+                                    ; use is the first file operation - and by
+                                    ; then the launch drive may hold the disk
+                                    ; the user is opening from or saving to.
+                                    ; The module is read from the LAUNCH
+                                    ; folder, so it was not there, and a cold
+                                    ; Scribe could neither open a document off
+                                    ; a data disk nor save a new one onto it.
+                                    ; This is SPEC.md 50.3's claims-at-entry.
+                                    ; CF IS NOT READ: a machine without the
+                                    ; heap or a disk without the file still
+                                    ; runs the editor, and sc_ovneed retries at
+                                    ; first use and says why. Silent here
+                                    ; because there is no document yet for the
+                                    ; message to be about
     call sc_defname                 ; the name and the TITLE the template
     call sc_compttl                 ; points at (SPEC.md 68.2: 'Microsoft
                                     ; Word - DOCUMENT.DOC') must exist before
@@ -20184,11 +20204,28 @@ SCM_MAX      equ 7              ; ...and the highest of them
 ; forbids both on a worker. [sc_inwk] is the same gate sc_itinit uses.
 ; -----------------------------------------------------------------------------
 sc_ovneed:
+    push ax
+    call sc_ovload                  ; CF=1: AX = what to say, or 0 for nothing
+    jnc .ok
+    test ax, ax
+    jz .quiet
+    call sc_saymsg                  ; preserves the flags, so CF is test's 0
+.quiet:
+    stc
+.ok:
+    pop ax
+    ret
+
+; sc_ovload - sc_ovneed without the voice, for sc_entry: there is no document
+; yet for a refusal to be about, and first use retries and speaks.
+; out: CF=0 loaded (AX clobbered); CF=1 not loaded, AX = the message to show,
+;      or 0 on a worker, where the caller's own gate has already answered.
+;      Preserves every other register.
+sc_ovload:
     cmp word [sc_ovseg], 0
     jne .ok
     cmp byte [sc_inwk], 0
     jne .nowk
-    push ax
     push bx
     push cx
     push dx
@@ -20231,7 +20268,6 @@ sc_ovneed:
     pop dx
     pop cx
     pop bx
-    pop ax
 .ok:
     clc
     ret
@@ -20240,11 +20276,10 @@ sc_ovneed:
     call OSAPI_MEM_FREE             ; module is worse than none
     mov word [sc_ovseg], 0
     mov ax, sc_m_noovl
-    jmp short .say
+    jmp short .fail
 .nomem:
     mov ax, sc_e_nomem
-.say:
-    call sc_saymsg
+.fail:
     call sc_ovback
     pop es
     pop di
@@ -20252,9 +20287,11 @@ sc_ovneed:
     pop dx
     pop cx
     pop bx
-    pop ax
-.nowk:
     stc
+    ret
+.nowk:
+    xor ax, ax                      ; nothing to say: a worker's own gate
+    stc                             ; answers, as it always did here
     ret
 
 ; sc_ovback - put the volume back where the user left it. Preserves all.


### PR DESCRIPTION
**A regression from #162 (mine): a freshly launched Scribe cannot open a document from a second floppy, or save a new one to a blank disk.** This loads `SCRIBE.OVL` at entry instead of at first use. 19 resident bytes.

## What happens

§94.8 moved Scribe's file formats into `SCRIBE.OVL`, and §68.10's design reads a module "the first time one of its features is asked for" — from the folder the package was **launched** from (`sc_ovdir`/`sc_ovdrv`). For WORD's module, a picture feature most sessions never touch, that costs nothing. For Open and Save it means the first use is the first file operation, and by then the launch drive typically holds the disk the user is opening from or saving to:

1. Launch Scribe from its disk in B:.
2. Swap a data disk into B:.
3. File ▸ Open a document on it (or type something and Save onto it).
4. `sc_ovneed` goes to the launch folder, finds no `SCRIBE.OVL`, and refuses.

That refusal is the ordinary path §68.10 describes — "a disk swapped for one without" the module — and for a picture it is a missing feature. For Open and Save it is an editor that cannot read from or write to a second floppy. WORD does not have the problem: its formats are resident.

## The change

- `sc_entry` calls **`sc_ovload`** after its three claims and before the window — §50.3's claims-at-entry.
- `sc_ovload` is `sc_ovneed` without the voice: CF, and the message in AX instead of posted. `sc_ovneed` becomes the wrapper that posts, so its one caller (`sc_ovcall`) and its contract are unchanged.
- The entry call is silent and reads no CF. Without heap or file the editor still runs, and the first file operation retries and says why — exactly as today.

## Verified

A/B under MartyPC on a 5150, cold launch, no file touched — `main`'s binary against this one, reading `mem_tab` through `tools/heapmap.py` and the floppy controller through `Marty.disk()`:

| | Scribe's claims | `SCRIBE.OVL` resident | launch floppy traffic |
|---|---|---|---|
| `main` | 3 of 8 | no | 6 reads, 87 sectors |
| this | 4 of 8 | **yes**, 12K pinned | 16 reads, 141 sectors |

Once resident, `sc_ovneed` returns at its first compare and touches no disk, which is what makes a swap harmless.

**The swap itself was not driven.** MartyPC's debug server has no mid-session mount, and `os88mouse` is MartyPC-only, so no harness in the tree can change a floppy under a running package. The claim above rests on the A/B plus the fact that the load path is never entered once `[sc_ovseg]` is set.

Fast tier green, including `stkbalance` and `ovlchk`; checkdocs clean. SPEC §94.8.6 records the change and the numbers.

## The cost, and something it exposed

Every launch now pays those **54 sectors**, including sessions that never open or save; before, they fell on the first file operation of the sessions that did.

54 for a 20-sector file is worth a look on its own. The load navigates to the launch folder and back and reads a cluster at a time — the §18.91 shape `Marty.disk()`'s docstring describes. That is the module load path, not this change, and every overlaid package pays it; I have not touched it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn9xNSCBfSvQxxiUoKv328
