### PR TITLE
Sheet: a saved file said what the sheet did not — stale values and BIFF error codes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -96661,6 +96661,36 @@ overrun corrupts a value; this one corrupts an *address*, and the next large
 it is worth knowing that bss adjacency can arrange it without anyone loading a
 segment register wrongly at all.
 
+### 81.22 A saved file said what the sheet did not
+
+Two ways a file SHEET wrote disagreed with the sheet it came from, each
+invisible from inside because SHEET read its own files back the same way.
+
+#### 81.22.1 A Save recalculates first
+
+**Evaluation is lazy.** `sh_eval_cell` runs when a cell is *read*, memoized
+against `sh_pass`, and a repaint reads only what is on the glass. That is the
+right shape for a display and the wrong one for a file, because two of the three
+writers never ask: the SYLK and BIFF writers read a cell's value with
+`sh_cellval_to_acc_si`, the **stored** double, while DIF reads through
+`sh_getcell2`, which evaluates. So a formula off-screen since it was loaded, or
+since a cell it names changed, was saved with whatever it last held — after a
+load, the zero `sh_setformula` leaves. Ten formulas `=A1*1` … `=A1*10` on a
+5150, opened and saved as SYLK: the four on the glass came back right and the
+six below them came back **0**.
+
+`sh_dowrite` now calls `sh_recalc_all`, which walks every record and calls
+`sh_eval_cell` on each formula. It decides nothing: the pass stamp already knows
+what is stale, in both modes — automatic advances `sh_pass` on every repaint, so
+anything not recomputed since recomputes; manual does not, so only a cell never
+computed (stamped `0xFFFF`) runs. **Every sheet is evaluated as itself**, the
+`sh_rowcol_op` impersonation, because `sh_findcell` packs `[sh_cursheet]` into
+every reference. 64 bytes.
+
+What it costs is time at Save for a sheet whose formulas were not computed at
+paint, and nothing on the glass says so — which is also why a harness that waits
+for the *screen* to settle reads the floppy before the file exists.
+
 ## 82. CHART — charting, and the buffer both halves draw into (`apps/chart/chart.asm`, `apps/os88chart.inc`)
 
 Two consumers, one rasterizer. **CHART.O88** is a standalone viewer that reads

--- a/SPEC.md
+++ b/SPEC.md
@@ -96691,6 +96691,29 @@ What it costs is time at Save for a sheet whose formulas were not computed at
 paint, and nothing on the glass says so — which is also why a harness that waits
 for the *screen* to settle reads the floppy before the file exists.
 
+#### 81.22.2 Error codes in the file's own numbering
+
+`SH_C_AUX` holds an error as `ERROR.TYPE` numbers it, 1–7. The file does not:
+BIFF's error byte, in a `BOOLERR` and in a `FORMULA` result alike, is 00H
+`#NULL!`, 07H `#DIV/0!`, 0FH `#VALUE!`, 17H `#REF!`, 1DH `#NAME?`, 24H `#NUM!`,
+2AH `#N/A`. The writer put the internal number into that byte and the reader
+took it back out the same way — so SHEET's own files round-tripped perfectly,
+which is exactly what hid it, and `docs/BIFF-NOTES.md` recorded the gap and
+the four places a fix had to go. Measured before: an error constant and
+`=1/0` saved as Normal carried **02H**, not a code the format has; Excel's
+`#DIV/0!` (07H), as a constant and as a formula's cached result, opened as
+`#N/A`.
+
+`sh_biff_errtab` holds the seven codes in `ERROR.TYPE` order; `sh_biff_e2b`
+converts on the way out (`.aserr`, `.errresult`) and `sh_biff_b2e` on the way
+in (`.isboolerr`, `.isformula`). An internal code outside 1–7 is written as
+`#VALUE!`, and a file's code the table does not hold reads as `#VALUE!`, since
+it is still an error and that is the honest one to show. 75 bytes.
+
+Both measured with a host-side reader that shares no code with SHEET (the one
+this project's fork uses as its second opinion, `tools/os88sheetfmt.py` there),
+before and after, on this tree's build under MartyPC.
+
 ## 82. CHART — charting, and the buffer both halves draw into (`apps/chart/chart.asm`, `apps/os88chart.inc`)
 
 Two consumers, one rasterizer. **CHART.O88** is a standalone viewer that reads

--- a/apps/sheet/sheet.asm
+++ b/apps/sheet/sheet.asm
@@ -9987,6 +9987,62 @@ sh_sheets_used:
     ret
 
 ; -----------------------------------------------------------------------------
+; sh_recalc_all - evaluate every formula cell on every sheet, as its own sheet
+; (SPEC.md 81.22.1). Preserves all registers.
+;
+; EVALUATION IS LAZY: sh_eval_cell runs when a cell is READ, and a repaint only
+; reads what is on the glass. The SYLK and BIFF writers read a cell's value
+; with sh_cellval_to_acc_si, the STORED double, and never ask for a fresh one -
+; so a formula scrolled out of sight since it was loaded, or since a cell it
+; names changed, was written with whatever it last held: after a load, the zero
+; sh_setformula leaves. DIF reads through sh_getcell2, which evaluates, which is
+; why it looked like a SYLK/BIFF quirk rather than a hole.
+;
+; NOTHING HERE DECIDES WHAT IS STALE. sh_eval_cell's pass stamp already does,
+; and does the right thing in both modes: automatic advances sh_pass on every
+; repaint, so anything not recomputed since is stale and recomputes; manual
+; does not, so only a cell never computed at all (stamped 0xFFFF) runs - which
+; keeps manual mode meaning what it says.
+;
+; THE SHEET IS IMPERSONATED per record, sh_rowcol_op's idiom: sh_findcell packs
+; [sh_cursheet] into every reference, so a Sheet 2 formula evaluated as Sheet 1
+; would read Sheet 1's cells.
+; -----------------------------------------------------------------------------
+sh_recalc_all:
+    push ax
+    push cx
+    push dx
+    push di
+    push es
+    push word [sh_cursheet]
+    xor di, di
+    mov cx, [sh_ncells]
+    jcxz .done
+.l:
+    mov es, [sh_cellseg]                ; re-read each time: the claim is
+    test byte [es:di+SH_C_FLAGS], 1     ; movable (66.2) and a word is what
+    jz .next                            ; sh_reloc keeps right, not ES
+    mov ax, [es:di+SH_C_ROW]
+    rol ax, 1                           ; the sheet is the row word's top two
+    rol ax, 1                           ; bits
+    and ax, 3
+    mov [sh_cursheet], ax
+    push cx                             ; the parser under sh_eval_cell is
+    call sh_eval_cell                   ; free with CX and DX; DI and ES it
+    pop cx                              ; keeps
+.next:
+    add di, SH_C_SZ
+    loop .l
+.done:
+    pop word [sh_cursheet]
+    pop es
+    pop di
+    pop dx
+    pop cx
+    pop ax
+    ret
+
+; -----------------------------------------------------------------------------
 ; sh_dowrite - pick the writer from the file name's extension.
 ;
 ; AND SAY SO WHEN A SAVE CANNOT CARRY EVERYTHING. SYLK and DIF have no
@@ -9996,7 +10052,8 @@ sh_sheets_used:
 ; format here that CAN carry them, and does (81.10.5).
 ; -----------------------------------------------------------------------------
 sh_dowrite:
-    push si
+    call sh_recalc_all                  ; every formula CURRENT before any
+    push si                             ; writer reads one (81.22.1)
     push di
     mov si, sh_name
     mov di, sh_s_ext_dif

--- a/apps/sheet/sheet.asm
+++ b/apps/sheet/sheet.asm
@@ -322,9 +322,8 @@ SH_T_ERR     equ 4
 ; ERROR.TYPE and ISERR become a table lookup if they are ever added. They are
 ; NOT the BIFF file's error codes: BOOLERR and a FORMULA's error result use
 ; 00H #NULL!, 07H #DIV/0!, 0FH #VALUE!, 17H #REF!, 1DH #NAME?, 24H #NUM!,
-; 2AH #N/A, and the BIFF writer and reader currently carry these numbers
-; untranslated (docs/BIFF-NOTES.md, "Values") - so this app's own files
-; round-trip and an Excel file's error codes do not.
+; 2AH #N/A, and sh_biff_e2b/sh_biff_b2e translate at every point a code
+; crosses the file (SPEC.md 81.22.2).
 SH_ERR_NULL  equ 1                  ; #NULL!
 SH_ERR_DIV0  equ 2                  ; #DIV/0!   - the only one produced today
 SH_ERR_VALUE equ 3                  ; #VALUE!
@@ -11637,6 +11636,56 @@ sh_biff_workbook:
 ; sheet (81.10.5). The BIFF3 path calls it exactly once, with sh_wsheet set to
 ; sh_cursheet, and emits the same bytes it always did.
 ; -----------------------------------------------------------------------------
+; -----------------------------------------------------------------------------
+; sh_biff_e2b / sh_biff_b2e - an error code between SH_C_AUX's numbering
+; (ERROR.TYPE, 1..7) and the file's (SPEC.md 81.22.2). AL in, AL out,
+; everything else preserved.
+;
+; TWO NUMBERINGS FOR THE SAME SEVEN ERRORS: BOOLERR's byte and a FORMULA
+; result's use 00H 07H 0FH 17H 1DH 24H 2AH. A #DIV/0! went out as 02H, which
+; is not a code the format defines, and came back in as 02H and was read as
+; ERROR.TYPE 2, which is #DIV/0! again - perfectly symmetric, perfectly wrong,
+; and invisible until a file from outside was read: Excel's 07H arrived as
+; ERROR.TYPE 7, #N/A.
+; -----------------------------------------------------------------------------
+sh_biff_errtab: db 0x00, 0x07, 0x0F, 0x17, 0x1D, 0x24, 0x2A
+
+sh_biff_e2b:                          ; ERROR.TYPE 1..7 -> the BIFF code
+    push bx
+    xor bh, bh
+    mov bl, al
+    dec bl
+    cmp bl, 6
+    ja .bad
+    mov al, [bx+sh_biff_errtab]
+    pop bx
+    ret
+.bad:
+    mov al, 0x0F                      ; an out-of-range code travels as
+    pop bx                            ; #VALUE!, which is what a reader that
+    ret                               ; cannot place it will show anyway
+
+sh_biff_b2e:                          ; the BIFF code -> ERROR.TYPE 1..7
+    push bx
+    push cx
+    mov cl, al
+    xor bx, bx
+.l:
+    cmp cl, [bx+sh_biff_errtab]
+    je .hit
+    inc bx
+    cmp bx, 7
+    jb .l
+    mov al, SH_ERR_VALUE              ; an unknown code is still an error, and
+    jmp .out                          ; #VALUE! is the honest one to show
+.hit:
+    mov al, bl
+    inc al
+.out:
+    pop cx
+    pop bx
+    ret
+
 sh_biff_cells:
     mov byte [sh_trunc], 0
     mov word [sh_wrow], 0            ; reused here as the record index
@@ -11790,7 +11839,8 @@ sh_biff_cells:
     xor ah, ah
     mov al, [sh_wrec_fmt]
     call sh_biffw
-    mov al, [sh_wrec_aux]
+    mov al, [sh_wrec_aux]              ; in the FILE's numbering (81.22.2)
+    call sh_biff_e2b
     call sh_stgputb
     mov al, 1                          ; fError
     call sh_stgputb
@@ -11940,7 +11990,8 @@ sh_biff_formula:
 .errresult:
     mov ax, 2                         ; byte 0 = 2: an error code
     call sh_biffw
-    mov al, [sh_wrec_aux]             ; byte 2 = which one
+    mov al, [sh_wrec_aux]             ; byte 2 = which one, in the FILE's
+    call sh_biff_e2b                  ; numbering (81.22.2)
     xor ah, ah
     call sh_biffw
     xor ax, ax
@@ -12241,7 +12292,9 @@ sh_doread_biff:
     cmp byte [sh_acc], 2
     jne .fresnum
     push es
-    mov dl, [sh_acc+2]
+    mov al, [sh_acc+2]                 ; the FILE's code, into ERROR.TYPE's
+    call sh_biff_b2e                   ; (81.22.2)
+    mov dl, al
     mov ax, [sh_wrec_col]
     mov bx, [sh_wrec_row]
     call sh_seterr
@@ -12278,6 +12331,9 @@ sh_doread_biff:
     push es
     or al, al
     jz .isbool
+    mov al, dl                         ; an ERROR: the file's code is the
+    call sh_biff_b2e                   ; FORMAT's numbering, not ERROR.TYPE's
+    mov dl, al                         ; (81.22.2)
     mov ax, [sh_wrec_col]
     mov bx, [sh_wrec_row]
     call sh_seterr

--- a/docs/BIFF-NOTES.md
+++ b/docs/BIFF-NOTES.md
@@ -150,14 +150,16 @@ accepted only the integer form dropped those cells in silence.
 those four back - any other id, including a custom `FORMAT`'s, reads as
 General.
 
-**Error codes are `SH_ERR_*`, 1-7 in `ERROR.TYPE` order, on both sides.**
-That is NOT the file format's numbering: BIFF's error byte in `BOOLERR` and
-in a `FORMULA` result is 00H #NULL!, 07H #DIV/0!, 0FH #VALUE!, 17H #REF!,
-1DH #NAME?, 24H #NUM!, 2AH #N/A. Sheet's own files round-trip because the
-reader applies the same numbers, but a `#DIV/0!` written here is byte 2 in
-a file where Excel expects 07H, and Excel's 07H reads back here as code 7,
-#N/A. No translation exists yet; add one in both `sh_biff_cells` (`.aserr`,
-`.errresult`) and `sh_doread_biff` (`.isboolerr`, `.isformula`) together.
+**Error codes are translated at the file's edge.** Inside SHEET they are
+`SH_ERR_*`, 1-7 in `ERROR.TYPE` order; BIFF's error byte in `BOOLERR` and in
+a `FORMULA` result is 00H #NULL!, 07H #DIV/0!, 0FH #VALUE!, 17H #REF!, 1DH
+#NAME?, 24H #NUM!, 2AH #N/A. `sh_biff_e2b` converts on the way out
+(`sh_biff_cells`' `.aserr`, `.errresult`) and `sh_biff_b2e` on the way in
+(`sh_doread_biff`'s `.isboolerr`, `.isformula`) - the four places this note
+used to say a translation had to go (SPEC.md 81.22.2). Before it, SHEET's
+own files round-tripped because the reader applied the same wrong numbers,
+while a `#DIV/0!` written here was byte 2 where Excel expects 07H, and
+Excel's 07H read back here as #N/A.
 
 ## What the reader accepts, and what it drops
 


### PR DESCRIPTION
**Two ways a file Sheet saved disagreed with the sheet it came from.** Both were invisible from inside, because Sheet read its own files back the same wrong way. Two commits, one SPEC section (§81.22), 139 bytes.

## Measured on this tree's build

A 5150 under MartyPC, checked with a host-side reader that shares no code with Sheet:

| | before | after |
|---|---|---|
| `=A1*1` … `=A1*10`, opened and saved as SYLK | `1 2 3 4 0 0 0 0 0 0` | `1 2 3 4 5 6 7 8 9 10` |
| an error constant, saved as Normal | error byte **02H** (not a BIFF code) | **07H** |
| `=1/0`, saved as Normal — its cached result | **02H** | **07H** |
| Excel's `#DIV/0!` (07H) as a constant, opened | **`#N/A`** | `#DIV/0!` |
| Excel's `#DIV/0!` as a formula's cached result, opened | **`#N/A`** | `#DIV/0!` |

## 1. A Save recalculates first (§81.22.1)

Evaluation is lazy: `sh_eval_cell` runs when a cell is read, and a repaint only reads what's on the glass. The SYLK and BIFF writers read the **stored** value (`sh_cellval_to_acc_si`), while DIF goes through `sh_getcell2`, which evaluates. So a formula that has been off-screen since it was loaded, or since a cell it names changed, is saved with whatever it last held — after a load, the zero `sh_setformula` leaves. That's the first row of the table: the four formulas on the glass saved correctly, and the six below them as 0.

`sh_dowrite` now calls `sh_recalc_all` before choosing a writer. It decides nothing itself: `sh_eval_cell`'s pass stamp already knows what's stale, in both calculation modes (automatic advances `sh_pass` on every repaint; manual doesn't, so only never-computed cells run). Each record is evaluated as its own sheet, using `sh_rowcol_op`'s impersonation, because `sh_findcell` packs `[sh_cursheet]` into every reference. 64 bytes.

## 2. Error codes in the file's own numbering (§81.22.2)

This is the gap `docs/BIFF-NOTES.md` already records, fixed at exactly the four places it names. `SH_C_AUX` numbers errors as ERROR.TYPE does (1–7); BIFF's error byte uses `00 07 0F 17 1D 24 2A`. `sh_biff_e2b` converts on the way out (`.aserr`, `.errresult`) and `sh_biff_b2e` on the way in (`.isboolerr`, `.isformula`). An out-of-range code in either direction becomes `#VALUE!`. The `SH_ERR_*` comment and BIFF-NOTES now describe what's done rather than what's missing. 75 bytes.

## Checked

Fast tier green, checkdocs clean. Each row of the table was measured before and after on this branch's own build, and the first commit alone fixes row 1 and leaves the rest as they were, so the evidence tells the two fixes apart.

These come from the fork, where Sheet has moved further ahead: its §81.38 and §81.48 are the same two fixes, and it gates them with a SYLK/BIFF round-trip test. That harness isn't in this PR; the table above is its output on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn9xNSCBfSvQxxiUoKv328
